### PR TITLE
Allow closed generic service types to be registered

### DIFF
--- a/src/ServiceStack/ServiceHost/ExpressionTypeFunqContainer.cs
+++ b/src/ServiceStack/ServiceHost/ExpressionTypeFunqContainer.cs
@@ -105,7 +105,7 @@ namespace ServiceStack.ServiceHost
 			foreach (var serviceType in serviceTypes)
 			{
 				//Don't try to register base service classes
-				if (serviceType.IsGenericType)
+				if (serviceType.IsAbstract || serviceType.ContainsGenericParameters)
 					continue;
 
 				var methodInfo = GetType().GetMethod("Register", new Type[0]);

--- a/src/ServiceStack/ServiceHost/ServiceController.cs
+++ b/src/ServiceStack/ServiceHost/ServiceController.cs
@@ -69,7 +69,7 @@ namespace ServiceStack.ServiceHost
 		{
 			foreach (var serviceType in ResolveServicesFn())
 			{
-				if (serviceType.IsAbstract || serviceType.IsGenericTypeDefinition) continue;
+				if (serviceType.IsAbstract || serviceType.ContainsGenericParameters) continue;
 
 				foreach (var service in serviceType.GetInterfaces())
 				{

--- a/tests/ServiceStack.ServiceHost.Tests/Support/GenericService.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Support/GenericService.cs
@@ -4,26 +4,26 @@ using System;
 
 namespace ServiceStack.ServiceHost.Tests.Support
 {
-    [DataContract]
     public class Generic1 { }
 
-    [DataContract]
-    public class Generic1Response { }
+    public class Generic1Response
+    {
+        public string Data { get; set; }
+    }
 
-    [DataContract]
     public class Generic2 { }
 
     [DataContract]
-    public class Generic2Response { }
+    public class Generic3<T>
+    {
+        public T Data { get; set; }
+    }
 
 	public class GenericService<T> : IService<T>
 	{
         public object Execute(T request)
         {
-            // Find the rewsponse type within the same namespace and assembly as the request
-            var responseType = typeof(T).Assembly.GetType(typeof(T).FullName + "Response");
-
-            return Activator.CreateInstance(responseType);
+            return new Generic1Response() { Data = request.GetType().FullName };
         }
     }
 }


### PR DESCRIPTION
Allow closed generic service types to be registered, but disallow abstract or open generic service types (or types containing a member that is an open generic type).

2 related fixes:
1. ServiceController was allowing something like the following open generic service to be registered: `GenericService<GenericType<>>` (fixed)
2. `ExpressionTypeFunqContainer` was not allowing any generic services to be registered (relaxed to match same restrictions that ServiceController enforces: not abstract and not open generic).  So something like `GenericService<SomeType>` can be registered.

See new unit tests.
