### PR TITLE
Fixed issue #216

### DIFF
--- a/tests/ServiceStack.WebHost.Endpoints.Tests/FileUploadTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/FileUploadTests.cs
@@ -35,7 +35,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		}
 
 		[Test]
-		[Ignore("Helps debugging when you need to find out WTF is going on")]
+		[Explicit("Helps debugging when you need to find out WTF is going on")]
 		public void Run_for_30secs()
 		{
 			Thread.Sleep(30000);


### PR DESCRIPTION
- PostFile & PostFileWithRequest works as Send request
- refactored ServiceClientBase, removed duplicated code with handle response
- SendRequest is reused and shared between PostFile & Send related methods
- created new tests for PostFile/PostFileWithRequest
