### PR TITLE
Fixed path mapping for static files in self-hosted scenario

### DIFF
--- a/src/ServiceStack.Common/Utils/PathUtils.cs
+++ b/src/ServiceStack.Common/Utils/PathUtils.cs
@@ -13,7 +13,9 @@ namespace ServiceStack.Common.Utils
 				var assemblyDirectoryPath = Path.GetDirectoryName(new Uri(typeof(PathUtils).Assembly.EscapedCodeBase).LocalPath);
 
 				// Escape the assembly bin directory to the hostname directory
-				var hostDirectoryPath = assemblyDirectoryPath + appendPartialPathModifier;
+			    var hostDirectoryPath = appendPartialPathModifier != null
+			                                ? assemblyDirectoryPath + appendPartialPathModifier
+			                                : assemblyDirectoryPath;
 
 				return Path.GetFullPath(relativePath.Replace("~", hostDirectoryPath));
 			}
@@ -21,12 +23,37 @@ namespace ServiceStack.Common.Utils
 			return relativePath;
 		}
 
-		public static string MapAbsolutePath(this string relativePath)
+        /// <summary>
+        /// Maps the path of a file in the context of a VS project
+        /// </summary>
+        /// <param name="relativePath">the relative path</param>
+        /// <returns>the absolute path</returns>
+        /// <remarks>Assumes static content is two directories above the /bin/ directory,
+        /// eg. in a unit test scenario  the assembly would be in /bin/Debug/.</remarks>
+		public static string MapProjectPath(this string relativePath)
 		{
 			var mapPath = MapAbsolutePath(relativePath, string.Format("{0}..{0}..", Path.DirectorySeparatorChar));
 			return mapPath;
 		}
 
+        /// <summary>
+        /// Maps the path of a file in a self-hosted scenario
+        /// </summary>
+        /// <param name="relativePath">the relative path</param>
+        /// <returns>the absolute path</returns>
+        /// <remarks>Assumes static content is copied to /bin/ folder with the assemblies</remarks>
+        public static string MapAbsolutePath(this string relativePath)
+        {
+            var mapPath = MapAbsolutePath(relativePath, null);
+            return mapPath;
+        }
+
+        /// <summary>
+        /// Maps the path of a file in an Asp.Net hosted scenario
+        /// </summary>
+        /// <param name="relativePath">the relative path</param>
+        /// <returns>the absolute path</returns>
+        /// <remarks>Assumes static content is in the parent folder of the /bin/ directory</remarks>
 		public static string MapHostAbsolutePath(this string relativePath)
 		{
 			var mapPath = MapAbsolutePath(relativePath, string.Format("{0}..", Path.DirectorySeparatorChar));

--- a/tests/ServiceStack.Common.Tests/OAuth/OAuthUserSessionTests.cs
+++ b/tests/ServiceStack.Common.Tests/OAuth/OAuthUserSessionTests.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.Common.Tests.OAuth
 					sqliteRepo.Clear();
 					yield return new TestCaseData(sqliteRepo);
 
-					var dbFilePath = "~/App_Data/auth.sqlite".MapAbsolutePath();
+					var dbFilePath = "~/App_Data/auth.sqlite".MapProjectPath();
 					if (File.Exists(dbFilePath)) File.Delete(dbFilePath);
 					var sqliteDbFactory = new OrmLiteConnectionFactory(dbFilePath);
 					var sqliteDbRepo = new OrmLiteAuthRepository(sqliteDbFactory);

--- a/tests/ServiceStack.Common.Tests/OAuth/OAuthUserSessionWithoutTestSourceTests.cs
+++ b/tests/ServiceStack.Common.Tests/OAuth/OAuthUserSessionWithoutTestSourceTests.cs
@@ -51,7 +51,7 @@ namespace ServiceStack.Common.Tests.OAuth
 					userAuthRepositorys.Add(sqliteInMemoryRepo);
 
 					var sqliteDbFactory = new OrmLiteConnectionFactory(
-						"~/App_Data/auth.sqlite".MapAbsolutePath());
+						"~/App_Data/auth.sqlite".MapProjectPath());
 					var sqliteDbRepo = new OrmLiteAuthRepository(sqliteDbFactory);
 					sqliteDbRepo.CreateMissingTables();
 					userAuthRepositorys.Add(sqliteDbRepo);

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/MarkdownFormatTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/MarkdownFormatTests.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 			//staticTemplatePath = "~/AppData/Template/default.shtml".MapAbsolutePath();
 			//staticTemplateContent = File.ReadAllText(staticTemplatePath);
 
-			dynamicPagePath = "~/Views/Template/DynamicTpl.md".MapAbsolutePath();
+			dynamicPagePath = "~/Views/Template/DynamicTpl.md".MapProjectPath();
 			dynamicPageContent = File.ReadAllText(dynamicPagePath);
 
 			//dynamicListPagePath = "~/Views/Template/DynamicListTpl.md".MapAbsolutePath();
