### PR TITLE
Changed ToRequest extension method to check if AppHostBase.Instance is null, and if so, set the HttpRequestWrapper.Container to null.  This allows ICacheClient and ISession to be used when no AppHost exists.

### DIFF
--- a/src/ServiceStack.ServiceInterface/SessionExtensions.cs
+++ b/src/ServiceStack.ServiceInterface/SessionExtensions.cs
@@ -136,14 +136,14 @@ namespace ServiceStack.ServiceInterface
         public static IHttpRequest ToRequest(this HttpRequest aspnetHttpReq)
         {
             return new HttpRequestWrapper(aspnetHttpReq) {
-                Container = AppHostBase.Instance.Container
+                Container = AppHostBase.Instance != null ? AppHostBase.Instance.Container : null
             };
         }
 
         public static IHttpRequest ToRequest(this HttpListenerRequest listenerHttpReq)
         {
             return new HttpListenerRequestWrapper(listenerHttpReq) {
-                Container = AppHostBase.Instance.Container
+                Container = AppHostBase.Instance != null ? AppHostBase.Instance.Container : null
             };
         }
 


### PR DESCRIPTION
...ull, and if so, set the HttpRequestWrapper.Container to null.  This allows ICacheClient and ISession to be used when no AppHost exists.
