### PR TITLE
ServiceClientBase CancelAsync

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -660,6 +660,11 @@ namespace ServiceStack.ServiceClient.Web
             asyncClient.SendAsync(Web.HttpMethod.Put, GetUrl(relativeOrAbsoluteUrl), request, onSuccess, onError);
         }
 
+        public virtual void CancelAsync()
+        {
+            asyncClient.CancelAsync();
+        }
+
 #if !SILVERLIGHT
         public virtual TResponse Send<TResponse>(string httpMethod, string relativeOrAbsoluteUrl, object request)
         {


### PR DESCRIPTION
HttpWebRequest supports Abort() to throw Exceptions when when any of the
underlying Async methods are called.  Allows client children to cancel outstanding Async calls.