@@ -61,7 +61,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[Test]
 		public void Can_load_all_markdown_files()
 		{
-			markdownFormat.RegisterMarkdownPages("~/".MapAbsolutePath());
+			markdownFormat.RegisterMarkdownPages("~/".MapProjectPath());
 
 			Assert.That(markdownFormat.ViewPages.Count, Is.EqualTo(viewPageNames.Length));
 			Assert.That(markdownFormat.ViewSharedPages.Count, Is.EqualTo(sharedViewPageNames.Length));
@@ -78,8 +78,8 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[Test]
 		public void Can_Render_StaticPage()
 		{
-			markdownFormat.RegisterMarkdownPages("~/".MapAbsolutePath());
-			var html = markdownFormat.RenderStaticPageHtml("~/AppData/NoTemplate/Static".MapAbsolutePath());
+			markdownFormat.RegisterMarkdownPages("~/".MapProjectPath());
+			var html = markdownFormat.RenderStaticPageHtml("~/AppData/NoTemplate/Static".MapProjectPath());
 
 			Assert.That(html, Is.Not.Null);
 			Assert.That(html, Is.StringStarting("<h1>Static Markdown template</h1>"));
@@ -88,8 +88,8 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[Test]
 		public void Can_Render_StaticPage_WithTemplate()
 		{
-			markdownFormat.RegisterMarkdownPages("~/".MapAbsolutePath());
-			var html = markdownFormat.RenderStaticPageHtml("~/AppData/Template/StaticTpl".MapAbsolutePath());
+			markdownFormat.RegisterMarkdownPages("~/".MapProjectPath());
+			var html = markdownFormat.RenderStaticPageHtml("~/AppData/Template/StaticTpl".MapProjectPath());
 
 			Console.WriteLine(html);
 
@@ -101,7 +101,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		public void Can_Render_DynamicPage()
 		{
 			var person = new Person { FirstName = "Demis", LastName = "Bellot" };
-			markdownFormat.RegisterMarkdownPages("~/".MapAbsolutePath());
+			markdownFormat.RegisterMarkdownPages("~/".MapProjectPath());
 
 			var html = markdownFormat.RenderDynamicPageHtml("Dynamic", person);
 

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/MockClass.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/MockClass.cs
@@ -27,7 +27,7 @@ namespace CSharpEval
 		//[Test]
 		public void Compare_access()
 		{
-			var filePath = "~/AppData/TestsResults/Customer.htm".MapAbsolutePath();
+			var filePath = "~/AppData/TestsResults/Customer.htm".MapProjectPath();
 			const int Times = 10000;
 
 			var start = DateTime.Now;

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/TemplateTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/TemplateTests.cs
@@ -27,13 +27,13 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			staticTemplatePath = "~/Views/Template/default.shtml".MapAbsolutePath();
+			staticTemplatePath = "~/Views/Template/default.shtml".MapProjectPath();
 			staticTemplateContent = File.ReadAllText(staticTemplatePath);
 
-			dynamicPagePath = "~/Views/Template/DynamicTpl.md".MapAbsolutePath();
+			dynamicPagePath = "~/Views/Template/DynamicTpl.md".MapProjectPath();
 			dynamicPageContent = File.ReadAllText(dynamicPagePath);
 
-			dynamicListPagePath = "~/Views/Template/DynamicListTpl.md".MapAbsolutePath();
+			dynamicListPagePath = "~/Views/Template/DynamicListTpl.md".MapProjectPath();
 			dynamicListPageContent = File.ReadAllText(dynamicListPagePath);
 		}
 

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/TextBlockTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/TextBlockTests.cs
@@ -17,7 +17,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			dynamicListPagePath = "~/Views/Template/DynamicListTpl.md".MapAbsolutePath();
+			dynamicListPagePath = "~/Views/Template/DynamicListTpl.md".MapProjectPath();
 			dynamicListPageContent = File.ReadAllText(dynamicListPagePath);
 		}
 

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/UseCaseTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/UseCaseTests.cs
@@ -73,7 +73,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			var jsonPages = File.ReadAllText("~/AppData/Pages.json".MapAbsolutePath());
+			var jsonPages = File.ReadAllText("~/AppData/Pages.json".MapProjectPath());
 	
 			Pages = JsonSerializer.DeserializeFromString<List<Page>>(jsonPages);
 

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
@@ -25,7 +25,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			var json = "~/AppData/ALFKI.json".MapAbsolutePath().ReadAllText();
+			var json = "~/AppData/ALFKI.json".MapProjectPath().ReadAllText();
 			response = JsonSerializer.DeserializeFromString<CustomerDetailsResponse>(json);
 		}
 
@@ -42,7 +42,7 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 			public AppHost()
 			{
 				this.Config = new EndpointHostConfig {
-					MarkdownSearchPath = "~".MapAbsolutePath(),
+					MarkdownSearchPath = "~".MapProjectPath(),
 					MarkdownReplaceTokens = new Dictionary<string, string>(),
 					IgnoreFormatsInMetadata = new HashSet<string>(),
 				};
@@ -235,14 +235,14 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 			var markdownHandler = new MarkdownHandler {
 				MarkdownFormat = markdownFormat,
 				PathInfo = "/AppData/NoTemplate/Static.md",
-				FilePath = "~/AppData/NoTemplate/Static.md".MapAbsolutePath(),
+				FilePath = "~/AppData/NoTemplate/Static.md".MapProjectPath(),
 			};
 			var httpReq = new MockHttpRequest { QueryString = new NameValueCollection() };
 			var httpRes = new MockHttpResponse();
 			markdownHandler.ProcessRequest(httpReq, httpRes, "Static");
 
 			var expectedHtml = markdownFormat.Transform(
-				File.ReadAllText("~/AppData/NoTemplate/Static.md".MapAbsolutePath()));
+				File.ReadAllText("~/AppData/NoTemplate/Static.md".MapProjectPath()));
 
 			httpRes.Close();
 			Assert.That(httpRes.Contents, Is.EqualTo(expectedHtml));

--- a/tests/ServiceStack.ServiceHost.Tests/Formats_Razor/TemplateTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats_Razor/TemplateTests.cs
@@ -121,13 +121,13 @@ namespace ServiceStack.ServiceHost.Tests.Formats_Razor
 		[TestFixtureSetUp]
 		public void TestFixtureSetUp()
 		{
-			staticTemplatePath = "~/Views/Template/_Layout.cshtml".MapAbsolutePath();
+			staticTemplatePath = "~/Views/Template/_Layout.cshtml".MapProjectPath();
 			staticTemplateContent = File.ReadAllText(staticTemplatePath);
 
-			dynamicPagePath = "~/Views/Template/DynamicTpl.cshtml".MapAbsolutePath();
+			dynamicPagePath = "~/Views/Template/DynamicTpl.cshtml".MapProjectPath();
 			dynamicPageContent = File.ReadAllText(dynamicPagePath);
 
-			dynamicListPagePath = "~/Views/Template/DynamicListTpl.cshtml".MapAbsolutePath();
+			dynamicListPagePath = "~/Views/Template/DynamicListTpl.cshtml".MapProjectPath();
 			dynamicListPageContent = File.ReadAllText(dynamicListPagePath);
 
 			templateArgs = person;

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/FileUploadTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/FileUploadTests.cs
@@ -93,7 +93,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		[Test]
 		public void Can_POST_upload_file()
 		{
-			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapAbsolutePath());
+			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapProjectPath());
 
 			var webRequest = (HttpWebRequest)WebRequest.Create(ListeningOn + "/fileuploads");
 			webRequest.Accept = ContentType.Json;
@@ -114,7 +114,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		{
 			IServiceClient client = new JsonServiceClient(ListeningOn);
 
-			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapAbsolutePath());
+			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapProjectPath());
 
 
 			var response = client.PostFile<FileUploadResponse>(
@@ -133,7 +133,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		{
 			IServiceClient client = new JsonServiceClient(ListeningOn);
 
-			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapAbsolutePath());
+			var uploadFile = new FileInfo("~/TestExistingDir/upload.html".MapProjectPath());
 
 			try
 			{
@@ -155,7 +155,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		[Test]
 		public void Can_GET_upload_file()
 		{
-			var uploadedFile = new FileInfo("~/TestExistingDir/upload.html".MapAbsolutePath());
+			var uploadedFile = new FileInfo("~/TestExistingDir/upload.html".MapProjectPath());
 			var webRequest = (HttpWebRequest)WebRequest.Create(ListeningOn + "/fileuploads/TestExistingDir/upload.html");
 			var expectedContents = new StreamReader(uploadedFile.OpenRead()).ReadToEnd();
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
@@ -229,8 +229,12 @@
       <Link>sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="webpage.forbidden" />
-    <Content Include="webpage.html" />
+    <Content Include="webpage.forbidden">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="webpage.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestExistingDir\default.html" />
     <Content Include="TestExistingDir\upload.html" />
   </ItemGroup>

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/FileUploadService.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Services/FileUploadService.cs
@@ -46,7 +46,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests.Support.Services
 			if (request.RelativePath.IsNullOrEmpty())
 				throw new ArgumentNullException("RelativePath");
 
-			var filePath = ("~/" + request.RelativePath).MapAbsolutePath();
+			var filePath = ("~/" + request.RelativePath).MapProjectPath();
 			if (!File.Exists(filePath))
 				throw new FileNotFoundException(request.RelativePath);
 


### PR DESCRIPTION
Usually when serving static files from Console or Windows Service we set Build Action to "Content" and Copy to Output Directory so the files end up in the same folder as the .dll's.

Use MapProjectPath() to locate files in a VS project, ie. when unit testing.
