### PR TITLE
Redirect: Path with query string

### DIFF
--- a/src/ServiceStack.FluentValidation.Mvc3/Mvc/ExecuteServiceStackFiltersAttribute.cs
+++ b/src/ServiceStack.FluentValidation.Mvc3/Mvc/ExecuteServiceStackFiltersAttribute.cs
@@ -20,9 +20,8 @@ namespace ServiceStack.Mvc
 			var authAttrs = GetActionAndControllerAttributes<AuthenticateAttribute>(filterContext);
 			if (authAttrs.Count > 0 && ( ssController.AuthSession==null || !ssController.AuthSession.IsAuthenticated))
 			{
-				var returnUrl = filterContext.HttpContext.Request.Url.AbsolutePath;
-			    returnUrl += filterContext.HttpContext.Request.QueryString;
-				filterContext.Result = new RedirectResult(ssController.LoginRedirectUrl.Fmt(returnUrl));
+			    var returnUrl = filterContext.HttpContext.Request.Url.PathAndQuery;
+				filterContext.Result = new RedirectResult(ssController.LoginRedirectUrl.Fmt(HttpUtility.UrlEncode(returnUrl)));
 				return;
 			}
 


### PR DESCRIPTION
If accessing a controller that needs authentication and ssController.AuthSession.IsAuthenticated evaluated false the redirect url was set incorrect. 

@mythz, @desunit Although I thought I fixed the problem, my local git environment somehow makes funny things (win7 64bit, git version 1.7.11, editor: VS2010). As you can see 100% of the lines in the affected file appear as changed (only line 24 and 25 were changed). I tried to play with core.autocrlf (at the moment it is set to "false" for --system and --global) and tried re-normalizing the repo but this did not really work out (after re-normalizing two files appeared as changed but i did not include them in the commit). I tried to remove the .gitattributes file (locally) and without this file everything works fine (no 100% diffs, no modified files on pull, ...). Am I missing something here?
