### PR TITLE
Allow multiple IService<Request1>, IService<Request2>, ... to be implemented in the same class/server.

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceExec.cs
+++ b/src/ServiceStack/ServiceHost/ServiceExec.cs
@@ -22,13 +22,13 @@ namespace ServiceStack.ServiceHost
 			MethodInfo mi;
 			lock (ServiceExecCache)
 			{
-				if (!ServiceExecCache.TryGetValue(serviceType, out mi))
+				if (!ServiceExecCache.TryGetValue(requestType /*serviceType */, out mi))
 				{
 					var genericType = typeof(ServiceExec<>).MakeGenericType(requestType);
 					
 					mi = genericType.GetMethod("Execute", BindingFlags.Public | BindingFlags.Static);
 
-					ServiceExecCache.Add(serviceType, mi);
+					ServiceExecCache.Add(requestType /* serviceType */, mi);
 				}
 			}
 


### PR DESCRIPTION
Allow multiple IService<Request1>, IService<Request2>, ... to be implemented in the same class/server.
Example:

```
public class Server : IService<T1>, TService<T2>
{
    public object Execute(T1 t1)
    {
    }

    public object Execute(T2 t2)
    {
    }
```
