### PR TITLE
HtmlFormat now uses JSON serializer instance

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/Formats/HtmlFormat.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Formats/HtmlFormat.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using ServiceStack.Common.Web;
 using ServiceStack.ServiceHost;
+using ServiceStack.ServiceModel.Serialization;
 using ServiceStack.Text;
 
 namespace ServiceStack.WebHost.Endpoints.Formats
@@ -41,7 +42,7 @@ namespace ServiceStack.WebHost.Endpoints.Formats
 				&& httpReq.ResponseContentType != ContentType.JsonReport) return;
 
 			// Serialize then escape any potential script tags to avoid XSS when displaying as HTML
-			var json = JsonSerializer.SerializeToString(dto) ?? "null";
+            var json = JsonDataContractSerializer.Instance.SerializeToString(dto) ?? "null";
 			json = json.Replace("<", "&lt;").Replace(">", "&gt;");
 
 			var url = httpReq.AbsoluteUri


### PR DESCRIPTION
Title says it all. Should fix the HTML view differing from the results of ?format=json.
