### PR TITLE
custom deserializer not called due to trailing charset header

### DIFF
--- a/src/ServiceStack.Common/Web/HttpResponseFilter.cs
+++ b/src/ServiceStack.Common/Web/HttpResponseFilter.cs
@@ -231,7 +231,8 @@ namespace ServiceStack.Common.Web
 		public StreamDeserializerDelegate GetStreamDeserializer(string contentType)
 		{
 			StreamDeserializerDelegate streamReader;
-			if (this.ContentTypeDeserializers.TryGetValue(contentType, out streamReader))
+            var realContentType = contentType.Split(';')[0].Trim();
+			if (this.ContentTypeDeserializers.TryGetValue(realContentType, out streamReader))
 			{
 				return streamReader;
 			}


### PR DESCRIPTION
Hi,

custom content-type is registered as 'application/xml', e.g.
But content-type sent by a request is used including charset-information to find registered types, e.g.
 'application/xml; charset=UTF-8'. The fix splits the charset away.

Cheers, mp
