### PR TITLE
ServiceController.CallServiceExecuteGeneric() Expression.Call() always fails in .NET 4 app

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceController.cs
+++ b/src/ServiceStack/ServiceHost/ServiceController.cs
@@ -273,7 +273,7 @@ namespace ServiceStack.ServiceHost
 				var mi = ServiceExec.GetExecMethodInfo(serviceType, requestType);
 
 				Expression callExecute = Expression.Call(
-					serviceStrong, mi, new Expression[] { serviceStrong, requestDtoStrong, attrsParam });
+					mi, new Expression[] { serviceStrong, requestDtoStrong, attrsParam });
 
 				var executeFunc = Expression.Lambda<Func<object, object, EndpointAttributes, object>>
 					(callExecute, requestDtoParam, serviceParam, attrsParam).Compile();


### PR DESCRIPTION
The attempt to build a lambda from an expression fails everytime because Expression.Call() complains that you are asking to call a static method yet are supplying a non-null instance.

Things work just fine when compiling and ServiceStack and running the unit tests.  But drop the dll into a .NET 4.0 application and all of a sudden this fails everytime and uses the method.Invoke() fallback.

This seems to be an undocumented change from 3.5 to 4.0.  I used .NET Reflector to look at System.Core just to verify.

Anyway, this commit fixes the problem without causing any harm to .NET 3.5 apps.
