### PR TITLE
CookieContainer is not set in AsyncServiceClient when authentication is required

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
@@ -404,6 +404,11 @@ namespace ServiceStack.ServiceClient.Web
                     {
                         requestState.WebRequest = (HttpWebRequest)WebRequest.Create(requestState.Url);
 
+                        if (StoreCookies)
+                        {
+                            requestState.WebRequest.CookieContainer = CookieContainer;
+                        }
+
                         requestState.WebRequest.AddBasicAuth(this.UserName, this.Password);
 
                         if (OnAuthenticationRequired != null)


### PR DESCRIPTION
When using AsyncServiceClient and the request requires authentication, another request is created, but the CookieContainer is not set and therefore the authentication cookies are not stored. In the next async call, the authentication is requested again, because the cookies hasn't been stored
