### PR TITLE
Add OnAfterExecute method to IAppHost for general execution purposes (like end db session)

### DIFF
--- a/src/ServiceStack.ServiceInterface/ServiceBase.cs
+++ b/src/ServiceStack.ServiceInterface/ServiceBase.cs
@@ -198,6 +198,7 @@ namespace ServiceStack.ServiceInterface
         /// <returns></returns>
         protected virtual object OnAfterExecute(object response)
         {
+            GetAppHost().OnAfterExecute(RequestContext, CurrentRequestDto, response);
             return response;
         }
         

--- a/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
@@ -25,7 +25,9 @@ namespace ServiceStack.ServiceInterface.Testing
         }
 
         public virtual void Release(object instance) { }
-        
+
+        public virtual void OnAfterExecute(IRequestContext requestContext, object requestDto, object responseDto) {}
+
         public void OnEndRequest() {}
 
         public void Register<T>(T instance)

--- a/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
@@ -41,7 +41,9 @@ namespace ServiceStack.ServiceInterface.Testing
         }
 
         public virtual void Release(object instance) { }
-        
+
+        public virtual void OnAfterExecute(IRequestContext requestContext, object requestDto, object responseDto) { }
+
         public void OnEndRequest() {}
 
         public void Register<T>(T instance)

--- a/src/ServiceStack/WebHost.EndPoints/AppHostBase.cs
+++ b/src/ServiceStack/WebHost.EndPoints/AppHostBase.cs
@@ -122,6 +122,10 @@ namespace ServiceStack.WebHost.Endpoints
             }
         }
 
+        public virtual void OnAfterExecute(IRequestContext requestContext, object requestDto, object responseDto)
+        {
+        }
+
         public virtual void OnEndRequest()
         {
             foreach (var item in HostContext.Instance.Items.Values)

--- a/src/ServiceStack/WebHost.EndPoints/IAppHost.cs
+++ b/src/ServiceStack/WebHost.EndPoints/IAppHost.cs
@@ -82,5 +82,11 @@ namespace ServiceStack.WebHost.Endpoints
 		/// </summary>
 		/// <param name="plugins"></param>
 		void LoadPlugin(params IPlugin[] plugins);
+
+        /// <summary>
+        /// Called after the request is Executed. Override to decorate the response dto.
+        /// This method is only called if no exception occured while executing the service.
+        /// </summary>
+        void OnAfterExecute(IRequestContext requestContext, object requestDto, object responseDto);
 	}
 }

--- a/src/ServiceStack/WebHost.EndPoints/Support/HttpListenerBase.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Support/HttpListenerBase.cs
@@ -302,6 +302,10 @@ namespace ServiceStack.WebHost.Endpoints.Support
             }
 		}
 
+        public virtual void OnAfterExecute(IRequestContext requestContext, object requestDto, object responseDto)
+        {
+        }
+
         public virtual void OnEndRequest()
         {
             foreach (var item in HostContext.Instance.Items.Values)


### PR DESCRIPTION
This is a solution for using one db session per request as presented in this (my) stackoverflow question:

http://stackoverflow.com/questions/11901216/using-ravendb-with-servicestack 
