### PR TITLE
Fix InMemoryRollingRequestLogger: Error response was not logged.

### DIFF
--- a/src/ServiceStack.ServiceInterface/Providers/InMemoryRollingRequestLogger.cs
+++ b/src/ServiceStack.ServiceInterface/Providers/InMemoryRollingRequestLogger.cs
@@ -73,7 +73,7 @@ namespace ServiceStack.ServiceInterface.Providers
                 entry.RequestDto = requestDto;
                 if (httpReq != null) entry.FormData = httpReq.FormData.ToDictionary();
             }
-            if (response.IsErrorResponse()) {
+            if (!response.IsErrorResponse()) {
                 if (EnableResponseTracking)
                     entry.ResponseDto = response;
             }


### PR DESCRIPTION
Hi!

I've tried RequestLogsFeature (using in memory logger). It looks amazing!

But it seems that error responses are not logged (regular responses are shown instead). This should fix it.

Thank you!
