### PR TITLE
Fixed: Dropping IRestClientAsync from IServiceClientAsync (#340)

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -30,6 +30,7 @@ namespace ServiceStack.ServiceClient.Web
 #else
         : IServiceClient
 #endif
+        , IDisposable
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(ServiceClientBase));
 

--- a/src/ServiceStack.Interfaces/Service/IMayRequireCredentials.cs
+++ b/src/ServiceStack.Interfaces/Service/IMayRequireCredentials.cs
@@ -1,0 +1,7 @@
+namespace ServiceStack.Service
+{
+    public interface IMayRequireCredentials
+    {
+        void SetCredentials(string userName, string password);
+    }
+}

--- a/src/ServiceStack.Interfaces/Service/IOneWayClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IOneWayClient.cs
@@ -1,6 +1,6 @@
 namespace ServiceStack.Service
 {
-	public interface IOneWayClient
+	public interface IOneWayClient : IMayRequireCredentials
 	{
         void SendOneWay(object request);
         

--- a/src/ServiceStack.Interfaces/Service/IReplyClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IReplyClient.cs
@@ -3,7 +3,7 @@ using ServiceStack.ServiceHost;
 
 namespace ServiceStack.Service
 {
-	public interface IReplyClient
+	public interface IReplyClient : IMayRequireCredentials
 	{
 		/// <summary>
 		/// Sends the specified request.

--- a/src/ServiceStack.Interfaces/Service/IRestClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IRestClient.cs
@@ -3,7 +3,7 @@ using ServiceStack.ServiceHost;
 
 namespace ServiceStack.Service
 {
-	public interface IRestClient 
+	public interface IRestClient : IMayRequireCredentials
 	{
 	    TResponse Get<TResponse>(IReturn<TResponse> request);
         void Get(IReturnVoid request);

--- a/src/ServiceStack.Interfaces/Service/IRestClientAsync.cs
+++ b/src/ServiceStack.Interfaces/Service/IRestClientAsync.cs
@@ -1,17 +1,12 @@
 using System;
-using System.IO;
 
 namespace ServiceStack.Service
 {
-	public interface IRestClientAsync : IDisposable
-	{
-		void SetCredentials(string userName, string password);
-
-		void GetAsync<TResponse>(string relativeOrAbsoluteUrl, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
+    public interface IRestClientAsync : IMayRequireCredentials
+    {
+        void GetAsync<TResponse>(string relativeOrAbsoluteUrl, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
 		void DeleteAsync<TResponse>(string relativeOrAbsoluteUrl, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
-
 		void PostAsync<TResponse>(string relativeOrAbsoluteUrl, object request, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
 		void PutAsync<TResponse>(string relativeOrAbsoluteUrl, object request, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
 	}
-
 }

--- a/src/ServiceStack.Interfaces/Service/IServiceClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IServiceClient.cs
@@ -1,12 +1,9 @@
-using System;
-
 namespace ServiceStack.Service
 {
-	public interface IServiceClient : IServiceClientAsync, IOneWayClient
+	public interface IServiceClient : IServiceClientAsync, IOneWayClient, IMayRequireCredentials
 #if !(SILVERLIGHT || MONOTOUCH)
 		, IReplyClient
 #endif
 	{
 	}
-
 }

--- a/src/ServiceStack.Interfaces/Service/IServiceClientAsync.cs
+++ b/src/ServiceStack.Interfaces/Service/IServiceClientAsync.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ServiceStack.Service
 {
-	public interface IServiceClientAsync
+	public interface IServiceClientAsync : IMayRequireCredentials
 	{
 		void SendAsync<TResponse>(object request, Action<TResponse> onSuccess, Action<TResponse, Exception> onError);
 	}

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
@@ -623,6 +623,7 @@
     <Compile Include="Service\IServiceClientAsync.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Service\IMayRequireCredentials.cs" />
     <Compile Include="Service\IStreamWriter.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/ServiceStack.ServiceInterface/Testing/TestBase.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/TestBase.cs
@@ -95,7 +95,7 @@ namespace ServiceStack.ServiceInterface.Testing
             return new DirectServiceClient(this, EndpointHost.ServiceManager);
         }
 
-        public class DirectServiceClient : IServiceClient, IRestClient
+        public class DirectServiceClient : IServiceClient, IRestClient, IRestClientAsync
         {
             private readonly TestBase parent;
             ServiceManager ServiceManager { get; set; }

--- a/tests/ServiceStack.WebHost.IntegrationTests/Tests/HelloWorldServiceClientTests.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Tests/HelloWorldServiceClientTests.cs
@@ -66,7 +66,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 		}
 
 		[Test, TestCaseSource("RestClients")]
-		public void Async_Call_HelloWorld_with_Async_ServiceClients_on_UserDefined_Routes(IServiceClient client)
+		public void Async_Call_HelloWorld_with_Async_ServiceClients_on_UserDefined_Routes(IRestClientAsync client)
 		{
 			HelloResponse response = null;
 			client.GetAsync<HelloResponse>("/hello/World!",


### PR DESCRIPTION
Changes done:
- Extracted SetCredentials from IRestClientAsync into a new IMayRequireCredentials
- All client interfaces now inherits from IMayRequireCredentials as well
- Dropped IDisposable from IRestClientAsync, I think this is more suited on the implementation class itself
