### PR TITLE
Add ability to intercept raw requests

### DIFF
--- a/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
@@ -62,6 +62,8 @@ namespace ServiceStack.ServiceInterface.Testing
 
         public List<HttpHandlerResolverDelegate> CatchAllHandlers { get; set; }
 
+        public Action<IHttpRequest> InterceptRequestHandler { get; set; }
+
         public Dictionary<Type, Func<IHttpRequest, object>> RequestBinders
         {
             get { throw new NotImplementedException(); }

--- a/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
@@ -77,6 +77,8 @@ namespace ServiceStack.ServiceInterface.Testing
 
         public List<HttpHandlerResolverDelegate> CatchAllHandlers { get; private set; }
 
+        public Action<IHttpRequest> InterceptRequestHandler { get; set; }
+
         public Dictionary<Type, Func<IHttpRequest, object>> RequestBinders
         {
             get { throw new NotImplementedException(); }

--- a/src/ServiceStack/WebHost.Endpoints/AppHostBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/AppHostBase.cs
@@ -230,6 +230,15 @@ namespace ServiceStack.WebHost.Endpoints
 			get { return EndpointHost.CatchAllHandlers; }
 		}
 
+        /// <summary>
+        /// Gets or sets a callback function that is invoked before each request.
+        /// </summary>
+        public Action<IHttpRequest> InterceptRequestHandler
+        {
+            get { return EndpointHost.InterceptRequestHandler; }
+            set { EndpointHost.InterceptRequestHandler = value; }
+        }
+
 		public EndpointHostConfig Config
 		{
 			get { return EndpointHost.Config; }

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
@@ -268,7 +268,12 @@ namespace ServiceStack.WebHost.Endpoints
 	    }
 
 	    public static ServiceMetadata Metadata { get { return Config.Metadata; } }
-       
+
+        /// <summary>
+        /// Gets or sets a callback function that is invoked before each request.
+        /// </summary>
+        public static Action<IHttpRequest> InterceptRequestHandler { get; set; }
+        
         /// <summary>
 		/// Applies the raw request filters. Returns whether or not the request has been handled 
 		/// and no more processing should be done.

--- a/src/ServiceStack/WebHost.Endpoints/IAppHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/IAppHost.cs
@@ -82,6 +82,11 @@ namespace ServiceStack.WebHost.Endpoints
 		/// </summary>
 		List<HttpHandlerResolverDelegate> CatchAllHandlers { get; }
 
+        /// <summary>
+        /// Gets or sets a callback function that is invoked before each request.
+        /// </summary>
+        Action<IHttpRequest> InterceptRequestHandler { get; set; }
+
 		/// <summary>
 		/// Provide a custom model minder for a specific Request DTO
 		/// </summary>

--- a/src/ServiceStack/WebHost.Endpoints/Soap11Handlers.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Soap11Handlers.cs
@@ -25,7 +25,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap11RequestMessage(context.Request.InputStream);
+            var requestMessage = GetSoap11RequestMessage(InterceptStream(context.Request));
             SendOneWay(requestMessage);
         }
     }
@@ -43,7 +43,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap11RequestMessage(context.Request.InputStream);
+            var requestMessage = GetSoap11RequestMessage(InterceptStream(context.Request));
             var responseMessage = Send(requestMessage);
 
             context.Response.ContentType = GetSoapContentType(context.Request.ContentType);
@@ -62,7 +62,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap11RequestMessage(httpReq.InputStream);
+            var requestMessage = GetSoap11RequestMessage(InterceptStream(httpReq));
             var responseMessage = Send(requestMessage, httpReq, httpRes);
 
             httpRes.ContentType = GetSoapContentType(httpReq.ContentType);

--- a/src/ServiceStack/WebHost.Endpoints/Soap12Handlers.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Soap12Handlers.cs
@@ -31,7 +31,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap12RequestMessage(context.Request.InputStream);
+            var requestMessage = GetSoap12RequestMessage(InterceptStream(context.Request));
             SendOneWay(requestMessage);
         }
     }
@@ -49,7 +49,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap12RequestMessage(context.Request.InputStream);
+            var requestMessage = GetSoap12RequestMessage(InterceptStream(context.Request));
             var responseMessage = Send(requestMessage);
 
             context.Response.ContentType = GetSoapContentType(context.Request.ContentType);
@@ -68,7 +68,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return;
             }
 
-            var requestMessage = GetSoap12RequestMessage(httpReq.InputStream);
+            var requestMessage = GetSoap12RequestMessage(InterceptStream(httpReq));
             var responseMessage = Send(requestMessage, httpReq, httpRes);
 
             httpRes.ContentType = GetSoapContentType(httpReq.ContentType);

--- a/src/ServiceStack/WebHost.Endpoints/Support/HttpListenerBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/HttpListenerBase.cs
@@ -431,7 +431,13 @@ namespace ServiceStack.WebHost.Endpoints.Support
 			get { return EndpointHost.CatchAllHandlers; }
 		}
 
