### PR TITLE
Fix illegal JSON response

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Extensions/IHttpResponseExtensions.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/IHttpResponseExtensions.cs
@@ -334,8 +334,9 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 			sb.AppendLine("{");
 			sb.AppendLine("\"ResponseStatus\":{");
 			sb.AppendFormat(" \"ErrorCode\":{0},\n", ex.ToErrorCode().EncodeJson());
-			sb.AppendFormat(" \"Message\":{0},\n", ex.Message.EncodeJson());
-            if (EndpointHost.Config.DebugMode) sb.AppendFormat(" \"StackTrace\":{0}\n", ex.StackTrace.EncodeJson());
+			sb.AppendFormat(" \"Message\":{0}", ex.Message.EncodeJson());
+			if (EndpointHost.Config.DebugMode) sb.AppendFormat(",\n \"StackTrace\":{0}\n", ex.StackTrace.EncodeJson());
+			else sb.Append("\n");
 			sb.AppendLine("}");
 			sb.AppendLine("}");
 


### PR DESCRIPTION
When exception is thrown and DebugMode = false, ResponseStatus contains a trailing comma.

e.g.,
http://myhost/something-that-throw-sexception?format=json

Previous response:

{
"ResponseStatus":{
 "ErrorCode":"some code",
 "Message":"some message",
}
}

Fixed response:

{
"ResponseStatus":{
 "ErrorCode":"some code",
 "Message":"some message"
}
}
