### PR TITLE
bugfix for null StatusDescription

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/Extensions/IHttpResponseExtensions.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Extensions/IHttpResponseExtensions.cs
@@ -96,7 +96,7 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 				if (httpResult != null)
 				{
 					response.StatusCode = (int)httpResult.StatusCode;
-                    response.StatusDescription = httpResult.StatusDescription;
+					response.StatusDescription = httpResult.StatusDescription ?? httpResult.StatusCode.ToString();
 					if (string.IsNullOrEmpty(httpResult.ContentType))
 					{
 						httpResult.ContentType = defaultContentType;

--- a/src/ServiceStack/WebHost.EndPoints/Support/Mocks/HttpResponseMock.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Support/Mocks/HttpResponseMock.cs
@@ -40,7 +40,18 @@ namespace ServiceStack.WebHost.Endpoints.Tests.Mocks
 
 		public int StatusCode { get; set; }
 
-        public string StatusDescription { get; set; }
+		private string statusDescription = string.Empty;
+		public string StatusDescription
+		{
+			get
+			{
+				return statusDescription;
+			}
+			set
+			{
+				statusDescription = value;
+			}
+		}
 
 		public string ContentType
 		{

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/HttpResultTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/HttpResultTests.cs
@@ -85,6 +85,18 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.That(statusDesc, Is.EqualTo(customStatus));
         }
 
+		[Test]
+		public void Can_handle_null_HttpResult_StatusDescription()
+		{
+			var mockResponse = new HttpResponseMock();
+
+			var httpResult = new HttpResult();
+			httpResult.StatusDescription = null;
+
+			mockResponse.WriteToResponse(httpResult, ContentType.Html);
+
+			Assert.IsNotNull(mockResponse.StatusDescription);
+		}
 	}
 
 }


### PR DESCRIPTION
added fix and test for null StatusDescription in HttpResult when constructing HttpResponse- null StatusDescription throws ArgumentNullException when set in System.Net.HttpListenerResponse
