### PR TITLE
Update NuGet/ServiceStack.Host.Mvc/content/README.txt

### DIFF
--- a/NuGet/ServiceStack.Host.Mvc/content/README.txt
+++ b/NuGet/ServiceStack.Host.Mvc/content/README.txt
@@ -1,8 +1,9 @@
-You *MUST* register ServiceStacks '/api' path by adding the line below to MvcApplication.RegisterRoutes(RouteCollection) in the Global.asax:
+You *MUST* register ServiceStacks '/api' path by adding the lines below to MvcApplication.RegisterRoutes(RouteCollection) in the Global.asax:
 
 	routes.IgnoreRoute("api/{*pathInfo}"); 
 	routes.IgnoreRoute("{*favicon}", new { favicon = @"(.*/)?favicon.ico(/.*)?" }); //Prevent exceptions for favicon
 
+Place them before the current entries the method.
 
 To enable the Mini Profiler add the following lines in to MvcApplication in Global.asax.cs:
 


### PR DESCRIPTION
For some reason, 

```
        routes.IgnoreRoute("api/{*pathInfo}");
        routes.IgnoreRoute("{*favicon}", new { favicon = @"(.*/)?favicon.ico(/.*)?" }); //Prevent exceptions for favicon
```

should be placed before the other statements. Otherwise the routing is not working
