### PR TITLE
Fix compilation of Silverlight projects

### DIFF
--- a/src/ServiceStack.Common.SL4/ServiceStack.Common.SL4.csproj
+++ b/src/ServiceStack.Common.SL4/ServiceStack.Common.SL4.csproj
@@ -415,6 +415,9 @@
     <Compile Include="..\ServiceStack.Common\Web\HttpResult.cs">
       <Link>Web\HttpResult.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResultExtensions.cs">
+      <Link>Web\HttpResultExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Common\Web\MimeTypes.cs">
       <Link>Web\MimeTypes.cs</Link>
     </Compile>

--- a/src/ServiceStack.Common.SL5/ServiceStack.Common.SL5.csproj
+++ b/src/ServiceStack.Common.SL5/ServiceStack.Common.SL5.csproj
@@ -414,6 +414,9 @@
     <Compile Include="..\ServiceStack.Common\Web\HttpResult.cs">
       <Link>Web\HttpResult.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResultExtensions.cs">
+      <Link>Web\HttpResultExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Common\Web\MimeTypes.cs">
       <Link>Web\MimeTypes.cs</Link>
     </Compile>

--- a/src/ServiceStack.Interfaces.SL4/ServiceStack.Interfaces.SL4.csproj
+++ b/src/ServiceStack.Interfaces.SL4/ServiceStack.Interfaces.SL4.csproj
@@ -550,6 +550,9 @@
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\Property.cs">
       <Link>ServiceInterface.ServiceModel\Property.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\RequestLogEntry.cs">
+      <Link>ServiceInterface.ServiceModel\RequestLogEntry.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ResponseError.cs">
       <Link>ServiceInterface.ServiceModel\ResponseError.cs</Link>
     </Compile>

--- a/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
+++ b/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
@@ -549,6 +549,9 @@
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\Property.cs">
       <Link>ServiceInterface.ServiceModel\Property.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\RequestLogEntry.cs">
+      <Link>ServiceInterface.ServiceModel\RequestLogEntry.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ResponseError.cs">
       <Link>ServiceInterface.ServiceModel\ResponseError.cs</Link>
     </Compile>


### PR DESCRIPTION
I added the missing links to allow clean compilation of the Silverlight projects.

Note: I only tested with SL4 but I made the modifications for SL5 (I see no reason why it would be different)
