### PR TITLE
Dropping IRestClientAsync from IServiceClientAsync

### DIFF
--- a/src/ServiceStack.Interfaces/Service/IServiceClientAsync.cs
+++ b/src/ServiceStack.Interfaces/Service/IServiceClientAsync.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ServiceStack.Service
 {
-	public interface IServiceClientAsync : IRestClientAsync
+	public interface IServiceClientAsync
 	{
 		void SendAsync<TResponse>(object request, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
 	}


### PR DESCRIPTION
Related to discussion in [#338](https://github.com/ServiceStack/ServiceStack/pull/338). Possibly a breaking change for existing code, but it should be more standardized to either include the sync interface or remove the async interface.
