### PR TITLE
Fix issue where connections does not get disposed properly when using ProfiledDbConnection

### DIFF
--- a/src/ServiceStack/MiniProfiler/Data/ProfiledDbConnection.cs
+++ b/src/ServiceStack/MiniProfiler/Data/ProfiledDbConnection.cs
@@ -44,15 +44,17 @@ namespace ServiceStack.MiniProfiler.Data
         /// </summary>
         /// <param name="connection">Your provider-specific flavor of connection, e.g. SqlConnection, OracleConnection</param>
         /// <param name="profiler">The currently started <see cref="MiniProfiler.Profiler"/> or null.</param>
-        public ProfiledDbConnection(DbConnection connection, IDbProfiler profiler)
+        /// <param name="autoDisposeConnection">Determines whether the ProfiledDbConnection will dispose the underlying connection.</param>
+        public ProfiledDbConnection(DbConnection connection, IDbProfiler profiler, bool autoDisposeConnection = true)
         {
-        	Init(connection, profiler);
+        	Init(connection, profiler, autoDisposeConnection);
         }
 
-    	private void Init(DbConnection connection, IDbProfiler profiler)
+        private void Init(DbConnection connection, IDbProfiler profiler, bool autoDisposeConnection)
     	{
     		if (connection == null) throw new ArgumentNullException("connection");
 
+    	    this.autoDisposeConnection = autoDisposeConnection;
     		_conn = connection;
     		_conn.StateChange += StateChangeHandler;
 
@@ -64,7 +66,6 @@ namespace ServiceStack.MiniProfiler.Data
 
         public ProfiledDbConnection(IDbConnection connection, IDbProfiler profiler, bool autoDisposeConnection=true)
         {
-            this.autoDisposeConnection = autoDisposeConnection;
     		var hasConn = connection as IHasDbConnection;
 			if (hasConn != null) connection = hasConn.DbConnection;
     		var dbConn = connection as DbConnection;
@@ -72,7 +73,7 @@ namespace ServiceStack.MiniProfiler.Data
 			if (dbConn == null)
 				throw new ArgumentException(connection.GetType().Name + " does not inherit DbConnection");
 			
-			Init(dbConn, profiler);
+			Init(dbConn, profiler, autoDisposeConnection);
         }
 
 
@@ -192,7 +193,7 @@ namespace ServiceStack.MiniProfiler.Data
         {
             ICloneable tail = _conn as ICloneable;
             if (tail == null) throw new NotSupportedException("Underlying " + _conn.GetType().Name + " is not cloneable");
-            return new ProfiledDbConnection((DbConnection)tail.Clone(), _profiler);
+            return new ProfiledDbConnection((DbConnection)tail.Clone(), _profiler, autoDisposeConnection);
         }
         object ICloneable.Clone() { return Clone(); }
 


### PR DESCRIPTION
This pull request fixes an issue with the built-in MiniProfiler in ServiceStack. I checked with the original MiniProfiler code, which does not have the issue:

There are two overloads on the constructor of ProfiledDbConnection. One of those takes the autoDisposeConnection parameter and sets it default to true, which is good. The other overload **does not set autoDisposeConnection** and it is therefore false.

I had a bug in my app because my conn factory called the ProfiledDbConnection ctor that does not set autoDisposeConnection, and as a consequence, I did not get my DB connections properly disposed.

I think both constructors should set autoDisposeConnections to true by default (while allowing the user to specify it), since having it set to false can cause major trouble in a production app. This pull request fixes just that.

Since this is something that was introduced recently, (https://github.com/ServiceStack/ServiceStack/commit/751ec3e5c127ba27f0e6f2ecd91578b860fc415f), it could break applications that choose to upgrade their ServiceStack version. 

Another option for fixing this could be to simply remove one of the constructors or make it protected, but  that could break apps that already use that public constructor, so I opted not to do this.

I will be happy to improve on this pull request if you find anything missing from it.
