### PR TITLE
ResponseStatus not set on async client error

### DIFF
--- a/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Host/ExampleAppHostHttpListener.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/Support/Host/ExampleAppHostHttpListener.cs
@@ -32,10 +32,11 @@ namespace ServiceStack.WebHost.Endpoints.Tests.Support.Host
 	}
 
 	[DataContract]
-	public class GetFactorialResponse
+	public class GetFactorialResponse : IHasResponseStatus
 	{
 		[DataMember]
 		public long Result { get; set; }
+	    public ResponseStatus ResponseStatus { get; set; }
 	}
 
 	public class GetFactorialService


### PR DESCRIPTION
Has something changed here? My mobile app is now receiving the FluentValidation NotNull message rather than the actual error message.
