### PR TITLE
Modify the handler matching of the MiniProfilerHandler

### DIFF
--- a/src/ServiceStack/MiniProfiler/UI/MiniProfilerHandler.cs
+++ b/src/ServiceStack/MiniProfiler/UI/MiniProfilerHandler.cs
@@ -20,7 +20,8 @@ namespace ServiceStack.MiniProfiler.UI
 	{
 		public static IHttpHandler MatchesRequest(IHttpRequest request)
 		{
-			return request.PathInfo.TrimStart('/').Contains("ss-")
+			var file = Path.GetFileNameWithoutExtension(request.PathInfo);
+			return file != null && file.StartsWith("ss-")
 				? new MiniProfilerHandler()
 				: null;
 		}


### PR DESCRIPTION
Hi,

I modified the handler of the MiniProfiler that matched all files/filenames containing the
string 'ss-' although only files starting with 'ss-' were handled.

Files like 'less-1.3.0.min.js' were treated as profiling files for that reason.

Cheers,
Gregor
