### PR TITLE
Fixes to prevent generic services from getting mis-registered

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceController.cs
+++ b/src/ServiceStack/ServiceHost/ServiceController.cs
@@ -68,10 +68,11 @@ namespace ServiceStack.ServiceHost
 			{
 				foreach (var serviceType in assembly.GetTypes())
 				{
+					if (serviceType.IsAbstract || serviceType.IsGenericTypeDefinition) continue;
+
 					foreach (var service in serviceType.GetInterfaces())
 					{
-						if (serviceType.IsAbstract
-							|| !service.IsGenericType
+						if (!service.IsGenericType
 							|| service.GetGenericTypeDefinition() != typeof(IService<>)
 							) continue;
 

--- a/tests/ServiceStack.ServiceHost.Tests/ServiceControllerTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/ServiceControllerTests.cs
@@ -72,5 +72,18 @@ namespace ServiceStack.ServiceHost.Tests
 			Assert.That(response, Is.Not.Null);
 		}
 
+        [Test]
+        public void Generic_Service_should_not_get_registered_with_generic_parameter()
+        {
+            var serviceManager = new ServiceManager(typeof(GenericService<>).Assembly);
+            serviceManager.Init();
+
+            // We should definately *not* be able to call the generic service with a "T" request object :)
+            var serviceController = serviceManager.ServiceController;
+            var requestType = typeof(GenericService<>).GetGenericArguments()[0];
+            var exception = Assert.Throws<System.NotImplementedException>(() => serviceController.GetService(requestType));
+
+            Assert.That(exception.Message, Is.StringContaining("Unable to resolve service"));
+        }
 	}
 }

--- a/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
+++ b/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="ServiceStackHandlerUrlTests.cs" />
     <Compile Include="Support\BasicService.cs" />
     <Compile Include="Support\AutoWireService.cs" />
+    <Compile Include="Support\GenericService.cs" />
     <Compile Include="Support\RestTestService.cs" />
     <Compile Include="Support\RequiresContextService.cs" />
     <Compile Include="TypeFactory\ReflectionTypeFunqContainer.cs" />

--- a/tests/ServiceStack.ServiceHost.Tests/Support/GenericService.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Support/GenericService.cs
@@ -1,0 +1,29 @@
+using System.Runtime.Serialization;
+using System.Reflection;
+using System;
+
+namespace ServiceStack.ServiceHost.Tests.Support
+{
+    [DataContract]
+    public class Generic1 { }
+
+    [DataContract]
+    public class Generic1Response { }
+
+    [DataContract]
+    public class Generic2 { }
+
+    [DataContract]
+    public class Generic2Response { }
+
+	public class GenericService<T> : IService<T>
+	{
+        public object Execute(T request)
+        {
+            // Find the rewsponse type within the same namespace and assembly as the request
+            var responseType = typeof(T).Assembly.GetType(typeof(T).FullName + "Response");
+
+            return Activator.CreateInstance(responseType);
+        }
+    }
+}

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/FailingService.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/FailingService.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using ServiceStack.ServiceHost;
+
+namespace ServiceStack.WebHost.Endpoints.Tests.Support.Services
+{
+    [DataContract]
+    public class FailingRequest { }
+
+    [DataContract]
+    public class FailingRequestResponse { }
+
+    public class FailingService : IService<FailingRequest>
+    {
+        private void ThisMethodAlwaysThrowsAnError(FailingRequest request)
+        {
+            throw new System.ArgumentException("Failure");
+        }
+        
+        public object Execute(FailingRequest request)
+        {
+            ThisMethodAlwaysThrowsAnError(request);
+            return new FailingRequestResponse();
+        }
+    }
+}


### PR DESCRIPTION
It seems that some of your post-2.09 changes also changed the nature of this bug.  It no longer throws an exception because you've got a "temporary" catch Exception clause when building your Expression and just return a delegate instead.  This causes a generic service to get registered with a generic request type.

This pull contains a regression test for the bug along with a fix which prevents generic services from getting registered.
