### PR TITLE
We need to protect Cookies from malicous Javascript. By setting HttpOnly...

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -53,6 +53,7 @@ namespace ServiceStack.ServiceHost
 			return new HttpCookie(cookie.Name, cookie.Value) {
 				Path = cookie.Path,
 				Expires = cookie.Expires,
+        HttpOnly = true,
 				Domain = (string.IsNullOrEmpty(cookie.Domain)) ? null : cookie.Domain,
 			};
 		}


### PR DESCRIPTION
... to true, cookies should only accessible by the server. This is a Security Best Practices.
