### PR TITLE
Update src/ServiceStack.ServiceInterface/Auth/OrmLiteAuthRepository.cs

### DIFF
--- a/src/ServiceStack.ServiceInterface/Auth/OrmLiteAuthRepository.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/OrmLiteAuthRepository.cs
@@ -191,7 +191,10 @@ namespace ServiceStack.ServiceInterface.Auth
         {
             if (userAuth == null) return;
 
-            session.PopulateWith(userAuth);
+            var idSesije = session.Id;  //first record session Id (original session Id)
+            session.PopulateWith(userAuth); //here, original sessionId is overwritten with facebook user Id
+            session.Id = idSesije;  //we return Id of original session here
+
             session.UserAuthId = userAuth.Id.ToString(CultureInfo.InvariantCulture);
             session.ProviderOAuthAccess = GetUserOAuthProviders(session.UserAuthId)
                 .ConvertAll(x => (IOAuthTokens)x);


### PR DESCRIPTION
When facebook OAuth finishes it's login process, it's object is sent to this method that automatically overwrittes user session Id with Id of User from facebook Auth. So instead of session Id (eg. ss-pid=zR/6qh4zME6XfwpbronWRw==;) we have facebook user Id from database (eg. 39)
