### PR TITLE
Added Support for Stream to PostFile instead of just FileInfo

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -438,6 +438,37 @@ namespace ServiceStack.ServiceClient.Web
 			}
 		}
 
+        public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, string mimeType)
+        {
+            var requestUri = GetUrl(relativeOrAbsoluteUrl);
+            var webRequest = (HttpWebRequest)WebRequest.Create(requestUri);
+            webRequest.Method = Web.HttpMethod.Post;
+            webRequest.Accept = ContentType;
+            if (Proxy != null) webRequest.Proxy = Proxy;
+
+            try
+            {
+                if (HttpWebRequestFilter != null)
+                {
+                    HttpWebRequestFilter(webRequest);
+                }
+
+                webRequest.UploadFile(fileToUpload, fileName, mimeType);
+                var webResponse = webRequest.GetResponse();
+
+                using (var responseStream = webResponse.GetResponseStream())
+                {
+                    var response = DeserializeFromStream<TResponse>(responseStream);
+                    return response;
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleResponseException<TResponse>(ex, requestUri);
+                throw;
+            }
+        }
+
 		public void Dispose() { }
 	}
 }

--- a/src/ServiceStack.Common/ServiceClient.Web/WcfServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WcfServiceClient.cs
@@ -125,6 +125,11 @@ namespace ServiceStack.ServiceClient.Web
 			throw new NotImplementedException();
 		}
 
+        public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, string mimeType)
+        {
+            throw new NotImplementedException();
+        }
+
 		public void SendOneWay(object request)
 		{
 			SendOneWay(request, request.GetType().Name);

--- a/src/ServiceStack.Interfaces/Service/IReplyClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IReplyClient.cs
@@ -12,5 +12,7 @@ namespace ServiceStack.Service
 		TResponse Send<TResponse>(object request);
 
 		TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, string mimeType);
+
+        TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, string mimeType);
 	}
 }

--- a/src/ServiceStack.ServiceInterface/Testing/TestBase.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/TestBase.cs
@@ -161,6 +161,12 @@ namespace ServiceStack.ServiceInterface.Testing
 				throw new NotImplementedException();
 			}
 
+            public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, string mimeType)
+            {
+                throw new NotImplementedException();
+            }
+
+
 			public void SendAsync<TResponse>(object request,
 				Action<TResponse> onSuccess, Action<TResponse, Exception> onError)
 			{

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/DirectServiceClient.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/DirectServiceClient.cs
@@ -129,6 +129,11 @@ namespace ServiceStack.WebHost.Endpoints.Tests.Support
 			throw new NotImplementedException();
 		}
 
+        public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileInfo, string mimeType)
+        {
+            throw new NotImplementedException();
+        }
+
 		public void SendAsync<TResponse>(object request, Action<TResponse> onSuccess, Action<TResponse, Exception> onError)
 		{
 			var response = default(TResponse);


### PR DESCRIPTION
...This is to support times when you are creating files in memory or other scenarios when the content doesn't exist on disk and would be slow to write to disk then call.  We have some file upload services that need to be really efficient and sometimes these files are loaded/modified or zipped in memory then sent.  Persisting to disk first is inefficient.
Wasn't happy that I needed to modify the interface, but not sure what the recommended way would be.
