### PR TITLE
Fixed NullRef, serialized DTO can be null

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/Formats/HtmlFormat.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Formats/HtmlFormat.cs
@@ -41,7 +41,8 @@ namespace ServiceStack.WebHost.Endpoints.Formats
 				&& httpReq.ResponseContentType != ContentType.JsonReport) return;
 
 			// Serialize then escape any potential script tags to avoid XSS when displaying as HTML
-			var json = JsonSerializer.SerializeToString(dto).Replace("<", "&lt;").Replace(">", "&gt;");
+			var json = JsonSerializer.SerializeToString(dto) ?? "null";
+			json = json.Replace("<", "&lt;").Replace(">", "&gt;");
 
 			var url = httpReq.AbsoluteUri
 				.Replace("format=html", "")


### PR DESCRIPTION
Realized that the serializer can return a null DTO string when the service doesn't return a DTO, for instance when it returns an HttpResult.
