### PR TITLE
Fixing issue #345

### DIFF
--- a/src/ServiceStack.Authentication.OpenId/OpenIdOAuthProvider.cs
+++ b/src/ServiceStack.Authentication.OpenId/OpenIdOAuthProvider.cs
@@ -68,6 +68,8 @@ namespace ServiceStack.Authentication.OpenId
                         {
                             httpResult.Headers[header] = openIdResponse.Headers[header];
                         }
+                        // Save the current session to keep the ReferrerUrl available (similar to Facebook provider)
+                        authService.SaveSession(session, SessionExpiry);
                         return httpResult;
                     }
                 }


### PR DESCRIPTION
Saving the session keeps the ReferrerUrl query string parameters
(similar to Facebook provider)
