### PR TITLE
Added support for multiple instances of service stack in the same app domain

### DIFF
--- a/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
+++ b/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using ServiceStack.DesignPatterns.Serialization;
@@ -6,9 +7,12 @@ using ServiceStack.Text;
 
 namespace ServiceStack.ServiceModel.Serialization
 {
+	/// <summary>
+	/// Responsible for JSON serialization.  Currently all serialization in the assembly uses this singleton.
+	/// </summary>
     public class JsonDataContractSerializer 
     {
-        public static JsonDataContractSerializer Instance = new JsonDataContractSerializer();
+        public static readonly JsonDataContractSerializer Instance = new JsonDataContractSerializer();
 
         public ITextSerializer TextSerializer { get; set; }
 

--- a/src/ServiceStack.ServiceInterface/ServiceStack.ServiceInterface.csproj
+++ b/src/ServiceStack.ServiceInterface/ServiceStack.ServiceInterface.csproj
@@ -280,7 +280,7 @@
     </ProjectReference>
     <ProjectReference Include="..\ServiceStack\ServiceStack.csproj">
       <Project>{680A1709-25EB-4D52-A87F-EE03FFD94BAA}</Project>
-      <Name>ServiceStack</Name>
+      <Name>ServiceStack %28ServiceStack\ServiceStack%29</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/ServiceStack/WebHost.Endpoints/AppHostHttpListenerBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/AppHostHttpListenerBase.cs
@@ -19,22 +19,28 @@ namespace ServiceStack.WebHost.Endpoints
 	{
 		protected AppHostHttpListenerBase() {}
 
-		protected AppHostHttpListenerBase(string serviceName, params Assembly[] assembliesWithServices)
+		protected AppHostHttpListenerBase(string serviceName, bool runAsNamedInstance, params Assembly[] assembliesWithServices)
 			: base(serviceName, assembliesWithServices)
 		{
-			EndpointHostConfig.Instance.ServiceStackHandlerFactoryPath = null;
-			EndpointHostConfig.Instance.MetadataRedirectPath = "metadata";
+			OurEndpointHost.Config.ServiceStackHandlerFactoryPath = null;
+			OurEndpointHost.Config.MetadataRedirectPath = "metadata";
 		}
 
-		protected AppHostHttpListenerBase(string serviceName, string handlerPath, params Assembly[] assembliesWithServices)
+		protected AppHostHttpListenerBase(string serviceName, string handlerPath, bool runAsNamedInstance, params Assembly[] assembliesWithServices)
 			: base(serviceName, assembliesWithServices)
 		{
-			EndpointHostConfig.Instance.ServiceStackHandlerFactoryPath = string.IsNullOrEmpty(handlerPath)
-				? null : handlerPath;			
-			EndpointHostConfig.Instance.MetadataRedirectPath = handlerPath == null 
+			OurEndpointHost.Config.ServiceStackHandlerFactoryPath = string.IsNullOrEmpty(handlerPath)
+				? null : handlerPath;
+			OurEndpointHost.Config.MetadataRedirectPath = handlerPath == null 
 				? "metadata"
 				: PathUtils.CombinePaths(handlerPath, "metadata");
 		}
+
+		protected AppHostHttpListenerBase(string serviceName, params Assembly[] assembliesWithServices)
+			: this(serviceName, false, assembliesWithServices) { }
+
+		protected AppHostHttpListenerBase(string serviceName, string handlerPath, params Assembly[] assembliesWithServices)
+			: this(serviceName, handlerPath, false, assembliesWithServices) { }
 
 		protected override void ProcessRequest(HttpListenerContext context)
 		{

--- a/src/ServiceStack/WebHost.Endpoints/AppHostHttpListenerLongRunningBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/AppHostHttpListenerLongRunningBase.cs
@@ -11,9 +11,6 @@ using ServiceStack.WebHost.Endpoints.Support;
 namespace ServiceStack.WebHost.Endpoints
 {
 
-
-
-
     public abstract class AppHostHttpListenerLongRunningBase : AppHostHttpListenerBase
     {
         private class ThreadPoolManager : IDisposable
@@ -89,13 +86,22 @@ namespace ServiceStack.WebHost.Endpoints
 
 
         #region IDisposable Members
-
-        public override void Dispose()
+		private bool _isDisposed = false;
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
-            _threadPoolManager.Dispose();
+			if (!_isDisposed)
+			{
+				if (disposing)
+				{
+					base.Dispose();
+					_threadPoolManager.Dispose();
+				}
 
-            Instance = null;
+				// new shared cleanup logic
+				_isDisposed = true;
+			}
+
+			base.Dispose(disposing);
         }
 
         #endregion

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostInstance.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostInstance.cs
@@ -50,10 +50,15 @@ namespace ServiceStack.WebHost.Endpoints
 
         public  DateTime ReadyAt { get; set; }
 
-		public EndpointHostInstance()
+		private bool _runAsNamedInstance = false;
+
+		public EndpointHostInstance(): this(false) { }
+
+		public EndpointHostInstance(bool runAsNamedInstance)
 		{
+			_runAsNamedInstance = runAsNamedInstance;
 			ContentTypeFilter = HttpResponseFilter.Instance;
-            RawRequestFilters = new List<Action<IHttpRequest, IHttpResponse>>();
+			RawRequestFilters = new List<Action<IHttpRequest, IHttpResponse>>();
 			RequestFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
 			ResponseFilters = new List<Action<IHttpRequest, IHttpResponse, object>>();
 			ViewEngines = new List<IViewEngine>();
@@ -66,17 +71,19 @@ namespace ServiceStack.WebHost.Endpoints
                 new MetadataFeature(),
 			};
 		}
-		
+
+
 		// Pre user config
 		public  void ConfigureHost(IAppHost appHost, string serviceName, ServiceManager serviceManager)
 		{
 			AppHost = appHost;
 
-			EndpointHostConfig.Instance.ServiceName = serviceName;
-			EndpointHostConfig.Instance.ServiceManager = serviceManager;
+			EndpointHostConfig config = _runAsNamedInstance ? EndpointHostConfig.GetNamedConfig(serviceName) : EndpointHostConfig.Instance;
 
-			var config = EndpointHostConfig.Instance;
-			Config = config; // avoid cross-dependency on Config setter
+			config.ServiceName = serviceName;
+			config.ServiceManager = serviceManager;
+
+			Config = config; 
 			VirtualPathProvider = new FileSystemVirtualPathProvider(AppHost, Config.WebHostPhysicalPath);
 
 		    Config.DebugMode = appHost.GetType().Assembly.IsDebugBuild();             
@@ -89,10 +96,11 @@ namespace ServiceStack.WebHost.Endpoints
 		// Config has changed
 		private  void ApplyConfigChanges()
 		{
-			config.ServiceEndpointsMetadataConfig = ServiceEndpointsMetadataConfig.Create(config.ServiceStackHandlerFactoryPath);
+			_config.ServiceEndpointsMetadataConfig = ServiceEndpointsMetadataConfig.Create(_config.ServiceStackHandlerFactoryPath);
 
-			JsonDataContractSerializer.Instance.UseBcl = config.UseBclJsonSerializers;
-			JsonDataContractDeserializer.Instance.UseBcl = config.UseBclJsonSerializers;
+			//will overwrite for whole app domain.
+			JsonDataContractSerializer.Instance.UseBcl = _config.UseBclJsonSerializers;
+			JsonDataContractDeserializer.Instance.UseBcl = _config.UseBclJsonSerializers;
 		}
 
 		//After configure called
@@ -100,49 +108,49 @@ namespace ServiceStack.WebHost.Endpoints
 		{
             StartedAt = DateTime.Now;
 
-			if (config.EnableFeatures != Feature.All)
+			if (_config.EnableFeatures != Feature.All)
 			{
-				if ((Feature.Xml & config.EnableFeatures) != Feature.Xml)
-					config.IgnoreFormatsInMetadata.Add("xml");
-				if ((Feature.Json & config.EnableFeatures) != Feature.Json)
-					config.IgnoreFormatsInMetadata.Add("json");
-				if ((Feature.Jsv & config.EnableFeatures) != Feature.Jsv)
-					config.IgnoreFormatsInMetadata.Add("jsv");
-				if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
-					config.IgnoreFormatsInMetadata.Add("csv");
-				if ((Feature.Html & config.EnableFeatures) != Feature.Html)
-					config.IgnoreFormatsInMetadata.Add("html");
-				if ((Feature.Soap11 & config.EnableFeatures) != Feature.Soap11)
-					config.IgnoreFormatsInMetadata.Add("soap11");
-				if ((Feature.Soap12 & config.EnableFeatures) != Feature.Soap12)
-					config.IgnoreFormatsInMetadata.Add("soap12");
+				if ((Feature.Xml & _config.EnableFeatures) != Feature.Xml)
+					_config.IgnoreFormatsInMetadata.Add("xml");
+				if ((Feature.Json & _config.EnableFeatures) != Feature.Json)
+					_config.IgnoreFormatsInMetadata.Add("json");
+				if ((Feature.Jsv & _config.EnableFeatures) != Feature.Jsv)
+					_config.IgnoreFormatsInMetadata.Add("jsv");
+				if ((Feature.Csv & _config.EnableFeatures) != Feature.Csv)
+					_config.IgnoreFormatsInMetadata.Add("csv");
+				if ((Feature.Html & _config.EnableFeatures) != Feature.Html)
+					_config.IgnoreFormatsInMetadata.Add("html");
+				if ((Feature.Soap11 & _config.EnableFeatures) != Feature.Soap11)
+					_config.IgnoreFormatsInMetadata.Add("soap11");
+				if ((Feature.Soap12 & _config.EnableFeatures) != Feature.Soap12)
+					_config.IgnoreFormatsInMetadata.Add("soap12");
 			}
 
-			if ((Feature.Html & config.EnableFeatures) != Feature.Html)
+			if ((Feature.Html & _config.EnableFeatures) != Feature.Html)
 				Plugins.RemoveAll(x => x is HtmlFormat);
 
-			if ((Feature.Csv & config.EnableFeatures) != Feature.Csv)
+			if ((Feature.Csv & _config.EnableFeatures) != Feature.Csv)
 				Plugins.RemoveAll(x => x is CsvFormat);
 
-            if ((Feature.Markdown & config.EnableFeatures) != Feature.Markdown)
+            if ((Feature.Markdown & _config.EnableFeatures) != Feature.Markdown)
                 Plugins.RemoveAll(x => x is MarkdownFormat);
 
-            if ((Feature.PredefinedRoutes & config.EnableFeatures) != Feature.PredefinedRoutes)
+            if ((Feature.PredefinedRoutes & _config.EnableFeatures) != Feature.PredefinedRoutes)
                 Plugins.RemoveAll(x => x is PredefinedRoutesFeature);
 
-            if ((Feature.Metadata & config.EnableFeatures) != Feature.Metadata)
+            if ((Feature.Metadata & _config.EnableFeatures) != Feature.Metadata)
                 Plugins.RemoveAll(x => x is MetadataFeature);
 
-            if ((Feature.RequestInfo & config.EnableFeatures) != Feature.RequestInfo)
+            if ((Feature.RequestInfo & _config.EnableFeatures) != Feature.RequestInfo)
                 Plugins.RemoveAll(x => x is RequestInfoFeature);
 
-			if ((Feature.Razor & config.EnableFeatures) != Feature.Razor)
+			if ((Feature.Razor & _config.EnableFeatures) != Feature.Razor)
 				Plugins.RemoveAll(x => x is IRazorPlugin);    //external
 
-            if ((Feature.ProtoBuf & config.EnableFeatures) != Feature.ProtoBuf)
+            if ((Feature.ProtoBuf & _config.EnableFeatures) != Feature.ProtoBuf)
                 Plugins.RemoveAll(x => x is IProtoBufPlugin); //external
 
-            if ((Feature.MsgPack & config.EnableFeatures) != Feature.MsgPack)
+            if ((Feature.MsgPack & _config.EnableFeatures) != Feature.MsgPack)
                 Plugins.RemoveAll(x => x is IMsgPackPlugin);  //external
 
             if (ExceptionHandler == null) {
@@ -157,7 +165,7 @@ namespace ServiceStack.WebHost.Endpoints
                 };
             }
 
-			var specifiedContentType = config.DefaultContentType; //Before plugins loaded
+			var specifiedContentType = _config.DefaultContentType; //Before plugins loaded
 
             ConfigurePlugins();
 
@@ -214,12 +222,12 @@ namespace ServiceStack.WebHost.Endpoints
 	    private  void AfterPluginsLoaded(string specifiedContentType)
 		{
 			if (!string.IsNullOrEmpty(specifiedContentType))
-				config.DefaultContentType = specifiedContentType;
-			else if (string.IsNullOrEmpty(config.DefaultContentType))
-				config.DefaultContentType = ContentType.Json;
+				_config.DefaultContentType = specifiedContentType;
+			else if (string.IsNullOrEmpty(_config.DefaultContentType))
+				_config.DefaultContentType = ContentType.Json;
 
-			config.ServiceManager.AfterInit();
-			ServiceManager = config.ServiceManager; //reset operations
+			_config.ServiceManager.AfterInit();
+			ServiceManager = _config.ServiceManager; //reset operations
 		}
 
 		public  void AddPlugin(params IPlugin[] plugins)
@@ -240,22 +248,23 @@ namespace ServiceStack.WebHost.Endpoints
 
 		public  ServiceManager ServiceManager
 		{
-			get { return config.ServiceManager; }
+			get { return _config.ServiceManager; }
 			set
 			{
-				config.ServiceManager = value;
+				_config.ServiceManager = value;
 				ServiceOperations = value.ServiceOperations;
 				AllServiceOperations = value.AllServiceOperations;
 			}
 		}
 
-		private  EndpointHostConfig config;
+		private  EndpointHostConfig _config;
 
 		public  EndpointHostConfig Config
 		{
 			get
 			{
-				return config;
+				//Q: should we instead retrieve this from EndPointHostConfig for named configs?
+				return _config;
 			}
 			set
 			{
@@ -265,7 +274,7 @@ namespace ServiceStack.WebHost.Endpoints
 				if (value.ServiceController == null)
 					throw new ArgumentNullException("ServiceController");
 
-				config = value;
+				_config = value;
 				ApplyConfigChanges();
 			}
 		}
@@ -400,7 +409,7 @@ namespace ServiceStack.WebHost.Endpoints
 		{
 			using (Profiler.Current.Step("Execute Service"))
 			{
-                return config.ServiceController.Execute(request,
+                return _config.ServiceController.Execute(request,
                     new HttpRequestContext(httpReq, httpRes, request, endpointAttributes));
             }
 		}


### PR DESCRIPTION
Added Support for Multiple instances of service stack for the HttpListener.  This enables multiple service stack servers running on different ports in the same app domain.  This is particularly helpful for running integration tests against multiple enpoints that may have the same urls but different implementations. 

To make the implementations in these classes thread safe and the methods more manageable to maintain, these files use "_" underscore for private member variable to make clear which variable are stack vars and which are heap vars for implementing critical sections in the code.

ServiceStack will continue to work the we it always has, however, if an implementer sets the runAsNamedInstance flag on an subclass of HttpListenerBase then that instance will run in named mode and can run next to other instances.

There is one open question, which is currently all instances use the same JsonSerializer, so on a config reload or load, all instances of SS must use the same JSONSerializer settings.  We can use seperate instances, but I don't know that doing so is the best way to go. 
