### PR TITLE
Fix problems preventing a Silverlight build for ServiceStack.SL5

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
-#if !MONOTOUCH
+#if !(MONOTOUCH || SILVERLIGHT)
 using System.Web;
 #endif
 using ServiceStack.Common;

--- a/src/ServiceStack.Common/ServiceModel/Serialization/DataContractDeserializer.cs
+++ b/src/ServiceStack.Common/ServiceModel/Serialization/DataContractDeserializer.cs
@@ -44,6 +44,8 @@ namespace ServiceStack.ServiceModel.Serialization
 
 #if MONOTOUCH				
                 using (var reader = XmlDictionaryReader.CreateTextReader(bytes, null))
+#elif SILVERLIGHT
+                using (var reader = XmlDictionaryReader.CreateTextReader(bytes, XmlDictionaryReaderQuotas.Max))
 #else
                 using (var reader = XmlDictionaryReader.CreateTextReader(bytes, this.quotas))
 #endif

--- a/src/ServiceStack.Common/TypeExtensions.cs
+++ b/src/ServiceStack.Common/TypeExtensions.cs
@@ -27,6 +27,7 @@ namespace ServiceStack.Common
             return type.GetCustomAttributes(typeof(T), true).SafeConvertAll(x => (T)x);
         }
 
+#if !SILVERLIGHT
         public static string GetAssemblyPath(this Type source)
         {
             var assemblyUri =
@@ -34,6 +35,6 @@ namespace ServiceStack.Common
 
             return assemblyUri.LocalPath;
         }
-
+#endif
     }
 }

--- a/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
+++ b/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
@@ -405,6 +405,9 @@
     <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisTransactionBase.cs">
       <Link>Redis\IRedisTransactionBase.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\ItemRef.cs">
+      <Link>Redis\ItemRef.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Interfaces\Redis\Pipeline\IRedisPipeline.cs">
       <Link>Redis\Pipeline\IRedisPipeline.cs</Link>
     </Compile>
@@ -440,9 +443,6 @@
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IAsyncService.cs">
       <Link>ServiceHost\IAsyncService.cs</Link>
-    </Compile>
-    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\ICanResolve.cs">
-      <Link>ServiceHost\ICanResolve.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IContentTypeFilter.cs">
       <Link>ServiceHost\IContentTypeFilter.cs</Link>
@@ -620,7 +620,7 @@
       <FlavorProperties GUID="{A1591282-1198-4647-A2B1-27E5FF5F6F3B}">
         <SilverlightProjectProperties />
       </FlavorProperties>
-      <UserProperties ProjectLinkReference="42e1c8c0-a163-44cc-92b1-8f416f2c0b01" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
+      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="42e1c8c0-a163-44cc-92b1-8f416f2c0b01" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
### 'src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs'

> WebExceptionStatus.Timeout is not supported in Silverlight
> webRequest.AutomaticDecompression is not supported in Silverlight
> Added missing 'using ServiceStack.Common.Web;' for 'HttpHeaders.XHttpMethodOverride'
> 
> AsyncServiceClient for SL5 uses an uninitialized class variable '_webRequest' 
> in [RequestState<TResponse> SendWebRequest<TResponse>]
> 
> SILVERLIGHT and non-SILVERLIGHT conditionals each initialize a different web request variable.
> The common section for the 'requestState' and 'SendWebRequestAsync()' function uses only the 
> '_webRequest' class variable, which is not initialized for SILVERLIGHT.
> 
> I just added some more SILVERLIGHT conditionals to make it compile and not crash here, but I 
> think it needs a good clean-up. In a non-SILVERLIGHT project, the code should check and throw 
> exceptions when there is an outstanding request.
> 
> The unprotected shared class variable '_webRequest' is being reset in each call to this function and 
> its properties (CookieContainer, Headers, AutomaticDecompression) can be overwritten and 
> possibly the wrong instance could be referenced in callbacks via the 'requestState.WebRequest' 
> property, e.g. CancelAsync().
> 
> Hands up anyone for a new rewrite...maybe a new Async base class with virtual functions for 
> Silverlight to overload? I'll look at making a few new classes for experimenting and testing.
### 'src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs'

> 'using System.Web' is not supported in Silverlight
### 'src/ServiceStack.Common/TypeExtensions.cs'

> Remove extension 'GetAssemblyPath()' function, which uses 'Assembly.EscapedCodeBase' 
> for SILVERLIGHT; not useful (?) and the alternative 'Assembly.CodeBase' is security-critical,
> which raises exceptions
### 'src/ServiceStack.Common/ServiceModel/Serialization/DataContractDeserializer.cs'

> To be safe in SILVERLIGHT:
> 'using (var reader = XmlDictionaryReader.CreateTextReader(bytes, XmlDictionaryReaderQuotas.Max))'
> http://msdn.microsoft.com/en-us/library/system.xml.xmldictionaryreaderquotas(v=vs.95).aspx
> 'Quotas can only be set to maximum values in Silverlight 5'
### 'ServiceStack.Interfaces.SL5' project

> Error: 'ServiceStack\ServiceStack\src\ServiceStack.Interfaces\ServiceHost\ICanResolve.cs' 
> could not be opened ('Unspecified error ')
> Remove non-existent file from project
### 'ServiceStack.Interfaces.SL5' project

> Error: The type or namespace name 'ItemRef' could not be found in 
> 'ServiceStack\ServiceStack\src\ServiceStack.Interfaces\Redis\IRedisClient.cs'
> Include a _link_ to the missing file 'ServiceStack.Interfaces\Redis\ItemRef.cs'
