### PR TITLE
Added untyped IServiceRoutes.Add() method

### DIFF
--- a/src/ServiceStack.Interfaces/ServiceHost/IServiceRoutes.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/IServiceRoutes.cs
@@ -32,5 +32,16 @@ namespace ServiceStack.ServiceHost
 		/// <param name="defaultContentType"></param>
 		/// <returns></returns>
 		IServiceRoutes Add<TRequest>(string restPath, string verbs, string defaultContentType);
+
+        /// <summary>
+        /// Register the user-defined restPath, HTTP verbs it applies to (empty == all) and
+        /// the defaultContentType the service should return if not specified by the client
+        /// </summary>
+        /// <param name="requestType"></param>
+        /// <param name="restPath"></param>
+        /// <param name="verbs">comma-delimited verbs e.g. GET,POST,PUT,DELETE.  Pass null to allow all verbs.</param>
+        /// <param name="defaultContentType">Pass null to use default.</param>
+        /// <returns></returns>
+        IServiceRoutes Add(System.Type requestType, string restPath, string verbs, string defaultContentType);
 	}
 }

--- a/src/ServiceStack/ServiceHost/ServiceRoutes.cs
+++ b/src/ServiceStack/ServiceHost/ServiceRoutes.cs
@@ -24,5 +24,11 @@ namespace ServiceStack.ServiceHost
 			RestPaths.Add(new RestPath(typeof(TRequest), restPath, verbs, defaultContentType));
 			return this;
 		}
+
+        public IServiceRoutes Add(Type requestType, string restPath, string verbs, string defaultContentType)
+        {
+            RestPaths.Add(new RestPath(requestType, restPath, verbs, defaultContentType));
+            return this;
+        }
 	}
 }


### PR DESCRIPTION
Added untyped IServiceRoutes.Add() method for times when you only have the System.Type of the request.
