### PR TITLE
IServiceClient should inherit IRestClient

### DIFF
--- a/src/ServiceStack.Interfaces/Service/IServiceClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IServiceClient.cs
@@ -4,7 +4,7 @@ namespace ServiceStack.Service
 {
 	public interface IServiceClient : IServiceClientAsync, IOneWayClient
 #if !(SILVERLIGHT || MONOTOUCH)
-		, IReplyClient
+		, IReplyClient, IRestClient
 #endif
 	{
 	}


### PR DESCRIPTION
IServiceClient currently is already having the Send and SendAsync inherited.
But for the REST methods (Get, Delete, etc) only the async version is inherited.
This commit is just to make it more complete by inheriting the sync version of the REST methods as well.
