### PR TITLE
IAuthSession should not be required to use the base controller

### DIFF
--- a/src/ServiceStack.FluentValidation.Mvc3/Mvc/ServiceStackController.cs
+++ b/src/ServiceStack.FluentValidation.Mvc3/Mvc/ServiceStackController.cs
@@ -81,7 +81,10 @@ namespace ServiceStack.Mvc
 			}
 		}
 
-		public abstract IAuthSession AuthSession { get; }
+		public virtual IAuthSession AuthSession
+		{
+			get { return null; }
+		}
 
 		protected string SessionKey
 		{


### PR DESCRIPTION
A couple of weeks ago I talked with mythz on the chat website about removing the abstract property AuthSession from ServiceStackController. The reason is that not all applications need authentication. He suggested replacing it instead with a property returning null. So here is a pull request with just that change.
