### PR TITLE
MemoryCacheClient changed to use UTC DateTime internally

### DIFF
--- a/src/ServiceStack/CacheAccess.Providers/MemoryCacheClient.cs
+++ b/src/ServiceStack/CacheAccess.Providers/MemoryCacheClient.cs
@@ -280,45 +280,54 @@ namespace ServiceStack.CacheAccess.Providers
 		}
 
 		/// <summary>
-		/// Add the value with key to the cache, set to expire at specified Local DateTime.
+		/// Add the value with key to the cache, set to expire at specified DateTime.
 		/// </summary>
-		/// <remarks>The version of Add that takes a TimeSpan expiration is faster, and not affected
-		/// by ambiguous local time during daylight savings/standard time transition.</remarks>
+		/// <remarks>This method examines the DateTimeKind of expiresAt to determine if conversion to
+		/// universal time is needed. The version of Add that takes a TimeSpan expiration is faster 
+		/// than using this method with a DateTime of Kind other than Utc, and is not affected by 
+		/// ambiguous local time during daylight savings/standard time transition.</remarks>
 		/// <param name="key">The key of the cache entry.</param>
 		/// <param name="value">The value being cached.</param>
-		/// <param name="expiresAt">The local DateTime at which the cache entry expires.</param>
+		/// <param name="expiresAt">The DateTime at which the cache entry expires.</param>
 		/// <returns>True if Add succeeds, otherwise false.</returns>
 		public bool Add<T>(string key, T value, DateTime expiresAt)
 		{
-			return CacheAdd(key, value, expiresAt.ToUniversalTime());
+			if (expiresAt.Kind != DateTimeKind.Utc) expiresAt = expiresAt.ToUniversalTime();
+			return CacheAdd(key, value, expiresAt);
 		}
 
 		/// <summary>
-		/// Add or replace the value with key to the cache, set to expire at specified Local DateTime.
+		/// Add or replace the value with key to the cache, set to expire at specified DateTime.
 		/// </summary>
-		/// <remarks>The version of Add that takes a TimeSpan expiration is faster, and not affected
-		/// by ambiguous local time during daylight savings/standard time transition.</remarks>
+		/// <remarks>This method examines the DateTimeKind of expiresAt to determine if conversion to
+		/// universal time is needed. The version of Set that takes a TimeSpan expiration is faster 
+		/// than using this method with a DateTime of Kind other than Utc, and is not affected by 
+		/// ambiguous local time during daylight savings/standard time transition.</remarks>
 		/// <param name="key">The key of the cache entry.</param>
 		/// <param name="value">The value being cached.</param>
-		/// <param name="expiresAt">The local DateTime at which the cache entry expires.</param>
+		/// <param name="expiresAt">The DateTime at which the cache entry expires.</param>
 		/// <returns>True if Set succeeds, otherwise false.</returns>
 		public bool Set<T>(string key, T value, DateTime expiresAt)
 		{
-			return CacheSet(key, value, expiresAt.ToUniversalTime());
+			if (expiresAt.Kind != DateTimeKind.Utc) expiresAt = expiresAt.ToUniversalTime();
+			return CacheSet(key, value, expiresAt);
 		}
 
 		/// <summary>
-		/// Replace the value with key in the cache, set to expire at specified Local DateTime.
+		/// Replace the value with key in the cache, set to expire at specified DateTime.
 		/// </summary>
-		/// <remarks>The version of Add that takes a TimeSpan expiration is faster, and not affected
-		/// by ambiguous local time during daylight savings/standard time transition.</remarks>
+		/// <remarks>This method examines the DateTimeKind of expiresAt to determine if conversion to
+		/// universal time is needed. The version of Replace that takes a TimeSpan expiration is faster 
+		/// than using this method with a DateTime of Kind other than Utc, and is not affected by 
+		/// ambiguous local time during daylight savings/standard time transition.</remarks>
 		/// <param name="key">The key of the cache entry.</param>
 		/// <param name="value">The value being cached.</param>
-		/// <param name="expiresAt">The local DateTime at which the cache entry expires.</param>
+		/// <param name="expiresAt">The DateTime at which the cache entry expires.</param>
 		/// <returns>True if Replace succeeds, otherwise false.</returns>
 		public bool Replace<T>(string key, T value, DateTime expiresAt)
 		{
-			return CacheReplace(key, value, expiresAt.ToUniversalTime());
+			if (expiresAt.Kind != DateTimeKind.Utc) expiresAt = expiresAt.ToUniversalTime();
+			return CacheReplace(key, value, expiresAt);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The public methods that take DateTimes will accept either Utc Kind or Local Kind DateTimes, and will only convert to universal time if the given DateTime is not already Utc.

Also wrote the following unit tests, but not sure which project should hold them, or whether you even want to include them since they use Thread.Sleep with small times to test expiration handling.

```
[TestFixture]
public class MemoryCacheClientTests
{
    MemoryCacheClient cache;

    [TestFixtureSetUp]
    public void TestFixtureSetUp()
    {
        cache = new MemoryCacheClient();
    }

    [TestFixtureTearDown]
    public void TestFixtureTearDown()
    {
        cache.Dispose();
        cache = null;
    }

    [Test]
    public void Get_before_Add_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, DateTime.Now.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Add_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, DateTime.Now.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }


    [Test]
    public void Get_before_Add_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, DateTime.UtcNow.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Add_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, DateTime.UtcNow.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Add_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, TimeSpan.FromMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Add_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Add(key, value, TimeSpan.FromMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Set_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, DateTime.Now.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Set_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, DateTime.Now.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Set_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, DateTime.UtcNow.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Set_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, DateTime.UtcNow.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Set_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, TimeSpan.FromMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Set_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value, TimeSpan.FromMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Replace_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, DateTime.Now.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Replace_local_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, DateTime.Now.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Replace_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, DateTime.UtcNow.AddMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Replace_utc_DateTime_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, DateTime.UtcNow.AddMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }

    [Test]
    public void Get_before_Replace_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, TimeSpan.FromMilliseconds(200));
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.SameAs(value));
    }

    [Test]
    public void Get_after_Replace_TimeSpan_expires()
    {
        cache.FlushAll();
        string key = "a";
        string value = "aValue";
        cache.Set(key, value);
        cache.Replace(key, value, TimeSpan.FromMilliseconds(200));
        System.Threading.Thread.Sleep(250);
        var retVal = cache.Get(key);
        Assert.That(retVal, Is.Null);
    }
}
```
