### PR TITLE
Mono Cookie Issue

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -54,7 +54,7 @@ namespace ServiceStack.ServiceHost
 			return new HttpCookie(cookie.Name, cookie.Value) {
 				Path = cookie.Path,
 				Expires = cookie.Expires,
-				Domain = cookie.Domain,				
+				Domain = (string.IsNullOrEmpty(cookie.Domain)) ? null : cookie.Domain,				
 			};
 		}
 


### PR DESCRIPTION
When running a ServiceStack application under mono I experienced that some clients do not process the cookies set at the server side. This is due the fact, the Set-Cookie header produced when running the web application in IIS differs from the one produced by the mono environment.

Example output
- Mono: Set-Cookie: ss-id=Swla39ZX9UCU12MeaABEsw==; domain=; path=/
- IIS: Set-Cookie: ss-id=0yeNOe2sEU6FLQjfxTcDow==; path=/

The reason for this can be found in the mono sources.
- <a href="https://github.com/mono/mono/blob/master/mcs/class/System.Web/System.Web/HttpCookie.cs" title="HttpCookie.cs">HttpCookie.cs</a>:  GetCookieHeaderValue
- <a href="https://github.com/mono/mono/blob/master/mcs/class/System/System.Net/Cookie.cs" title="Cookie.cs">Cookie.cs</a>: Domain is string.Empty by default

The solution has been tested under linux running apache2 + modmono + mono 2.10.5
