### PR TITLE
Add a ConnectTimeout attribute to IRedisClient

### DIFF
--- a/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
@@ -30,6 +30,7 @@ namespace ServiceStack.Redis
 		DateTime LastSave { get; }
 		string Host { get; }
 		int Port { get; }
+        int ConnectTimeout { get; set; }
 		int RetryTimeout { get; set; }
 		int RetryCount { get; set; }
 		int SendTimeout { get; set; }


### PR DESCRIPTION
The current Redis client can take up to 15 seconds to timeout when
attempting to connect to a server that is not running. This attribute can
be used to set a shorter connection timeout.

There will be another pull request for the ServiceStack.Redis project as
well that actually implements this feature.
