### PR TITLE
Workaround a Mono 2.6.7 compiler specific bug

### DIFF
--- a/src/ServiceStack.Common/Messaging/MessageHandler.cs
+++ b/src/ServiceStack.Common/Messaging/MessageHandler.cs
@@ -155,7 +155,8 @@ namespace ServiceStack.Messaging
                     if (mqReplyTo == null)
                     {
                         var responseType = response.GetType();
-                        if (!responseType.IsUserType()) return;
+                        // Leave as-is to work around a Mono 2.6.7 compiler bug
+                        if (!StringExtensions.IsUserType(responseType)) return;
                         mqReplyTo = new QueueNames(responseType).In;
                     }
                     
@@ -173,8 +174,9 @@ namespace ServiceStack.Messaging
                                 .Fmt(mqReplyTo, replyClient.GetType().Name), ex);
 
                             var responseType = response.GetType();
-                            if (!responseType.IsUserType()) return;
-                            
+                            // Leave as-is to work around a Mono 2.6.7 compiler bug
+                            if (!StringExtensions.IsUserType(responseType)) return;
+
                             mqReplyTo = new QueueNames(responseType).In;
                         }
                     }


### PR DESCRIPTION
The Mono 2.6.7 compiler is unable to resolve the StringExtensions.IsUserType()
extension method properly and instead picks the internal System.Type.IsUserType
and then errors out.
