### PR TITLE
Changes made to get Manos to host ServiceStack

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/EndpointHost.cs
+++ b/src/ServiceStack/WebHost.EndPoints/EndpointHost.cs
@@ -104,7 +104,7 @@ namespace ServiceStack.WebHost.Endpoints
 
 		public static EndpointHostConfig Config
 		{
-			internal get
+			get
 			{
 				return config;
 			}
@@ -153,7 +153,7 @@ namespace ServiceStack.WebHost.Endpoints
 			return httpRes.IsClosed;
 		}
 
-		internal static void SetOperationTypes(ServiceOperations operationTypes, ServiceOperations allOperationTypes)
+		public static void SetOperationTypes(ServiceOperations operationTypes, ServiceOperations allOperationTypes)
 		{
 			ServiceOperations = operationTypes;
 			AllServiceOperations = allOperationTypes;


### PR DESCRIPTION
Changes to allow IAppHost implementations to init services from outside ServiceStack.dll
