### PR TITLE
Added global and local filter for being able to access the web response

### DIFF
--- a/tests/ServiceStack.WebHost.Endpoints.Tests/_SyncRestClientTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/_SyncRestClientTests.cs
@@ -159,6 +159,19 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		{
 			return new JsonServiceClient(ListeningOn);
 		}
+
+        [Test]
+        public void Can_use_response_filters()
+        {
+            var isActioncalledGlobal = false;
+            var isActioncalledLocal = false;
+            ServiceClientBase.HttpWebResponseFilter = r => isActioncalledGlobal = true;
+            var restClient = (JsonServiceClient)CreateRestClient();
+            restClient.LocalHttpWebResponseFilter = r => isActioncalledLocal = true;
+            restClient.Get<MoviesResponse>("movies");
+            Assert.That(isActioncalledGlobal, Is.True);
+            Assert.That(isActioncalledLocal, Is.True);
+        }
 	}
 
 	[TestFixture]


### PR DESCRIPTION
This adds an action to ClientserviceBase to be able to access the web response coming from the server to support scenarios where access to the response Headers etc. are necessary.
