### PR TITLE
Issue #222 - Moving HtmlTemplate to be public instead of private

### DIFF
--- a/src/ServiceStack/WebHost.EndPoints/Extensions/HttpRequestWrapper.cs
+++ b/src/ServiceStack/WebHost.EndPoints/Extensions/HttpRequestWrapper.cs
@@ -176,8 +176,7 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
         {
             get
             {
-                //return userHostAddress ?? (userHostAddress = request.Headers[HttpHeaders.XForwardedFor] ?? (request.Headers[HttpHeaders.XRealIp] ?? request.UserHostAddress));
-                return userHostAddress ??request.UserHostAddress; // last line commented due to Console-To-Go bug in x-forwarded-for
+                return userHostAddress ?? (userHostAddress = request.Headers[HttpHeaders.XForwardedFor] ?? (request.Headers[HttpHeaders.XRealIp] ?? request.UserHostAddress));
             }
         }
 


### PR DESCRIPTION
I have reverted the x-forwarded-for.
The only changed file is now - HtmlFormat.cs

Arxisos - I Hope that is the best / correct way to revert stuff...
