### PR TITLE
Make RestHandler.RestPath property public.

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/RestHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/RestHandler.cs
@@ -37,7 +37,7 @@ namespace ServiceStack.WebHost.Endpoints
 			return this.RestPath;
 		}
 
-		internal IRestPath RestPath { get; set; }
+		public IRestPath RestPath { get; set; }
 
 		public override void ProcessRequest(IHttpRequest httpReq, IHttpResponse httpRes, string operationName)
 		{


### PR DESCRIPTION
This will allow me to use the OWIN host without any other changes / requirements. 

We briefly discussed this here: https://github.com/damianh/ServiceStack/commit/bfaa70d0a9a5383a68f16158cb1c249dbc81d093#L0R37

Cheers
