### PR TITLE
Added ability for client code to supply algorithm for finding IService<T> implementations & Fix corrupted stacktrace when IService.Execute() throws an exception

### DIFF
--- a/src/ServiceStack/ExceptionHelper.cs
+++ b/src/ServiceStack/ExceptionHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+
+namespace ServiceStack
+{
+    /// <summary>
+    /// Provides extension method for preserving the stacktrace of an exception that needs to be thrown again.
+    /// </summary>
+    internal static class ExceptionHelper
+    {
+        private static Action<Exception> _preserveInternalException;
+
+        static ExceptionHelper()
+        {
+            MethodInfo preserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic);
+            _preserveInternalException = (Action<Exception>)Delegate.CreateDelegate(typeof(Action<Exception>), preserveStackTrace);
+        }
+
+        /// <summary>
+        /// Will cause the current stacktrace of the exception to be preserved even if you throw it again.
+        /// </summary>
+        /// <param name="ex"></param>
+        public static TException PreserveStackTrace<TException>(this TException ex)
+            where TException : Exception
+        {
+            _preserveInternalException(ex);
+            return ex;
+        }
+    }
+}

--- a/src/ServiceStack/ServiceHost/IServiceImplementationsLocator.cs
+++ b/src/ServiceStack/ServiceHost/IServiceImplementationsLocator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace ServiceStack.ServiceHost
+{
+    public interface IServiceImplementationsLocator
+    {
+        /// <summary>
+        /// Locates all of the services defined within the provided assemblies.
+        /// </summary>
+        /// <param name="assembliesWithServices"></param>
+        /// <returns></returns>
+        IEnumerable<ServiceImplementation> GetServiceImplementations(Assembly[] assembliesWithServices);
+    }
+}

--- a/src/ServiceStack/ServiceHost/ServiceImplementation.cs
+++ b/src/ServiceStack/ServiceHost/ServiceImplementation.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.ServiceHost
+{
+    public struct ServiceImplementation
+    {
+        /// <summary>
+        /// The type of the request dto
+        /// </summary>
+        public Type RequestType { get; set; }
+
+        /// <summary>
+        /// The type that implements IService{RequestType}
+        /// </summary>
+        public Type ServiceType { get; set; }
+    }
+}

--- a/src/ServiceStack/ServiceHost/ServiceManager.cs
+++ b/src/ServiceStack/ServiceHost/ServiceManager.cs
@@ -33,13 +33,18 @@ namespace ServiceStack.ServiceHost
 			}
 		}
 
-		public void Init()
+        public void Init()
+        {
+            Init(ServiceController);
+        }
+
+		public void Init(IServiceImplementationsLocator locator)
 		{
 			this.Container = new Container();
 
 			var typeFactory = new ExpressionTypeFunqContainer(this.Container);
 
-			this.ServiceController.Register(typeFactory, assembliesWithServices);
+			this.ServiceController.Register(locator, typeFactory, assembliesWithServices);
 
 			this.ServiceOperations = new ServiceOperations(this.ServiceController.OperationTypes);
 			this.AllServiceOperations = new ServiceOperations(this.ServiceController.AllOperationTypes);

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -105,6 +105,7 @@
     <Compile Include="CacheAccess.Providers\XmlCacheManager.cs" />
     <Compile Include="Configuration\ConfigurationResourceManager.cs" />
     <Compile Include="Configuration\ConfigUtils.cs" />
+    <Compile Include="ExceptionHelper.cs" />
     <Compile Include="Funq\Action.cs" />
     <Compile Include="Funq\Container.cs" />
     <Compile Include="Funq\Container.Overloads.cs">
@@ -130,6 +131,7 @@
     <Compile Include="ServiceHost\HttpResponseExtensions.cs" />
     <Compile Include="ServiceHost\IHttpRequest.cs" />
     <Compile Include="ServiceHost\IHttpResponse.cs" />
+    <Compile Include="ServiceHost\IServiceImplementationsLocator.cs" />
     <Compile Include="ServiceHost\Operations.cs" />
     <Compile Include="ServiceHost\RequestAttributes.cs" />
     <Compile Include="ServiceHost\RequestContextExtensions.cs" />
@@ -138,6 +140,7 @@
     <Compile Include="ServiceHost\ServiceControllerReflection.cs" />
     <Compile Include="ServiceHost\ServiceExec.cs" />
     <Compile Include="ServiceHost\ServiceExecOperations.cs" />
+    <Compile Include="ServiceHost\ServiceImplementation.cs" />
     <Compile Include="ServiceHost\ServiceManager.cs" />
     <Compile Include="ServiceHost\ServiceOperations.cs" />
     <Compile Include="ServiceHost\ServiceRoutes.cs" />

--- a/src/ServiceStack/WebHost.EndPoints/AppHostBase.cs
+++ b/src/ServiceStack/WebHost.EndPoints/AppHostBase.cs
@@ -54,7 +54,12 @@ namespace ServiceStack.WebHost.Endpoints
 			}
 		}
 
