### PR TITLE
Added tests for the new SetBaseUri method...

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -69,21 +69,31 @@ namespace ServiceStack.ServiceClient.Web
             this.AsyncOneWayBaseUri = asyncOneWayBaseUri;
         }
 
+        /// <summary>
+        /// Sets all baseUri properties, using the Format property for the SyncReplyBaseUri and AsyncOneWayBaseUri
+        /// </summary>
+        /// <param name="baseUri">Base URI of the service</param>
         public void SetBaseUri(string baseUri)
         {
-            if (String.IsNullOrEmpty(Format))
-                throw new InvalidOperationException("SetBaseUri(string baseUri) was called, but no Format was found. "
-                    + "Please consider calling SetBaseUri(string baseUri, string format).");
-            SetBaseUri(baseUri, Format);
-        }
-
-        public void SetBaseUri(string baseUri, string format)
-        {
-            this.Format = format;
             this.BaseUri = baseUri;
             this.asyncClient.BaseUri = baseUri;
-            this.SyncReplyBaseUri = baseUri.WithTrailingSlash() + this.Format + "/syncreply/";
-            this.AsyncOneWayBaseUri = baseUri.WithTrailingSlash() + this.Format + "/asynconeway/";
+            this.SyncReplyBaseUri = baseUri.WithTrailingSlash() + Format + "/syncreply/";
+            this.AsyncOneWayBaseUri = baseUri.WithTrailingSlash() + Format + "/asynconeway/";
+        }
+
+        /// <summary>
+        /// Sets all baseUri properties allowing for a temporary override of the Format property
+        /// </summary>
+        /// <param name="baseUri">Base URI of the service</param>
+        /// <param name="format">Override of the Format property for the service</param>
+        //Marked obsolete on 4/11/2012
+        [Obsolete("Please call the SetBaseUri(string baseUri) method, which uses the specific implementation's Format property.")]
+        public void SetBaseUri(string baseUri, string format)
+        {
+            this.BaseUri = baseUri;
+            this.asyncClient.BaseUri = baseUri;
+            this.SyncReplyBaseUri = baseUri.WithTrailingSlash() + format + "/syncreply/";
+            this.AsyncOneWayBaseUri = baseUri.WithTrailingSlash() + format + "/asynconeway/";
         }
 
         private string _username;
@@ -121,7 +131,7 @@ namespace ServiceStack.ServiceClient.Web
 
         public string BaseUri { get; set; }
 
-        public virtual string Format { get; set; }
+        public abstract string Format { get;}
 
         public string SyncReplyBaseUri { get; set; }
 

--- a/tests/ServiceStack.Common.Tests/ServiceClient.Web/ServiceClientBaseTester.cs
+++ b/tests/ServiceStack.Common.Tests/ServiceClient.Web/ServiceClientBaseTester.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ServiceStack.ServiceClient.Web;
+
+namespace ServiceStack.Common.Tests.ServiceClient.Web
+{
+    public class ServiceClientBaseTester : ServiceClientBase
+    {
+        public override string ContentType { get { return String.Format("application/{0}", Format); } }
+
+        public override void SerializeToStream(ServiceHost.IRequestContext requestContext, object request, System.IO.Stream stream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override T DeserializeFromStream<T>(System.IO.Stream stream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ServiceHost.StreamDeserializerDelegate StreamDeserializer
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public override string Format
+        {
+            get { return "TestFormat"; }
+        }
+    }
+}

--- a/tests/ServiceStack.Common.Tests/ServiceClient.Web/ServiceClientBaseTests.cs
+++ b/tests/ServiceStack.Common.Tests/ServiceClient.Web/ServiceClientBaseTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace ServiceStack.Common.Tests.ServiceClient.Web
+{
+    [TestFixture]
+    public class ServiceClientBaseTests
+    {
+        [Test]
+        public void SetBaseUri_FormatLoaded_LoadedFormatUsedInSyncAndAsyncUri()
+        {
+            var serviceClientBaseTester = new ServiceClientBaseTester();
+            String baseUri = "BaseURI";
+
+            serviceClientBaseTester.SetBaseUri(baseUri);
+
+            String expectedBaseUri = baseUri;
+            String expectedSyncReplyBaseUri = baseUri + "/" + serviceClientBaseTester.Format + "/syncreply/";
+            String expectedAsyncOneWayBaseUri = baseUri + "/" + serviceClientBaseTester.Format + "/asynconeway/";
+            Assert.That(serviceClientBaseTester.BaseUri, Is.EqualTo(expectedBaseUri));
+            Assert.That(serviceClientBaseTester.SyncReplyBaseUri, Is.EqualTo(expectedSyncReplyBaseUri));
+            Assert.That(serviceClientBaseTester.AsyncOneWayBaseUri, Is.EqualTo(expectedAsyncOneWayBaseUri));
+        }
+    }
+}

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -185,6 +185,8 @@
     <Compile Include="Perf\ToStringPerf.cs" />
     <Compile Include="PerfTestBase.cs" />
     <Compile Include="Perf\StringParsePerf.cs" />
+    <Compile Include="ServiceClient.Web\ServiceClientBaseTester.cs" />
+    <Compile Include="ServiceClient.Web\ServiceClientBaseTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
     <Compile Include="StringExtensionTests.cs" />
     <Compile Include="ReflectionUtilTests.cs" />


### PR DESCRIPTION
Also, I made Format abstract since each implementation will always have its own format. Otherwise, it breaks Liskov's Substitution Principle since the concrete implementations only had a get. I marked SetBaseUri that took format as a parameter obsolete, since it should use the internal property anyway. This was the actual functionality, however it was originally not happening with the parameterless constructors.
