### PR TITLE
Made EndPointHost use private instance

### DIFF
--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -238,6 +238,7 @@
     <Compile Include="ServiceHost\ServiceRoutes.cs" />
     <Compile Include="WebHost.Endpoints\AppHostBase.cs" />
     <Compile Include="WebHost.Endpoints\AppHostHttpListenerLongRunningBase.cs" />
+    <Compile Include="WebHost.Endpoints\EndpointHostInstance.cs" />
     <Compile Include="WebHost.Endpoints\Extensions\HttpResponseStreamExtensions.cs" />
     <Compile Include="WebHost.Endpoints\Formats\CsvFormat.cs" />
     <Compile Include="WebHost.Endpoints\Extensions\HttpListenerRequestWrapper.cs" />

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
@@ -19,168 +19,52 @@ namespace ServiceStack.WebHost.Endpoints
 {
 	public class EndpointHost
 	{
-		public static ServiceOperations ServiceOperations { get; private set; }
-		public static ServiceOperations AllServiceOperations { get; private set; }
+		private static readonly EndpointHostInstance _instance = new EndpointHostInstance();
 
-		public static IAppHost AppHost { get; internal set; }
+		public static ServiceOperations ServiceOperations { get { return _instance.ServiceOperations; }  }
+		public static ServiceOperations AllServiceOperations { get { return _instance.AllServiceOperations; } }
 
-		public static IContentTypeFilter ContentTypeFilter { get; set; }
+		public static IAppHost AppHost { get { return _instance.AppHost; } internal set { _instance.AppHost = value; } }
 
-        public static List<Action<IHttpRequest, IHttpResponse>> RawRequestFilters { get; private set; }
+		public static IContentTypeFilter ContentTypeFilter { get { return _instance.ContentTypeFilter; } set { _instance.ContentTypeFilter = value; } }
 
-		public static List<Action<IHttpRequest, IHttpResponse, object>> RequestFilters { get; private set; }
+		public static List<Action<IHttpRequest, IHttpResponse>> RawRequestFilters { get { return _instance.RawRequestFilters; } }
 
-		public static List<Action<IHttpRequest, IHttpResponse, object>> ResponseFilters { get; private set; }
+		public static List<Action<IHttpRequest, IHttpResponse, object>> RequestFilters { get { return _instance.RequestFilters; } }
 
-        public static List<IViewEngine> ViewEngines { get; set; }
+		public static List<Action<IHttpRequest, IHttpResponse, object>> ResponseFilters { get { return _instance.ResponseFilters; } }
 
-        public static HandleUncaughtExceptionDelegate ExceptionHandler { get; set; }
-        
-        public static HandleServiceExceptionDelegate ServiceExceptionHandler { get; set; }
+		public static List<IViewEngine> ViewEngines { get { return _instance.ViewEngines; } set { _instance.ViewEngines = value; } }
 
-		public static List<HttpHandlerResolverDelegate> CatchAllHandlers { get; set; }
+		public static HandleUncaughtExceptionDelegate ExceptionHandler { get { return _instance.ExceptionHandler; } set { _instance.ExceptionHandler = value; } }
 
-		private static bool pluginsLoaded = false;
+		public static HandleServiceExceptionDelegate ServiceExceptionHandler { get { return _instance.ServiceExceptionHandler; } set { _instance.ServiceExceptionHandler = value; } }
 
-		public static List<IPlugin> Plugins { get; set; }
+		public static List<HttpHandlerResolverDelegate> CatchAllHandlers { get { return _instance.CatchAllHandlers; } set { _instance.CatchAllHandlers = value; } }
 
-		public static IVirtualPathProvider VirtualPathProvider { get; set; }
+		public static List<IPlugin> Plugins { get { return _instance.Plugins; } set { _instance.Plugins = value; } }
 
-        public static DateTime StartedAt { get; set; }
+		public static IVirtualPathProvider VirtualPathProvider { get { return _instance.VirtualPathProvider; } set { _instance.VirtualPathProvider = value; } }
 
-        public static DateTime ReadyAt { get; set; }
+		public static DateTime StartedAt { get { return _instance.StartedAt; } set { _instance.StartedAt = value; } }
 
-		static EndpointHost()
-		{
-			ContentTypeFilter = HttpResponseFilter.Instance;
-            RawRequestFilters = new List<Action<IHttpRequest, IHttpResponse>>();
-			RequestFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
-			ResponseFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
-			ViewEngines = new List<IViewEngine>();
-			CatchAllHandlers = new List<HttpHandlerResolverDelegate>();
-			Plugins = new List<IPlugin> {
-				new HtmlFormat(),
-				new CsvFormat(),
-				new MarkdownFormat(),
-                new PredefinedRoutesFeature(),
-                new MetadataFeature(),
-			};
-		}
+		public static DateTime ReadyAt { get { return _instance.ReadyAt; } set { _instance.ReadyAt = value; } }
 		
 		// Pre user config
 		public static void ConfigureHost(IAppHost appHost, string serviceName, ServiceManager serviceManager)
 		{
-			AppHost = appHost;
-
-			EndpointHostConfig.Instance.ServiceName = serviceName;
-			EndpointHostConfig.Instance.ServiceManager = serviceManager;
-
-			var config = EndpointHostConfig.Instance;
-			Config = config; // avoid cross-dependency on Config setter
-			VirtualPathProvider = new FileSystemVirtualPathProvider(AppHost, Config.WebHostPhysicalPath);
-
-		    Config.DebugMode = appHost.GetType().Assembly.IsDebugBuild();             
-            if (Config.DebugMode)
-            {
-                Plugins.Add(new RequestInfoFeature());
-            }
-		}
-
-		// Config has changed
-		private static void ApplyConfigChanges()
-		{
-			config.ServiceEndpointsMetadataConfig = ServiceEndpointsMetadataConfig.Create(config.ServiceStackHandlerFactoryPath);
-
-			JsonDataContractSerializer.Instance.UseBcl = config.UseBclJsonSerializers;
-			JsonDataContractDeserializer.Instance.UseBcl = config.UseBclJsonSerializers;
+			_instance.ConfigureHost(appHost, serviceName, serviceManager);
 		}
 
 		//After configure called
 		public static void AfterInit()
 		{
-            StartedAt = DateTime.Now;
-
-			if (config.EnableFeatures != Feature.All)
-			{
-				if ((Feature.Xml & config.EnableFeatures) != Feature.Xml)
-					config.IgnoreFormatsInMetadata.Add("xml");
-				if ((Feature.Json & config.EnableFeatures) != Feature.Json)
-					config.IgnoreFormatsInMetadata.Add("json");
-				if ((Feature.Jsv & config.EnableFeatures) != Feature.Jsv)
-					config.IgnoreFormatsInMetadata.Add("jsv");
-				if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
-					config.IgnoreFormatsInMetadata.Add("csv");
-				if ((Feature.Html & config.EnableFeatures) != Feature.Html)
-					config.IgnoreFormatsInMetadata.Add("html");
-				if ((Feature.Soap11 & config.EnableFeatures) != Feature.Soap11)
-					config.IgnoreFormatsInMetadata.Add("soap11");
-				if ((Feature.Soap12 & config.EnableFeatures) != Feature.Soap12)
-					config.IgnoreFormatsInMetadata.Add("soap12");
-			}
-
-			if ((Feature.Html & config.EnableFeatures) != Feature.Html)
-				Plugins.RemoveAll(x => x is HtmlFormat);
-
-			if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
-				Plugins.RemoveAll(x => x is CsvFormat);
-
-            if ((Feature.Markdown & config.EnableFeatures) != Feature.Markdown)
-                Plugins.RemoveAll(x => x is MarkdownFormat);
-
-            if ((Feature.PredefinedRoutes & config.EnableFeatures) != Feature.PredefinedRoutes)
-                Plugins.RemoveAll(x => x is PredefinedRoutesFeature);
-
-            if ((Feature.Metadata & config.EnableFeatures) != Feature.Metadata)
-                Plugins.RemoveAll(x => x is MetadataFeature);
-
-            if ((Feature.RequestInfo & config.EnableFeatures) != Feature.RequestInfo)
-                Plugins.RemoveAll(x => x is RequestInfoFeature);
-
-			if ((Feature.Razor & config.EnableFeatures) != Feature.Razor)
-				Plugins.RemoveAll(x => x is IRazorPlugin);    //external
-
-            if ((Feature.ProtoBuf & config.EnableFeatures) != Feature.ProtoBuf)
-                Plugins.RemoveAll(x => x is IProtoBufPlugin); //external
-
-            if ((Feature.MsgPack & config.EnableFeatures) != Feature.MsgPack)
-                Plugins.RemoveAll(x => x is IMsgPackPlugin);  //external
-
-            if (ExceptionHandler == null) {
-                ExceptionHandler = (httpReq, httpRes, operationName, ex) => {
-                    var errorMessage = string.Format("Error occured while Processing Request: {0}", ex.Message);
-                    var statusCode = ex.ToStatusCode();
-                    //httpRes.WriteToResponse always calls .Close in it's finally statement so 
-                    //if there is a problem writing to response, by now it will be closed
-                    if (!httpRes.IsClosed) {
-                        httpRes.WriteErrorToResponse(httpReq.ResponseContentType, operationName, errorMessage, ex, statusCode);
-                    }
-                };
-            }
-
-			var specifiedContentType = config.DefaultContentType; //Before plugins loaded
-
-            ConfigurePlugins();
-
-			AppHost.LoadPlugin(Plugins.ToArray());
-			pluginsLoaded = true;
-
-			AfterPluginsLoaded(specifiedContentType);
-
-		    var registeredCacheClient = AppHost.TryResolve<ICacheClient>();
-            using (registeredCacheClient)
-            {
-                if (registeredCacheClient == null)
-                {
-                    Container.Register<ICacheClient>(new MemoryCacheClient());
-                }
-            }
-
-		    ReadyAt = DateTime.Now;
+			_instance.AfterInit();
 		}
 
         public static T TryResolve<T>()
         {
-            return AppHost != null ? AppHost.TryResolve<T>() : default(T);
+			return _instance.TryResolve<T>();
         }
 
         /// <summary>
@@ -188,64 +72,22 @@ namespace ServiceStack.WebHost.Endpoints
         /// </summary>
 	    public static Container Container
 	    {
-	        get { 
-                var aspHost = AppHost as AppHostBase;
-                if (aspHost != null)
-                    return aspHost.Container;
-	            var listenerHost = AppHost as HttpListenerBase;
-                return listenerHost != null ? listenerHost.Container : new Container(); //testing may use alt AppHost
+	        get {
+				return _instance.Container;
 	        }
 	    }
-
-	    private static void ConfigurePlugins()
-	    {
-            //Some plugins need to initialize before other plugins are registered.
-
-	        foreach (var plugin in Plugins)
-	        {
-	            var preInitPlugin = plugin as IPreInitPlugin;
-	            if (preInitPlugin != null)
-	            {
-                    preInitPlugin.Configure(AppHost);
-                }
-	        }
-	    }
-
-	    private static void AfterPluginsLoaded(string specifiedContentType)
-		{
-			if (!string.IsNullOrEmpty(specifiedContentType))
-				config.DefaultContentType = specifiedContentType;
-			else if (string.IsNullOrEmpty(config.DefaultContentType))
-				config.DefaultContentType = ContentType.Json;
-
-			config.ServiceManager.AfterInit();
-			ServiceManager = config.ServiceManager; //reset operations
-		}
 
 		public static void AddPlugin(params IPlugin[] plugins)
 		{
-			if (pluginsLoaded)
-			{
-				AppHost.LoadPlugin(plugins);
-				ServiceManager.ReloadServiceOperations();
-			}
-			else
-			{
-				foreach (var plugin in plugins)
-				{
-					Plugins.Add(plugin);
-				}
-			}
+			_instance.AddPlugin(plugins);
 		}
 
 		public static ServiceManager ServiceManager
 		{
-			get { return config.ServiceManager; }
+			get { return _instance.ServiceManager; }
 			set
 			{
-				config.ServiceManager = value;
-				ServiceOperations = value.ServiceOperations;
-				AllServiceOperations = value.AllServiceOperations;
+				_instance.ServiceManager = value;
 			}
 		}
 
@@ -257,24 +99,17 @@ namespace ServiceStack.WebHost.Endpoints
 			}
 		}
 
-		private static EndpointHostConfig config;
+		//private static EndpointHostConfig config;
 
 		public static EndpointHostConfig Config
 		{
 			get
 			{
-				return config;
+				return _instance.Config;
 			}
 			set
 			{
-				if (value.ServiceName == null)
-					throw new ArgumentNullException("ServiceName");
-
-				if (value.ServiceController == null)
-					throw new ArgumentNullException("ServiceController");
-
-				config = value;
-				ApplyConfigChanges();
+				_instance.Config = value;
 			}
 		}
 
@@ -285,13 +120,7 @@ namespace ServiceStack.WebHost.Endpoints
 		/// <returns></returns>
 		public static bool ApplyPreRequestFilters(IHttpRequest httpReq, IHttpResponse httpRes)
 		{
-			foreach (var requestFilter in RawRequestFilters)
-			{
-				requestFilter(httpReq, httpRes);
-				if (httpRes.IsClosed) break;
-			}
-
-			return httpRes.IsClosed;
+			return _instance.ApplyPreRequestFilters(httpReq, httpRes);
 		}
 
 		/// <summary>
@@ -301,44 +130,7 @@ namespace ServiceStack.WebHost.Endpoints
 		/// <returns></returns>
 		public static bool ApplyRequestFilters(IHttpRequest httpReq, IHttpResponse httpRes, object requestDto)
 		{
-			httpReq.ThrowIfNull("httpReq");
-			httpRes.ThrowIfNull("httpRes");
-
-			using (Profiler.Current.Step("Executing Request Filters"))
-			{
-				//Exec all RequestFilter attributes with Priority < 0
-				var attributes = FilterAttributeCache.GetRequestFilterAttributes(requestDto.GetType());
-				var i = 0;
-				for (; i < attributes.Length && attributes[i].Priority < 0; i++)
-				{
-					var attribute = attributes[i];
-					ServiceManager.Container.AutoWire(attribute);
-					attribute.RequestFilter(httpReq, httpRes, requestDto);
-					if (AppHost != null) //tests
-						AppHost.Release(attribute);
-					if (httpRes.IsClosed) return httpRes.IsClosed;
-				}
-
-				//Exec global filters
-				foreach (var requestFilter in RequestFilters)
-				{
-					requestFilter(httpReq, httpRes, requestDto);
-					if (httpRes.IsClosed) return httpRes.IsClosed;
-				}
-
-				//Exec remaining RequestFilter attributes with Priority >= 0
-				for (; i < attributes.Length; i++)
-				{
-					var attribute = attributes[i];
-					ServiceManager.Container.AutoWire(attribute);
-					attribute.RequestFilter(httpReq, httpRes, requestDto);
-					if (AppHost != null) //tests
-						AppHost.Release(attribute);
-					if (httpRes.IsClosed) return httpRes.IsClosed;
-				}
-
-				return httpRes.IsClosed;
-			}
+			return _instance.ApplyRequestFilters(httpReq, httpRes, requestDto);
 		}
 
 		/// <summary>
@@ -348,76 +140,22 @@ namespace ServiceStack.WebHost.Endpoints
 		/// <returns></returns>
 		public static bool ApplyResponseFilters(IHttpRequest httpReq, IHttpResponse httpRes, object response)
 		{
-			httpReq.ThrowIfNull("httpReq");
-			httpRes.ThrowIfNull("httpRes");
-
-			using (Profiler.Current.Step("Executing Response Filters"))
-			{
-				var responseDto = response.ToResponseDto();
-				var attributes = responseDto != null
-					? FilterAttributeCache.GetResponseFilterAttributes(responseDto.GetType())
-					: null;
-
-				//Exec all ResponseFilter attributes with Priority < 0
-				var i = 0;
-				if (attributes != null)
-				{
-					for (; i < attributes.Length && attributes[i].Priority < 0; i++)
-					{
-						var attribute = attributes[i];
-						ServiceManager.Container.AutoWire(attribute);
-						attribute.ResponseFilter(httpReq, httpRes, response);
-						if (AppHost != null) //tests
-							AppHost.Release(attribute);
-						if (httpRes.IsClosed) return httpRes.IsClosed;
-					}
-				}
-
-				//Exec global filters
-				foreach (var responseFilter in ResponseFilters)
-				{
-					responseFilter(httpReq, httpRes, response);
-					if (httpRes.IsClosed) return httpRes.IsClosed;
-				}
-
-				//Exec remaining RequestFilter attributes with Priority >= 0
-				if (attributes != null)
-				{
-					for (; i < attributes.Length; i++)
-					{
-						var attribute = attributes[i];
-						ServiceManager.Container.AutoWire(attribute);
-						attribute.ResponseFilter(httpReq, httpRes, response);
-						if (AppHost != null) //tests
-							AppHost.Release(attribute);
-						if (httpRes.IsClosed) return httpRes.IsClosed;
-					}
-				}
-
-				return httpRes.IsClosed;
-			}
+			return _instance.ApplyResponseFilters(httpReq, httpRes, response);
 		}
 
 		public static void SetOperationTypes(ServiceOperations operationTypes, ServiceOperations allOperationTypes)
 		{
-			ServiceOperations = operationTypes;
-			AllServiceOperations = allOperationTypes;
+			_instance.SetOperationTypes(operationTypes, allOperationTypes);
 		}
 
 		internal static object ExecuteService(object request, EndpointAttributes endpointAttributes, IHttpRequest httpReq, IHttpResponse httpRes)
 		{
-			using (Profiler.Current.Step("Execute Service"))
-			{
-                return config.ServiceController.Execute(request,
-                    new HttpRequestContext(httpReq, httpRes, request, endpointAttributes));
-            }
+			return _instance.ExecuteService(request, endpointAttributes, httpReq, httpRes);
 		}
 
         public static IServiceRunner<TRequest> CreateServiceRunner<TRequest>(ActionContext actionContext)
         {
-            return AppHost != null 
-                ? AppHost.CreateServiceRunner<TRequest>(actionContext) 
-                : new ServiceRunner<TRequest>(null, actionContext);
+			return _instance.CreateServiceRunner<TRequest>(actionContext);
         }
 
 	    /// <summary>
@@ -425,14 +163,7 @@ namespace ServiceStack.WebHost.Endpoints
         /// </summary>
 	    internal static void CompleteRequest()
         {
-	        try
-	        {
-                if (AppHost != null)
-                {
-                    AppHost.OnEndRequest();
-                }
-	        }
-	        catch (Exception ex) {}
+			_instance.CompleteRequest();
         }
 	}
 }

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostInstance.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostInstance.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using Funq;
+using ServiceStack.CacheAccess;
+using ServiceStack.CacheAccess.Providers;
+using ServiceStack.Common;
+using ServiceStack.Common.Web;
+using ServiceStack.Html;
+using ServiceStack.MiniProfiler;
+using ServiceStack.ServiceHost;
+using ServiceStack.VirtualPath;
+using ServiceStack.ServiceModel.Serialization;
+using ServiceStack.WebHost.Endpoints.Extensions;
+using ServiceStack.WebHost.Endpoints.Formats;
+using ServiceStack.WebHost.Endpoints.Support;
+using ServiceStack.WebHost.Endpoints.Utils;
+
+namespace ServiceStack.WebHost.Endpoints
+{
+	public class EndpointHostInstance
+	{
+		public  ServiceOperations ServiceOperations { get; private set; }
+		public  ServiceOperations AllServiceOperations { get; private set; }
+
+		public  IAppHost AppHost { get; internal set; }
+
+		public  IContentTypeFilter ContentTypeFilter { get; set; }
+
+        public  List<Action<IHttpRequest, IHttpResponse>> RawRequestFilters { get; private set; }
+
+		public  List<Action<IHttpRequest, IHttpResponse, object>> RequestFilters { get; private set; }
+
+		public  List<Action<IHttpRequest, IHttpResponse, object>> ResponseFilters { get; private set; }
+
+        public  List<IViewEngine> ViewEngines { get; set; }
+
+        public  HandleUncaughtExceptionDelegate ExceptionHandler { get; set; }
+        
+        public  HandleServiceExceptionDelegate ServiceExceptionHandler { get; set; }
+
+		public  List<HttpHandlerResolverDelegate> CatchAllHandlers { get; set; }
+
+		private  bool pluginsLoaded = false;
+
+		public  List<IPlugin> Plugins { get; set; }
+
+		public  IVirtualPathProvider VirtualPathProvider { get; set; }
+
+        public  DateTime StartedAt { get; set; }
+
+        public  DateTime ReadyAt { get; set; }
+
+		public EndpointHostInstance()
+		{
+			ContentTypeFilter = HttpResponseFilter.Instance;
+            RawRequestFilters = new List<Action<IHttpRequest, IHttpResponse>>();
+			RequestFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
+			ResponseFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
+			ViewEngines = new List<IViewEngine>();
+			CatchAllHandlers = new List<HttpHandlerResolverDelegate>();
+			Plugins = new List<IPlugin> {
+				new HtmlFormat(),
+				new CsvFormat(),
+				new MarkdownFormat(),
+                new PredefinedRoutesFeature(),
+                new MetadataFeature(),
+			};
+		}
+		
+		// Pre user config
+		public  void ConfigureHost(IAppHost appHost, string serviceName, ServiceManager serviceManager)
+		{
+			AppHost = appHost;
+
+			EndpointHostConfig.Instance.ServiceName = serviceName;
+			EndpointHostConfig.Instance.ServiceManager = serviceManager;
+
+			var config = EndpointHostConfig.Instance;
+			Config = config; // avoid cross-dependency on Config setter
+			VirtualPathProvider = new FileSystemVirtualPathProvider(AppHost, Config.WebHostPhysicalPath);
+
+		    Config.DebugMode = appHost.GetType().Assembly.IsDebugBuild();             
+            if (Config.DebugMode)
+            {
+                Plugins.Add(new RequestInfoFeature());
+            }
+		}
+
+		// Config has changed
+		private  void ApplyConfigChanges()
+		{
+			config.ServiceEndpointsMetadataConfig = ServiceEndpointsMetadataConfig.Create(config.ServiceStackHandlerFactoryPath);
+
+			JsonDataContractSerializer.Instance.UseBcl = config.UseBclJsonSerializers;
+			JsonDataContractDeserializer.Instance.UseBcl = config.UseBclJsonSerializers;
+		}
+
+		//After configure called
+		public  void AfterInit()
+		{
+            StartedAt = DateTime.Now;
+
+			if (config.EnableFeatures != Feature.All)
+			{
+				if ((Feature.Xml & config.EnableFeatures) != Feature.Xml)
+					config.IgnoreFormatsInMetadata.Add("xml");
+				if ((Feature.Json & config.EnableFeatures) != Feature.Json)
+					config.IgnoreFormatsInMetadata.Add("json");
+				if ((Feature.Jsv & config.EnableFeatures) != Feature.Jsv)
+					config.IgnoreFormatsInMetadata.Add("jsv");
+				if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
+					config.IgnoreFormatsInMetadata.Add("csv");
+				if ((Feature.Html & config.EnableFeatures) != Feature.Html)
+					config.IgnoreFormatsInMetadata.Add("html");
+				if ((Feature.Soap11 & config.EnableFeatures) != Feature.Soap11)
+					config.IgnoreFormatsInMetadata.Add("soap11");
+				if ((Feature.Soap12 & config.EnableFeatures) != Feature.Soap12)
+					config.IgnoreFormatsInMetadata.Add("soap12");
+			}
+
+			if ((Feature.Html & config.EnableFeatures) != Feature.Html)
+				Plugins.RemoveAll(x => x is HtmlFormat);
+
+			if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
+				Plugins.RemoveAll(x => x is CsvFormat);
+
+            if ((Feature.Markdown & config.EnableFeatures) != Feature.Markdown)
+                Plugins.RemoveAll(x => x is MarkdownFormat);
+
+            if ((Feature.PredefinedRoutes & config.EnableFeatures) != Feature.PredefinedRoutes)
+                Plugins.RemoveAll(x => x is PredefinedRoutesFeature);
+
+            if ((Feature.Metadata & config.EnableFeatures) != Feature.Metadata)
+                Plugins.RemoveAll(x => x is MetadataFeature);
+
+            if ((Feature.RequestInfo & config.EnableFeatures) != Feature.RequestInfo)
+                Plugins.RemoveAll(x => x is RequestInfoFeature);
+
+			if ((Feature.Razor & config.EnableFeatures) != Feature.Razor)
+				Plugins.RemoveAll(x => x is IRazorPlugin);    //external
+
+            if ((Feature.ProtoBuf & config.EnableFeatures) != Feature.ProtoBuf)
+                Plugins.RemoveAll(x => x is IProtoBufPlugin); //external
+
+            if ((Feature.MsgPack & config.EnableFeatures) != Feature.MsgPack)
+                Plugins.RemoveAll(x => x is IMsgPackPlugin);  //external
+
+            if (ExceptionHandler == null) {
+                ExceptionHandler = (httpReq, httpRes, operationName, ex) => {
+                    var errorMessage = string.Format("Error occured while Processing Request: {0}", ex.Message);
+                    var statusCode = ex.ToStatusCode();
+                    //httpRes.WriteToResponse always calls .Close in it's finally statement so 
+                    //if there is a problem writing to response, by now it will be closed
+                    if (!httpRes.IsClosed) {
+                        httpRes.WriteErrorToResponse(httpReq.ResponseContentType, operationName, errorMessage, ex, statusCode);
+                    }
+                };
+            }
+
+			var specifiedContentType = config.DefaultContentType; //Before plugins loaded
+
+            ConfigurePlugins();
+
+			AppHost.LoadPlugin(Plugins.ToArray());
+			pluginsLoaded = true;
+
+			AfterPluginsLoaded(specifiedContentType);
+
+		    var registeredCacheClient = AppHost.TryResolve<ICacheClient>();
+            using (registeredCacheClient)
+            {
+                if (registeredCacheClient == null)
+                {
+                    Container.Register<ICacheClient>(new MemoryCacheClient());
+                }
+            }
+
+		    ReadyAt = DateTime.Now;
+		}
+
+        public  T TryResolve<T>()
+        {
+            return AppHost != null ? AppHost.TryResolve<T>() : default(T);
+        }
+
+        /// <summary>
+        /// The AppHost.Container. Note: it is not thread safe to register dependencies after AppStart.
+        /// </summary>
+	    public  Container Container
+	    {
+	        get { 
+                var aspHost = AppHost as AppHostBase;
+                if (aspHost != null)
+                    return aspHost.Container;
+	            var listenerHost = AppHost as HttpListenerBase;
+                return listenerHost != null ? listenerHost.Container : new Container(); //testing may use alt AppHost
+	        }
+	    }
+
+	    private  void ConfigurePlugins()
+	    {
+            //Some plugins need to initialize before other plugins are registered.
+
+	        foreach (var plugin in Plugins)
+	        {
+	            var preInitPlugin = plugin as IPreInitPlugin;
+	            if (preInitPlugin != null)
+	            {
+                    preInitPlugin.Configure(AppHost);
+                }
+	        }
+	    }
+
+	    private  void AfterPluginsLoaded(string specifiedContentType)
+		{
+			if (!string.IsNullOrEmpty(specifiedContentType))
+				config.DefaultContentType = specifiedContentType;
+			else if (string.IsNullOrEmpty(config.DefaultContentType))
+				config.DefaultContentType = ContentType.Json;
+
+			config.ServiceManager.AfterInit();
+			ServiceManager = config.ServiceManager; //reset operations
+		}
+
+		public  void AddPlugin(params IPlugin[] plugins)
+		{
+			if (pluginsLoaded)
+			{
+				AppHost.LoadPlugin(plugins);
+				ServiceManager.ReloadServiceOperations();
+			}
+			else
+			{
+				foreach (var plugin in plugins)
+				{
+					Plugins.Add(plugin);
+				}
+			}
+		}
+
+		public  ServiceManager ServiceManager
+		{
+			get { return config.ServiceManager; }
+			set
+			{
+				config.ServiceManager = value;
+				ServiceOperations = value.ServiceOperations;
+				AllServiceOperations = value.AllServiceOperations;
+			}
+		}
+
+		private  EndpointHostConfig config;
+
+		public  EndpointHostConfig Config
+		{
+			get
+			{
+				return config;
+			}
+			set
+			{
+				if (value.ServiceName == null)
+					throw new ArgumentNullException("ServiceName");
+
+				if (value.ServiceController == null)
+					throw new ArgumentNullException("ServiceController");
+
+				config = value;
+				ApplyConfigChanges();
+			}
+		}
+
+		/// <summary>
+		/// Applies the raw request filters. Returns whether or not the request has been handled 
+		/// and no more processing should be done.
+		/// </summary>
+		/// <returns></returns>
+		public  bool ApplyPreRequestFilters(IHttpRequest httpReq, IHttpResponse httpRes)
+		{
+			foreach (var requestFilter in RawRequestFilters)
+			{
+				requestFilter(httpReq, httpRes);
+				if (httpRes.IsClosed) break;
+			}
+
+			return httpRes.IsClosed;
+		}
+
+		/// <summary>
+		/// Applies the request filters. Returns whether or not the request has been handled 
+		/// and no more processing should be done.
+		/// </summary>
+		/// <returns></returns>
+		public  bool ApplyRequestFilters(IHttpRequest httpReq, IHttpResponse httpRes, object requestDto)
+		{
+			httpReq.ThrowIfNull("httpReq");
+			httpRes.ThrowIfNull("httpRes");
+
+			using (Profiler.Current.Step("Executing Request Filters"))
+			{
+				//Exec all RequestFilter attributes with Priority < 0
+				var attributes = FilterAttributeCache.GetRequestFilterAttributes(requestDto.GetType());
+				var i = 0;
+				for (; i < attributes.Length && attributes[i].Priority < 0; i++)
+				{
+					var attribute = attributes[i];
+					ServiceManager.Container.AutoWire(attribute);
+					attribute.RequestFilter(httpReq, httpRes, requestDto);
+					if (AppHost != null) //tests
+						AppHost.Release(attribute);
+					if (httpRes.IsClosed) return httpRes.IsClosed;
+				}
+
+				//Exec global filters
+				foreach (var requestFilter in RequestFilters)
+				{
+					requestFilter(httpReq, httpRes, requestDto);
+					if (httpRes.IsClosed) return httpRes.IsClosed;
+				}
+
+				//Exec remaining RequestFilter attributes with Priority >= 0
+				for (; i < attributes.Length; i++)
+				{
+					var attribute = attributes[i];
+					ServiceManager.Container.AutoWire(attribute);
+					attribute.RequestFilter(httpReq, httpRes, requestDto);
+					if (AppHost != null) //tests
+						AppHost.Release(attribute);
+					if (httpRes.IsClosed) return httpRes.IsClosed;
+				}
+
+				return httpRes.IsClosed;
+			}
+		}
+
+		/// <summary>
+		/// Applies the response filters. Returns whether or not the request has been handled 
+		/// and no more processing should be done.
+		/// </summary>
+		/// <returns></returns>
+		public  bool ApplyResponseFilters(IHttpRequest httpReq, IHttpResponse httpRes, object response)
+		{
+			httpReq.ThrowIfNull("httpReq");
+			httpRes.ThrowIfNull("httpRes");
+
+			using (Profiler.Current.Step("Executing Response Filters"))
+			{
+				var responseDto = response.ToResponseDto();
+				var attributes = responseDto != null
+					? FilterAttributeCache.GetResponseFilterAttributes(responseDto.GetType())
+					: null;
+
+				//Exec all ResponseFilter attributes with Priority < 0
+				var i = 0;
+				if (attributes != null)
+				{
+					for (; i < attributes.Length && attributes[i].Priority < 0; i++)
+					{
+						var attribute = attributes[i];
+						ServiceManager.Container.AutoWire(attribute);
+						attribute.ResponseFilter(httpReq, httpRes, response);
+						if (AppHost != null) //tests
+							AppHost.Release(attribute);
+						if (httpRes.IsClosed) return httpRes.IsClosed;
+					}
+				}
+
+				//Exec global filters
+				foreach (var responseFilter in ResponseFilters)
+				{
+					responseFilter(httpReq, httpRes, response);
+					if (httpRes.IsClosed) return httpRes.IsClosed;
+				}
+
+				//Exec remaining RequestFilter attributes with Priority >= 0
+				if (attributes != null)
+				{
+					for (; i < attributes.Length; i++)
+					{
+						var attribute = attributes[i];
+						ServiceManager.Container.AutoWire(attribute);
+						attribute.ResponseFilter(httpReq, httpRes, response);
+						if (AppHost != null) //tests
+							AppHost.Release(attribute);
+						if (httpRes.IsClosed) return httpRes.IsClosed;
+					}
+				}
+
+				return httpRes.IsClosed;
+			}
+		}
+
+		public  void SetOperationTypes(ServiceOperations operationTypes, ServiceOperations allOperationTypes)
+		{
+			ServiceOperations = operationTypes;
+			AllServiceOperations = allOperationTypes;
+		}
+
+		internal  object ExecuteService(object request, EndpointAttributes endpointAttributes, IHttpRequest httpReq, IHttpResponse httpRes)
+		{
+			using (Profiler.Current.Step("Execute Service"))
+			{
+                return config.ServiceController.Execute(request,
+                    new HttpRequestContext(httpReq, httpRes, request, endpointAttributes));
+            }
+		}
+
+        public  IServiceRunner<TRequest> CreateServiceRunner<TRequest>(ActionContext actionContext)
+        {
+            return AppHost != null 
+                ? AppHost.CreateServiceRunner<TRequest>(actionContext) 
+                : new ServiceRunner<TRequest>(null, actionContext);
+        }
+
+	    /// <summary>
+        /// Call to signal the completion of a ServiceStack-handled Request
+        /// </summary>
+	    internal  void CompleteRequest()
+        {
+	        try
+	        {
+                if (AppHost != null)
+                {
+                    AppHost.OnEndRequest();
+                }
+	        }
+	        catch (Exception ex) {}
+        }
+	}
+}


### PR DESCRIPTION
Made EndPointHost use a private instance to make it easier to test and as a first step to allow multiple service stack instances run in the same process on different ports.  Important for organizations wanting to run integration tests on multiple endpoints concurrently.

No functional changes, only structural.
