### PR TITLE
Add RemoveByPattern and RemoveByRegex to ICacheClient

### DIFF
--- a/src/ServiceStack.Interfaces/CacheAccess/ICacheClient.cs
+++ b/src/ServiceStack.Interfaces/CacheAccess/ICacheClient.cs
@@ -25,6 +25,18 @@ namespace ServiceStack.CacheAccess
 		void RemoveAll(IEnumerable<string> keys);
 
 		/// <summary>
+		/// Removes items from cache that have keys matching the specified wildcard pattern
+		/// </summary>
+		/// <param name="pattern">The wildcard, where "*" means any sequence of characters and "?" means any single character.</param>
+		void RemoveByPattern(string pattern);
+
+		/// <summary>
+		/// Removes items from the cache based on the specified regular expression pattern
+		/// </summary>
+		/// <param name="regex">Regular expression pattern to search cache keys</param>
+		void RemoveByRegex(string regex);
+
+		/// <summary>
 		/// Retrieves the specified item from the cache.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>

--- a/src/ServiceStack/CacheAccess.Providers/FileSystemXmlCacheClient.cs
+++ b/src/ServiceStack/CacheAccess.Providers/FileSystemXmlCacheClient.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using ServiceStack.Logging;
 using ServiceStack.ServiceModel.Serialization;
 
@@ -59,6 +61,28 @@ namespace ServiceStack.CacheAccess.Providers
 				catch (Exception ex)
 				{
 					Log.Error(string.Format("Error trying to remove {0} from the FileSystem Cache", key), ex);
+				}
+			}
+		}
+
+		public void RemoveByPattern(string pattern)
+		{
+			RemoveByRegex(pattern.Replace("*", ".*").Replace("?", ".+"));
+		}
+
+		public void RemoveByRegex(string pattern)
+		{
+			var regex = new Regex(pattern);
+			foreach (var filename in Directory.GetFiles(baseFilePath, "*.*", SearchOption.AllDirectories)
+				.Where(path => regex.IsMatch(path)))
+			{
+				try
+				{
+					File.Delete(filename);
+				}
+				catch (Exception ex)
+				{
+					Log.Error(string.Format("Error trying to remove {0} from the FileSystem Cache", filename), ex);
 				}
 			}
 		}

--- a/src/ServiceStack/CacheAccess.Providers/MemoryCacheClient.cs
+++ b/src/ServiceStack/CacheAccess.Providers/MemoryCacheClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using ServiceStack.Logging;
 using ServiceStack.Net30.Collections.Concurrent;
 
@@ -153,6 +154,31 @@ namespace ServiceStack.CacheAccess.Providers
 				{
 					Log.Error(string.Format("Error trying to remove {0} from the cache", key), ex);
 				}
+			}
+		}
+
+		public void RemoveByPattern(string pattern)
+		{
+			RemoveByRegex(pattern.Replace("*", ".*").Replace("?", ".+"));
+		}
+
+		public void RemoveByRegex(string pattern)
+		{
+			var regex = new Regex(pattern);
+			var enumerator = this.memory.GetEnumerator();
+			try
+			{
+				while (enumerator.MoveNext())
+				{
+					var current = enumerator.Current;
+					if (regex.IsMatch(current.Key))
+					{
+						this.Remove(current.Key);
+					}
+				}
+			}
+			catch
+			{
 			}
 		}
 

--- a/src/ServiceStack/CacheAccess.Providers/MultiCacheClient.cs
+++ b/src/ServiceStack/CacheAccess.Providers/MultiCacheClient.cs
@@ -30,6 +30,16 @@ namespace ServiceStack.CacheAccess.Providers
 			return firstResult;
 		}
 
+		public void RemoveByPattern(string pattern)
+		{
+			cacheClients.ExecAll(client => client.RemoveByPattern(pattern));
+		}
+
+		public void RemoveByRegex(string regex)
+		{
+			cacheClients.ExecAll(client => client.RemoveByRegex(regex));
+		}
+
 		public T Get<T>(string key)
 		{
 			return cacheClients.ExecReturnFirstWithResult(client => client.Get<T>(key));


### PR DESCRIPTION
Sorry about the problem with line endings.  Although the diffs make this look like a massive change, it's really not.  It just adds two methods to ICacheClient, to remove cache entries by pattern (supporting \* and ? tokens) and by regex.

This allows a user to easily remove all cache entries that match a pattern.  Eg. _cacheClient.RemoveByPattern("users/*");
