### PR TITLE
File uploads do not contain the CookieContainer

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -722,6 +722,9 @@ namespace ServiceStack.ServiceClient.Web
             webRequest.Accept = ContentType;
             if (Proxy != null) webRequest.Proxy = Proxy;
 
+            if (StoreCookies)
+                webRequest.CookieContainer = CookieContainer;
+
             try
             {
                 ApplyWebRequestFilters(webRequest);
@@ -778,6 +781,9 @@ namespace ServiceStack.ServiceClient.Web
             webRequest.Accept = ContentType;
             if (Proxy != null) webRequest.Proxy = Proxy;
 
+            if (StoreCookies)
+                webRequest.CookieContainer = CookieContainer;
+
             try
             {
                 ApplyWebRequestFilters(webRequest);
@@ -804,6 +810,9 @@ namespace ServiceStack.ServiceClient.Web
             webRequest.Method = Web.HttpMethod.Post;
             webRequest.Accept = ContentType;
             if (Proxy != null) webRequest.Proxy = Proxy;
+
+            if (StoreCookies)
+                webRequest.CookieContainer = CookieContainer;
 
             try
             {


### PR DESCRIPTION
There is a new session with each PostFile.

Neither PostFile or PostFileWithResponse added the cookie container to
their posts, and therefore wasn't passing the session id.

(Am I right in this?  I cannot compile the code as I don't have VS2010)
