### PR TITLE
Bugfix in RequestContextExtensions.ToOptimizedResult method

### DIFF
--- a/src/ServiceStack/CacheAccess.Providers/ContentSerializer.cs
+++ b/src/ServiceStack/CacheAccess.Providers/ContentSerializer.cs
@@ -72,8 +72,16 @@ namespace ServiceStack.CacheAccess.Providers
 			contentType.ThrowIfNull("MimeType");
 
 			var serializeCtx = new SerializationContext(contentType) { CompressionType = compressionType };
-			return ToCompressedBytes(ToSerializedString(result, serializeCtx), compressionType);
+            return ToCompressedBytes(result, serializeCtx);
 		}
+
+        public static byte[] ToCompressedBytes(object result, IRequestContext context)
+        {
+            result.ThrowIfNull("result");
+            context.ThrowIfNull("context");
+
+            return ToCompressedBytes(ToSerializedString(result, context), context.CompressionType);
+        }
 
 		public static byte[] ToCompressedBytes(string serializedResult, string compressionType)
 		{
@@ -134,13 +142,12 @@ namespace ServiceStack.CacheAccess.Providers
 			}
 		}
 
-		public static object ToOptimizedResult(string contentType, string compressionType, T result)
+		public static object ToOptimizedResult(IRequestContext context, T result)
 		{
-			var serializeCtx = new SerializationContext(contentType) { CompressionType = compressionType };
-			return compressionType == null
-				? (object)ToSerializedString(result, serializeCtx)
-				: new CompressedResult(ToCompressedBytes(result, contentType, compressionType),
-					compressionType, contentType);
+			return context.CompressionType == null
+                ? (object)ToSerializedString(result, context)
+				: new CompressedResult(ToCompressedBytes(result, context),
+                    context.CompressionType, context.ContentType);
 		}
 
 	}

--- a/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
+++ b/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
@@ -16,8 +16,7 @@ namespace ServiceStack.ServiceHost
 		public static object ToOptimizedResult<T>(this IRequestContext requestContext, T dto) 
 			where T : class
 		{
-			return ContentSerializer<T>.ToOptimizedResult(
-				requestContext.ResponseContentType, requestContext.CompressionType, dto);
+			return ContentSerializer<T>.ToOptimizedResult(requestContext, dto);
 		}
 
 		/// <summary>

--- a/tests/ServiceStack.ServiceHost.Tests/RequestContextExtensionsTest.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/RequestContextExtensionsTest.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using ServiceStack.CacheAccess.Providers;
+using ServiceStack.Common.Web;
+using ServiceStack.ServiceHost.Tests.Formats;
+using ServiceStack.ServiceInterface.Testing;
+using ServiceStack.WebHost.Endpoints.Formats;
+
+namespace ServiceStack.ServiceHost.Tests
+{
+    [TestFixture]
+    public class RequestContextExtensionsTest
+    {
+        [Test]
+        public void Can_optimize_result_with_ToOptimizedResult()
+        {
+            var dto = new TestDto {Name = "test"};
+            
+            var httpReq = new MockHttpRequest();
+            httpReq.Headers.Add(HttpHeaders.AcceptEncoding, "gzip,deflate,sdch");
+            httpReq.ResponseContentType = "text/html";
+            var httpRes = new ViewTests.MockHttpResponse();
+
+            var httpRequestContext = new HttpRequestContext(httpReq, httpRes, dto);
+
+            var appHost = new TestAppHost();
+            HtmlFormat.Register(appHost);
+            ContentCacheManager.ContentTypeFilter = appHost.ContentTypeFilters;            
+            
+            object result = RequestContextExtensions.ToOptimizedResult(httpRequestContext, dto);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is CompressedResult);
+        }
+
+        public class TestDto
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
+++ b/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Formats\UseCaseTests.cs" />
     <Compile Include="Formats\ViewTests.cs" />
     <Compile Include="PerfTests.cs" />
+    <Compile Include="RequestContextExtensionsTest.cs" />
     <Compile Include="RestPathTests.cs" />
     <Compile Include="Routes\SimpleRestServices.cs" />
     <Compile Include="Routes\ServiceRoutesTests.cs" />


### PR DESCRIPTION
Added an overloaded method ContentSerializer<T>.ToOptimizedResult(IRequestContext context, T result) which passes the given context to the underlying methods.

The previous implementation failed because the HtmlFormat.SerializeToStream needed IHttpRequest which was not available in the SerializationContext.
