### PR TITLE
Do not override the configured default domain on HttpCookie

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -50,11 +50,15 @@ namespace ServiceStack.ServiceHost
 
 		public HttpCookie ToHttpCookie(Cookie cookie)
 		{
-			return new HttpCookie(cookie.Name, cookie.Value) {
+			var httpCookie = new HttpCookie(cookie.Name, cookie.Value) {
 				Path = cookie.Path,
 				Expires = cookie.Expires,
-				Domain = (string.IsNullOrEmpty(cookie.Domain)) ? null : cookie.Domain,
 			};
+			if (string.IsNullOrEmpty(httpCookie.Domain))
+			{
+				httpCookie.Domain = (string.IsNullOrEmpty(cookie.Domain) ? null : cookie.Domain);
+			}
+			return httpCookie;
 		}
 
 		public string GetHeaderValue(Cookie cookie)


### PR DESCRIPTION
HttpCookie's constructor will set defaults from runtime configuration
at system.web/httpCookies

Related to my question at [stackoverflow](http://stackoverflow.com/questions/13829537/servicestack-authentication-for-domain-and-subdomains)