-		public void Init()
+        public void Init()
+        {
+            Init(null);
+        }
+
+		public void Init(IServiceImplementationsLocator locator)
 		{
 			if (Instance != null)
 			{
@@ -66,7 +71,7 @@ namespace ServiceStack.WebHost.Endpoints
 			var serviceManager = EndpointHost.Config.ServiceManager;
 			if (serviceManager != null)
 			{
-				serviceManager.Init();
+                serviceManager.Init(locator ?? serviceManager.ServiceController);
 				Configure(EndpointHost.Config.ServiceManager.Container);
 
 				EndpointHost.SetOperationTypes(

--- a/src/ServiceStack/WebHost.EndPoints/Support/HttpListenerBase.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Support/HttpListenerBase.cs
@@ -52,7 +52,12 @@ namespace ServiceStack.WebHost.Endpoints.Support
 			EndpointHost.ConfigureHost(this, serviceName, assembliesWithServices);
 		}
 
-		public void Init()
+        public void Init()
+        {
+            Init(null);
+        }
+
+		public void Init(IServiceImplementationsLocator locator)
 		{
 			if (Instance != null)
 			{
@@ -64,7 +69,7 @@ namespace ServiceStack.WebHost.Endpoints.Support
 			var serviceManager = EndpointHost.Config.ServiceManager;
 			if (serviceManager != null)
 			{
-				serviceManager.Init();
+                serviceManager.Init(locator ?? serviceManager.ServiceController);
 				Configure(EndpointHost.Config.ServiceManager.Container);
 
 				EndpointHost.SetOperationTypes(


### PR DESCRIPTION
I have my services setup like this:

``` csharp
public abstract class RealServiceBase<T>
{
  // ...
  public abstract object Execute(T request);
}

public class Service<T> : IService<T>
{
  public MyAppHost AppHost { get; set; } // injected by ServiceStack IoC container

  public object Execute(T request)
  {
    return AppHost.ResolveRealService<T>().Execute(request);    
  }
}

public class HelloService : RealServiceBase<Hello>
{
   // ...
   public override object Execute(Hello request) { ... }
}
```

ServiceStack is unable to find any services because obviously I've not instantiated any concrete implementations of IService<T>.  In fact, ServiceStack crashes when I point it at this assembly because it tries to use Service<T> as a service with requestType = T.

This pull request (a) fixes the crash by having it ignore cases where the serviceType it finds IsGenericTypeDefinition, and (b) allows client code to supply a different algorithm for finding IService<T> implementations to register.

For example:

``` csharp
public class CustomLocator : IServiceImplementationsLocator
{
  public IEnumerable<ServiceImplementation> GetServiceImplementations(Assembly[] assembliesWithServices)
  {
     return new[] { new ServiceImplementation() { ServiceType = typeof(HelloService), RequestType = typeof(Hello) };
    // Or some algorithm involving reflection to find subclasses of my RealServiceBase<> and using MakeGenericType() to get a specific version of Service<>.
  }
}

var host = new AppHostBase("My Services", Assembly.GetExecutingAssembly());
host.Init(new CustomLocator()); // use my custom locator

```

Also, there's a fix in there for the following issue with exception stacktraces:

``` csharp
public class HelloService : IService<Hello>
{
  public object Execute(Hello request)
  {
     throw new ArgumentException("error");
  }
}

try
{
  host.ExecuteService(new Hello());
}
catch (Exception e)
{
  // e.StackTrace will not point into my HelloService.Execute() method.  Instead it points into ServiceController.Register() since that is where the exception gets rethrown.
}
```

Thanks!
