### PR TITLE
Add unit tests for X-Forwarded-For addresses

### DIFF
--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/EndpointHandlerBaseTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/EndpointHandlerBaseTests.cs
@@ -67,6 +67,10 @@ namespace ServiceStack.WebHost.Endpoints.Support.Tests
 				//ipv4 loopback
 				yield return new TestCaseData("127.0.0.1", EndpointAttributes.Localhost);
 				yield return new TestCaseData("127.0.0.1:20", EndpointAttributes.Localhost);
+
+                //ipv4 in X-FORWARDED-FOR HTTP Header format
+                yield return new TestCaseData("192.168.100.2, 192.168.0.1", EndpointAttributes.External);
+                yield return new TestCaseData("192.168.100.2, 192.168.0.1, 10.1.1.1", EndpointAttributes.External);
 			}
 		}
 	}


### PR DESCRIPTION
Added Unit Tests for comma separated style addresses when input is from
the X-FORWAREDED-FOR HTTP header. Current implementation throws an
FormatException on the IP address when going through a load balancer or
proxy.

This issue was discussed in:

https://groups.google.com/forum/?fromgroups=#!topic/servicestack/_S8ozQ4vPTU

The fix is discussed in https://github.com/ServiceStack/ServiceStack/issues/226
