### PR TITLE
Added duration measurement to IRequestLogger and RequestLogsService

### DIFF
--- a/src/ServiceStack.Interfaces/ServiceHost/IRequestLogger.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/IRequestLogger.cs
@@ -46,7 +46,8 @@ namespace ServiceStack.ServiceHost
 		/// <param name="requestContext">The RequestContext</param>
 		/// <param name="requestDto">Request DTO</param>
 		/// <param name="response">Response DTO or Exception</param>
-		void Log(IRequestContext requestContext, object requestDto, object response);
+		/// <param name="elapsed">How long did the Request take</param>
+		void Log(IRequestContext requestContext, object requestDto, object response, TimeSpan elapsed);
 
 		/// <summary>
 		/// View the most recent logs

--- a/src/ServiceStack.Interfaces/ServiceInterface.ServiceModel/RequestLogEntry.cs
+++ b/src/ServiceStack.Interfaces/ServiceInterface.ServiceModel/RequestLogEntry.cs
@@ -25,5 +25,6 @@ namespace ServiceStack.ServiceInterface.ServiceModel
 		public object Session { get; set; }
 		public object ResponseDto { get; set; }
 		public object ErrorResponse { get; set; }
+        public TimeSpan RequestDuration { get; set; }
 	}
 }

--- a/src/ServiceStack.ServiceInterface/Providers/InMemoryRollingRequestLogger.cs
+++ b/src/ServiceStack.ServiceInterface/Providers/InMemoryRollingRequestLogger.cs
@@ -35,7 +35,7 @@ namespace ServiceStack.ServiceInterface.Providers
             this.capacity = capacity.GetValueOrDefault(DefaultCapacity);
         }
 
-        public void Log(IRequestContext requestContext, object requestDto, object response)
+        public void Log(IRequestContext requestContext, object requestDto, object response, TimeSpan requestDuration)
         {
             var requestType = requestDto != null ? requestDto.GetType() : null;
 
@@ -59,6 +59,7 @@ namespace ServiceStack.ServiceInterface.Providers
                 SessionId = httpReq.GetSessionId(),
                 Items = httpReq.Items,
                 Session = EnableSessionTracking ? httpReq.GetSession() : null,
+                RequestDuration = requestDuration,
             };
 
             if (HideRequestBodyForRequestDtoTypes != null

--- a/src/ServiceStack.ServiceInterface/ServiceBase.cs
+++ b/src/ServiceStack.ServiceInterface/ServiceBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Web;
 using ServiceStack.CacheAccess;
 using ServiceStack.CacheAccess.Providers;
@@ -27,6 +28,11 @@ namespace ServiceStack.ServiceInterface
         : IService<TRequest>, IRequiresRequestContext, IServiceBase, IAsyncService<TRequest>
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(ServiceBase<>));
+
+        /// <summary>
+        /// Stopwatch used to record the duration of each request
+        /// </summary>
+        private Stopwatch _requestDurationStopwatch;
 
         /// <summary>
         /// Service error logs are kept in 'urn:ServiceErrors:{ServiceName}'
@@ -77,6 +83,11 @@ namespace ServiceStack.ServiceInterface
         {
             this.CurrentRequestDto = requestDto;
             OnBeforeExecute(requestDto);
+
+            if (this.RequestLogger != null)
+            {
+                _requestDurationStopwatch = Stopwatch.StartNew();
+            }
         }
 
         protected object AfterEachRequest(TRequest requestDto, object response)
@@ -85,7 +96,7 @@ namespace ServiceStack.ServiceInterface
             {
                 try
                 {
-                    RequestLogger.Log(this.RequestContext, requestDto, response);
+                    RequestLogger.Log(this.RequestContext, requestDto, response, _requestDurationStopwatch.Elapsed);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Hi,

I thought this might be a nice thing to add to the request logs since it can help debug long running requests running on a remote production site by letting you filter out longrunning requests and then giving you all the information about those requests and responses which is available in the RequestLogEntry.

Regards

Simon, Denmark
