### PR TITLE
Binary serialization breaks cache

### DIFF
--- a/src/ServiceStack.Interfaces/ServiceHost/IContentTypeFilter.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/IContentTypeFilter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using ServiceStack.DesignPatterns.Serialization;
 
 namespace ServiceStack.ServiceHost
 {
@@ -12,6 +13,8 @@ namespace ServiceStack.ServiceHost
 
 		void Register(string contentType,
 			ResponseSerializerDelegate responseSerializer, StreamDeserializerDelegate streamDeserializer);
+
+	    void Register(string contentType, ITextSerializer stringSerializer);
 
 		void ClearCustomFilters();
 	}

--- a/src/ServiceStack.Plugins.ProtoBuf/ProtoBufFormat.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/ProtoBufFormat.cs
@@ -11,6 +11,8 @@ namespace ServiceStack.Plugins.ProtoBuf
 			appHost.ContentTypeFilters.Register(ContentType.ProtoBuf,
 				(reqCtx, res, stream) => Serializer.NonGeneric.Serialize(stream, res),
 				Serializer.NonGeneric.Deserialize);
+
+            appHost.ContentTypeFilters.Register(ContentType.ProtoBuf, new StringSerializerProtoBufImpl());
 		}
 	}
 }

--- a/src/ServiceStack.Plugins.ProtoBuf/ServiceStack.Plugins.ProtoBuf.csproj
+++ b/src/ServiceStack.Plugins.ProtoBuf/ServiceStack.Plugins.ProtoBuf.csproj
@@ -42,6 +42,7 @@
     <Compile Include="ProtoBufFormat.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtoBufServiceClient.cs" />
+    <Compile Include="StringSerializerProtoBufImpl.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.csproj">

--- a/src/ServiceStack.Plugins.ProtoBuf/StringSerializerProtoBufImpl.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/StringSerializerProtoBufImpl.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using ProtoBuf;
+using ServiceStack.DesignPatterns.Serialization;
+
+namespace ServiceStack.Plugins.ProtoBuf
+{
+    public class StringSerializerProtoBufImpl : ITextSerializer
+    {
+        public object DeserializeFromString(string stringBase64, Type returnType)
+        {
+            byte[] byteAfter64 = Convert.FromBase64String(stringBase64);
+            var afterStream = new MemoryStream(byteAfter64);
+            return Serializer.NonGeneric.Deserialize(returnType, afterStream);
+        }
+
+        public T DeserializeFromString<T>(string stringBase64)
+        {
+            byte[] byteAfter64 = Convert.FromBase64String(stringBase64);
+            var afterStream = new MemoryStream(byteAfter64);
+            return Serializer.Deserialize<T>(afterStream);
+        }
+
+        public T DeserializeFromStream<T>(Stream stream)
+        {
+            return Serializer.Deserialize<T>(stream);
+        }
+
+        public object DeserializeFromStream(Type type, Stream stream)
+        {
+            return Serializer.NonGeneric.Deserialize(type, stream);
+        }
+
+        public string SerializeToString<T>(T obj)
+        {
+            var ms = new MemoryStream();
+            Serializer.Serialize(ms, obj);
+            string stringBase64 = Convert.ToBase64String(ms.ToArray());
+            return stringBase64;
+        }
+
+        public void SerializeToStream<T>(T obj, Stream stream)
+        {
+            Serializer.Serialize<T>(stream, obj);
+        }
+    }
+}

--- a/src/ServiceStack/CacheAccess.Providers/CacheClientExtensions.cs
+++ b/src/ServiceStack/CacheAccess.Providers/CacheClientExtensions.cs
@@ -20,8 +20,9 @@ namespace ServiceStack.CacheAccess.Providers
 		}
 
 		public static object ResolveFromCache(this ICacheClient cacheClient, 
-			string cacheKey, 
-			IRequestContext context)
+			string cacheKey,
+            IRequestContext context,
+            Type deserializedType=null)
 		{
 			string modifiers = null;
 			if (context.ResponseContentType == ContentType.Json)
@@ -52,7 +53,13 @@ namespace ServiceStack.CacheAccess.Providers
 				var serializedResult = cacheClient.Get<string>(cacheKeySerialized);
 				if (serializedResult != null)
 				{
-					return serializedResult;
+                    if (context.ResponseContentType == ContentType.ProtoBuf)
+                    {
+                        // deserialized result
+                        return EndpointHost.ContentTypeFilter.DeserializeFromString(ContentType.ProtoBuf, deserializedType,
+                                                                                 serializedResult);
+                    }
+				    return serializedResult;
 				}
 			}
 
@@ -101,7 +108,7 @@ namespace ServiceStack.CacheAccess.Providers
 					: null;
 			}
 
-			return serializedDto;
+            return responseDto;
 		}
 
 		public static void ClearCaches(this ICacheClient cacheClient, params string[] cacheKeys)

--- a/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
+++ b/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
@@ -49,8 +49,8 @@ namespace ServiceStack.ServiceHost
 			TimeSpan? expireCacheIn, Func<T> factoryFn)
 			where T : class
 		{
-			var cacheResult = cacheClient.ResolveFromCache(cacheKey, requestContext);
-			if (cacheResult != null)
+			var cacheResult = cacheClient.ResolveFromCache(cacheKey, requestContext, typeof(T));
+            if (cacheResult != null)
 				return cacheResult;
 
 			cacheResult = cacheClient.Cache(cacheKey, factoryFn(), requestContext, expireCacheIn);

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -101,9 +101,6 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="ServiceStack.Text">
-      <HintPath>..\..\lib\ServiceStack.Text.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CacheAccess.Providers\BasicPersistenceProviderCacheBase.cs" />
@@ -355,16 +352,11 @@
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\ServiceStack\ServiceStack.Text\src\ServiceStack.Text\ServiceStack.Text.csproj">
+      <Project>{579B3FDB-CDAD-44E1-8417-885C38E49A0E}</Project>
+      <Name>ServiceStack.Text</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.csproj">
       <Project>{982416DB-C143-4028-A0C3-CF41892D18D3}</Project>
       <Name>ServiceStack.Common</Name>
@@ -374,4 +366,12 @@
       <Name>ServiceStack.Interfaces</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>


### PR DESCRIPTION
Proposal to overcome this problem: http://stackoverflow.com/questions/12140571/encoding-serialization-issues-when-using-icacheclient-and-protobuf-in-servicesta

When using a binary serializer, caching does not work since the response is treated as text.

Related Unit Test be here: https://gist.github.com/3533182
