### PR TITLE
ServiceController should always dispose IDisposable service even if an error occurs.

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/Extensions/HttpListenerResponseWrapper.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Extensions/HttpListenerResponseWrapper.cs
@@ -59,8 +59,11 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 
 		public void Close()
 		{
-			this.IsClosed = true;
-			this.response.CloseOutputStream();
+            if (!this.IsClosed)
+            {
+                this.IsClosed = true;
+                this.response.CloseOutputStream();
+            }
 		}
 
 		public bool IsClosed

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/IocServiceTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/IocServiceTests.cs
@@ -62,11 +62,24 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		public void Does_dispose_service()
 		{
 			IocService.DisposedCount = 0;
+            IocService.ThrowErrors = false;
+
 			var restClient = new JsonServiceClient(ListeningOn);
 			var response = restClient.Get<IocResponse>("ioc");
 
 			Assert.That(IocService.DisposedCount, Is.EqualTo(1));
 		}
 
+        [Test]
+        public void Does_dispose_service_when_there_is_an_error()
+        {
+            IocService.DisposedCount = 0;
+            IocService.ThrowErrors = true;
+
+            var restClient = new JsonServiceClient(ListeningOn);
+            Assert.Throws<WebServiceException>(() => restClient.Get<IocResponse>("ioc"));
+
+            Assert.That(IocService.DisposedCount, Is.EqualTo(1));
+        }
 	}
 }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/IocService.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/IocService.cs
@@ -54,10 +54,13 @@ namespace ServiceStack.WebHost.Endpoints.Tests.Support.Services
 					response.Results.Add(dep.GetType().Name);
 			}
 
+            if (ThrowErrors) throw new ArgumentException("This service has intentionally failed");
+
 			return response;
 		}
 
 		public static int DisposedCount = 0;
+        public static bool ThrowErrors = false;
 
 		public void Dispose()
 		{


### PR DESCRIPTION
Modified ServiceController to always dispose IDisposable service, even if exceptions occur.  Could not get regression test to pass until I also fixed HttpListenerResponseWrapper.Close() to not close again if it was already closed.
