### PR TITLE
Changed Add extension method signature to match other Add methods

### DIFF
--- a/src/ServiceStack.ServiceInterface/ServiceRoutesExtensions.cs
+++ b/src/ServiceStack.ServiceInterface/ServiceRoutesExtensions.cs
@@ -137,20 +137,20 @@ namespace ServiceStack.ServiceInterface
 			return false;
 		}
 
-        private static string FormatRoute<T>(string path, params Expression<Func<T, object>>[] propertyExpressions)
+        private static string FormatRoute<T>(string restPath, params Expression<Func<T, object>>[] propertyExpressions)
         {
             var properties = propertyExpressions.Select(x => string.Format("{{{0}}}", PropertyName(x))).ToArray();
-            return string.Format(path, properties);
+            return string.Format(restPath, properties);
         }
 
-        private static string PropertyName(LambdaExpression ex)
+        private static string PropertyName(LambdaExpression lambdaExpression)
         {
-            return (ex.Body is UnaryExpression ? (MemberExpression)((UnaryExpression)ex.Body).Operand : (MemberExpression)ex.Body).Member.Name;
+            return (lambdaExpression.Body is UnaryExpression ? (MemberExpression)((UnaryExpression)lambdaExpression.Body).Operand : (MemberExpression)lambdaExpression.Body).Member.Name;
         }
 
-        public static void Add<T>(this IServiceRoutes serviceRoutes, string httpMethod, string url, params Expression<Func<T, object>>[] propertyExpressions)
+        public static void Add<T>(this IServiceRoutes serviceRoutes, string restPath, ApplyTo verbs, params Expression<Func<T, object>>[] propertyExpressions)
         {
-            serviceRoutes.Add<T>(FormatRoute(url, propertyExpressions), httpMethod);
+            serviceRoutes.Add<T>(FormatRoute(restPath, propertyExpressions), verbs);
         }
 	}
 }

--- a/tests/ServiceStack.ServiceHost.Tests/Routes/ServiceRoutesTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Routes/ServiceRoutesTests.cs
@@ -48,14 +48,14 @@ namespace ServiceStack.ServiceHost.Tests.Routes
 			Assert.That(restWithAFewMethodsRoute.AllowedVerbs.Contains("PATCH"), Is.False);
 		}
 
-		[Test]
-		public void Can_Register_Routes_Using_Add_Extension()
-		{
-			var routes = new ServiceRoutes();
-			routes.Add<Customer>(HttpMethod.Get, "/Users/{0}/Orders/{1}", x => x.Name, x => x.OrderId);
-			var route = routes.RestPaths[0];
-			Assert.That(route.Path == "/Users/{Name}/Orders/{OrderId}");
-		}
+        [Test]
+        public void Can_Register_Routes_Using_Add_Extension()
+        {
+            var routes = new ServiceRoutes();
+            routes.Add<Customer>("/Users/{0}/Orders/{1}", ApplyTo.Get, x => x.Name, x => x.OrderId);
+            var route = routes.RestPaths[0];
+            Assert.That(route.Path == "/Users/{Name}/Orders/{OrderId}");
+        }
 	}
 
 	public class Customer


### PR DESCRIPTION
I'm probably the only person using this but the difference in the signature has caught me out a couple of times recently.
