### PR TITLE
Support Handlers declaration with no type attribute

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -314,9 +314,17 @@ namespace ServiceStack.WebHost.Endpoints
         {
             return XDocument.Parse(rawXml).Root.Element("handlers")
                 .Descendants("add")
-                .Where(handler => (handler.Attribute("type").Value ?? String.Empty).StartsWith("ServiceStack"))
+                .Where(handler => EndpointHostConfig.EnsureHandlerTypeAttribute(handler).StartsWith("ServiceStack"))
                 .Select(handler => handler.Attribute("path").Value)
                 .FirstOrDefault();
+        }
+        private static string EnsureHandlerTypeAttribute(XElement handler)
+        {
+          if (handler.Attribute("type") != null && !string.IsNullOrEmpty(handler.Attribute("type").Value))
+          {
+            return handler.Attribute("type").Value;
+          }
+          return string.Empty;
         }
 
         public ServiceManager ServiceManager { get; internal set; }


### PR DESCRIPTION
This syntax is commonly used in Sharepoint.
<add name="OwssvrHandler" scriptProcessor="C:\Program Files\Common
Files\Microsoft Shared\Web Server Extensions\14\isapi\owssvr.dll"
path="/_vti_bin/owssvr.dll" verb="*" modules="IsapiModule"
preCondition="integratedMode" />