-		public EndpointHostConfig Config
+        public Action<IHttpRequest> InterceptRequestHandler
+        {
+            get { return EndpointHost.InterceptRequestHandler; }
+            set { EndpointHost.InterceptRequestHandler = value; }
+        }
+
+	    public EndpointHostConfig Config
 		{
 			get { return EndpointHost.Config; }
 		}

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
@@ -94,7 +94,9 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 
 		    public List<HttpHandlerResolverDelegate> CatchAllHandlers { get; set; }
 
-			public Dictionary<Type, Func<IHttpRequest, object>> RequestBinders
+            public Action<IHttpRequest> InterceptRequestHandler { get; set; }
+
+		    public Dictionary<Type, Func<IHttpRequest, object>> RequestBinders
 			{
 				get { throw new NotImplementedException(); }
 			}

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/InterceptInputStreamTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/InterceptInputStreamTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Funq;
+using NUnit.Framework;
+using ServiceStack.Service;
+using ServiceStack.ServiceClient.Web;
+using ServiceStack.ServiceHost;
+using ServiceStack.WebHost.Endpoints.Tests.Support.Services;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    [Route("/interceptinputitream", "POST")]
+    [DataContract]
+    public class InterceptRequestRequest
+    {
+        [DataMember]
+        public string Data { get; set; }
+    }
+
+    public class InterceptRequestResponse {}
+
+    public class InterceptRequestService : ServiceInterface.Service, IAny<InterceptRequestRequest>
+    {
+        public object Any(InterceptRequestRequest request)
+        {
+            return new InterceptRequestResponse();
+        }
+    }
+
+    public class InterceptRequestTests
+    {
+        private const string ListeningOn = "http://localhost:82/";
+
+        public class InterceptRequestAppHostHttpListener
+            : AppHostHttpListenerBase
+        {
+
+            public InterceptRequestAppHostHttpListener()
+                : base("Intercept InputStream tests", typeof(HelloService).Assembly) { }
+
+            public override void Configure(Container container)
+            {
+                InterceptRequestHandler = request =>
+                {
+                    if (ThrowException)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    RawBody = request.GetRawBody();
+                };
+            }
+
+            public string RawBody { get; private set; }
+            public bool ThrowException { get; set; }
+        }
+
+        InterceptRequestAppHostHttpListener appHost;
+
+        [TestFixtureSetUp]
+        public void OnTestFixtureSetUp()
+        {
+            appHost = new InterceptRequestAppHostHttpListener();
+            appHost.Init();
+            appHost.Start(ListeningOn);
+        }
+
+        [TestFixtureTearDown]
+        public void OnTestFixtureTearDown()
+        {
+            appHost.Dispose();
+        }
+        
+        private static readonly IServiceClient[] ServiceClients = 
+		{
+			new JsonServiceClient(ListeningOn),
+			new XmlServiceClient(ListeningOn),
+			new JsvServiceClient(ListeningOn),
+            new Soap11ServiceClient(ListeningOn),
+            new Soap12ServiceClient(ListeningOn)
+		};
+
+        [Test, TestCaseSource("ServiceClients")]
+        public void Can_Intercept_Request(IServiceClient client)
+        {
+            const string data = "SDBF4U%^TRMJY%^IgfnhjSD^*o*(PdbfnSEVF#$%TK";
+            client.Send<InterceptRequestResponse>(new InterceptRequestRequest { Data = data });
+
+            Console.WriteLine(appHost.RawBody);
+
+            Assert.That(appHost.RawBody, Is.Not.Null.Or.Empty);
+            Assert.That(appHost.RawBody, Contains.Substring(data));
+        }
+
+        [Test, TestCaseSource("ServiceClients")]
+        public void Ignores_Thrown_Exception_In_Intercept_Callback(IServiceClient client)
+        {
+            var request = new InterceptRequestRequest { Data = "abcdefg" };
+            appHost.ThrowException = true;
+
+            client.Send<InterceptRequestResponse>(request);
+            Assert.Pass();
+        }
+    }
+}

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="CompressionTests.cs" />
     <Compile Include="ExceptionHandling2Tests.cs" />
     <Compile Include="IntegrationTests\MovieSoap11Tests.cs" />
+    <Compile Include="InterceptInputStreamTests.cs" />
     <Compile Include="ServiceSetupTests.cs" />
     <Compile Include="UniqueRequestTests.cs" />
     <Compile Include="SendOneWayTests.cs" />


### PR DESCRIPTION
At my company, for our existing services, we log each request as it comes in (the raw request body, ip address, headers, etc.). I've created a new service using Service Stack, and wanted to have this same functionality. I was surprised that this functionality didn't already exist, so I've added it (and it's entirely possible that it _does_ exist - if so, feel free to reject this pull request (and show me how!)).

Here's the usage:

``` c#
public class MyAppHost : AppHostBase
{
    private readonly ILogger logger;

    public MyAppHost(ILogger logger)
        : base("My Service", typeof(MyAppHost).Assembly)
    {
        this.logger = logger;
    }

    public override void Configure(Container container)
    {
        InterceptRequestHandler = (IHttpRequest request) =>
        {
            logger.Log(new
                {
                    Request = request.GetRawBody(),
                    request.RemoteIp,
                    request.ContentType
                });
        };
    }
}
```
