### PR TITLE
populate response body 

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -409,6 +409,7 @@ namespace ServiceStack.ServiceClient.Web
                     {
                         using (var stream = errorResponse.GetResponseStream())
                         {
+                            serviceEx.ResponseBody = stream.ToUtf8String();
                             serviceEx.ResponseDto = DeserializeFromStream<TResponse>(stream);
                         }
                     }
@@ -424,6 +425,7 @@ namespace ServiceStack.ServiceClient.Web
                     {
                         StatusCode = (int)errorResponse.StatusCode,
                         StatusDescription = errorResponse.StatusDescription,
+                        ResponseBody = serviceEx.ResponseBody
                     };
                 }
 


### PR DESCRIPTION
in clientbase handleexception  to allow for more flexible error handling. This is a change we have been using at Daptiv and would like to get it into the base repo so that we can more easily update our fork
