### PR TITLE
Fix for missing content type on optimized cached results

### DIFF
--- a/src/ServiceStack/CacheAccess.Providers/CacheClientExtensions.cs
+++ b/src/ServiceStack/CacheAccess.Providers/CacheClientExtensions.cs
@@ -44,7 +44,7 @@ namespace ServiceStack.CacheAccess.Providers
 					return new CompressedResult(
 						compressedResult,
 						context.CompressionType,
-						context.ContentType);
+						context.ResponseContentType);
 				}
 			}
 			else
@@ -97,7 +97,7 @@ namespace ServiceStack.CacheAccess.Providers
 				cacheClient.Set<byte[]>(cacheKeySerializedZip, compressedSerializedDto, expireCacheIn);
 
 				return (compressedSerializedDto != null)
-					? new CompressedResult(compressedSerializedDto, context.CompressionType, context.ContentType)
+					? new CompressedResult(compressedSerializedDto, context.CompressionType, context.ResponseContentType)
 					: null;
 			}
 


### PR DESCRIPTION
This is a fix for issue #122.

Problem was that the content type of `CompressedResult` was being set to `context.ContentType` instead of `context.ResponseContentType` in a couple of places.

Go easy on me please... it's my first ever pull request on an OSS project. Would be happy to clean it up / do it again in a better way if you give me some pointers. ;)
