### PR TITLE
RequiredPermission and RequiredRole attributes now return 403 instead of 401

### DIFF
--- a/src/ServiceStack.ServiceInterface/RequiredPermissionAttribute.cs
+++ b/src/ServiceStack.ServiceInterface/RequiredPermissionAttribute.cs
@@ -34,7 +34,7 @@ namespace ServiceStack.ServiceInterface
             var session = req.GetSession();
             if (HasAllPermissions(req, session)) return;
 
-            res.StatusCode = (int)HttpStatusCode.Unauthorized;
+            res.StatusCode = (int)HttpStatusCode.Forbidden;
             res.StatusDescription = "Invalid Permissions";
             res.EndServiceStackRequest();
         }

--- a/src/ServiceStack.ServiceInterface/RequiredRoleAttribute.cs
+++ b/src/ServiceStack.ServiceInterface/RequiredRoleAttribute.cs
@@ -36,7 +36,7 @@ namespace ServiceStack.ServiceInterface
             var session = req.GetSession();
             if (HasAllRoles(req, session)) return;
 
-            res.StatusCode = (int)HttpStatusCode.Unauthorized;
+            res.StatusCode = (int)HttpStatusCode.Forbidden;
             res.StatusDescription = "Invalid Role";
             res.EndServiceStackRequest();
         }
@@ -82,7 +82,7 @@ namespace ServiceStack.ServiceInterface
             if (session != null && requiredRoles.All(session.HasRole))
                 return;
 
-            throw new HttpError(HttpStatusCode.Unauthorized, "Invalid Role");
+            throw new HttpError(HttpStatusCode.Forbidden, "Invalid Role");
         }
     }
 

--- a/tests/ServiceStack.WebHost.IntegrationTests/Tests/ManageRolesTests.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Tests/ManageRolesTests.cs
@@ -67,7 +67,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 			}
 			catch (WebServiceException webEx)
 			{
-				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Forbidden));
 				//StatusDescription is ignored in WebDevServer
 				//Assert.That(webEx.StatusDescription, Is.EqualTo("Invalid Role"));
 			}
@@ -132,7 +132,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 			}
 			catch (WebServiceException webEx)
 			{
-				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Forbidden));
 				//StatusDescription is ignored in WebDevServer
 				//Assert.That(webEx.StatusDescription, Is.EqualTo("Invalid Role"));
 			}
@@ -154,7 +154,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 			}
 			catch (WebServiceException webEx)
 			{
-				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Forbidden));
 				//StatusDescription is ignored in WebDevServer
 				//Assert.That(webEx.StatusDescription, Is.EqualTo("Invalid Role"));
 			}
@@ -184,7 +184,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 			}
 			catch (WebServiceException webEx)
 			{
-				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Forbidden));
 				//StatusDescription is ignored in WebDevServer
 				//Assert.That(webEx.StatusDescription, Is.EqualTo("Invalid Permissions"));
 			}
@@ -206,7 +206,7 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 			}
 			catch (WebServiceException webEx)
 			{
-				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+				Assert.That(webEx.StatusCode, Is.EqualTo((int)HttpStatusCode.Forbidden));
 				//StatusDescription is ignored in WebDevServer
 				//Assert.That(webEx.StatusDescription, Is.EqualTo("Invalid Permissions"));
 			}


### PR DESCRIPTION
Not having the required permission(s) and/or role(s) should now return 403 instead of 401. This will allow the consuming application to easily differentiate whether the user needs to authenticate or that they just don't have sufficient permissions.

I think I updated all the related unit tests, but the ServiceStack.WebHost.IntegrationTests fails to build for me.
