### PR TITLE
Getting Metadata throws "no default constructor" error if dto contains a string[] property

### DIFF
--- a/src/ServiceStack.Common/Utils/ReflectionUtils.cs
+++ b/src/ServiceStack.Common/Utils/ReflectionUtils.cs
@@ -294,9 +294,8 @@ namespace ServiceStack.Common.Utils
 		{
 			var elementType = type.GetElementType();
 			var objArray = Array.CreateInstance(elementType, 1);
-			var objElementType = PopulateType(elementType);
+			var objElementType = CreateDefaultValue(elementType);
 			objArray.SetValue(objElementType, 0);
-			PopulateObject(objElementType);
 
 			return objArray;
 		}

--- a/tests/ServiceStack.Common.Tests/ReflectionUtilTests.cs
+++ b/tests/ServiceStack.Common.Tests/ReflectionUtilTests.cs
@@ -38,6 +38,34 @@ namespace ServiceStack.Common.Tests
 			public string Member4 { get; set; }
 		}
 
+        public class DtoWithStringArray
+        {
+            public string[] Data { get; set; }
+        }
+
+        public class DtoWithEnumArray
+        {
+            public TestClassType[] Data { get; set; }
+        }
+
+        [Test]
+        public void Can_PopulateObjectWithStringArray()
+        {
+            var obj = (DtoWithStringArray)ReflectionUtils.PopulateObject(new DtoWithStringArray());
+            Assert.IsNotNull(obj.Data);
+            Assert.Greater(obj.Data.Length, 0);
+            Assert.IsNotNull(obj.Data[0]);
+        }
+
+        [Test]
+        public void Can_PopulateObjectWithNonZeroEnumArray()
+        {
+            var obj = (DtoWithEnumArray)ReflectionUtils.PopulateObject(new DtoWithEnumArray());
+            Assert.IsNotNull(obj.Data);
+            Assert.Greater(obj.Data.Length, 0);
+            Assert.That(Enum.IsDefined(typeof(TestClassType), obj.Data[0]), "Values in created array should be valid for the enum");
+        }
+
 		[Test]
 		public void PopulateObject_UsesDefinedEnum()
 		{


### PR DESCRIPTION
Other types of arrays will do bad things.  Like arrays of enums that do not have a 0 value etc.

Here's some unit tests and a fix.
