### PR TITLE
Use default ContentType when Request ContentType is null or empty

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/RestHandler.cs
+++ b/src/ServiceStack/WebHost.EndPoints/RestHandler.cs
@@ -99,7 +99,7 @@ namespace ServiceStack.WebHost.Endpoints
 				var requestDto = GetCustomRequestFromBinder(httpReq, requestType);
 				if (requestDto != null)	return requestDto;
 
-				requestDto = CreateContentTypeRequest(httpReq, requestType, httpReq.ContentType);
+				requestDto = CreateContentTypeRequest(httpReq, requestType, string.IsNullOrEmpty(httpReq.ContentType)? restPath.DefaultContentType : httpReq.ContentType);
 
 				return restPath.CreateRequest(httpReq.PathInfo, requestParams, requestDto);
 			}


### PR DESCRIPTION
If the Request.ContentType is null from the client, then use the default content type for the Rest path. 

Encountered this problem where the client app was not setting a custom content type correctly. 

Thx,
Ash
