### PR TITLE
bug fixes: added cross domain rest + fixed a bug in the "movies" test service

### DIFF
--- a/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
@@ -78,7 +78,7 @@ namespace ServiceStack.WebHost.IntegrationTests
 				dbFactory.Exec(dbCmd => dbCmd.CreateTable<Movie>(true));
 				ModelConfig<Movie>.Id(x => x.Title);
 				Routes
-					.Add<Movies>("/custom-movies", "GET")
+					.Add<Movies>("/custom-movies", "GET, OPTIONS")
 					.Add<Movies>("/custom-movies/genres/{Genre}")
 					.Add<Movie>("/custom-movies", "POST,PUT")
 					.Add<Movie>("/custom-movies/{Id}")
@@ -96,6 +96,11 @@ namespace ServiceStack.WebHost.IntegrationTests
 
 				//var onlyEnableFeatures = Feature.All.Remove(Feature.Jsv | Feature.Soap);
 				SetConfig(new EndpointHostConfig {
+                    GlobalResponseHeaders = {
+                        { "Access-Control-Allow-Origin", "*" },
+                        { "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS" },
+                        { "Access-Control-Allow-Headers", "Content-Type, X-Requested-With" },
+                    },
 					//EnableFeatures = onlyEnableFeatures,
 					DebugMode = true, //Show StackTraces for easier debugging
 				});

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/MovieService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/MovieService.cs
@@ -125,7 +125,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
 		/// </summary>
 		public override object OnPut(Movie movie)
 		{
-			DbFactory.Exec(dbCmd => dbCmd.Save(movie));
+			DbFactory.Exec(dbCmd => dbCmd.Update(movie));
 			return new MovieResponse();
 		}
 

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/MoviesService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/MoviesService.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
 {
 
 	[DataContract]
-	[RestService("/movies", "GET")]
+	[RestService("/movies", "GET, OPTIONS")]
 	[RestService("/movies/genres/{Genre}")]
 	public class Movies
 	{


### PR DESCRIPTION
Added support for cross domain rest using json to the "movies" test service.
To do that I:
Added "Access-Control-Allow-Origin" and his friends as "GlobalResponseHeaders".
Added "OPTIONS" verb to the "movies" GET route.

Fixed a bug in the "movies" test service. Now "OnPut" updates the record (instead of adding a new record).
