### PR TITLE
Pull Request for Issue 410 (DirectServiceClient causing issues in ServiceRunner)

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceRunner.cs
+++ b/src/ServiceStack/ServiceHost/ServiceRunner.cs
@@ -183,7 +183,7 @@ namespace ServiceStack.ServiceHost
         //signature matches ServiceExecFn
         public object Process(IRequestContext requestContext, object instance, object request)
         {
-            return requestContext.EndpointAttributes.Has(EndpointAttributes.OneWay) 
+            return requestContext != null && requestContext.EndpointAttributes.Has(EndpointAttributes.OneWay) 
                 ? ExecuteOneWay(requestContext, instance, (TRequest)request) 
                 : Execute(requestContext, instance, (TRequest)request);
         }

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/AlwaysThrowsService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/AlwaysThrowsService.cs
@@ -32,9 +32,9 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
 	}
 
 	public class AlwaysThrowsService 
-		: ServiceBase<AlwaysThrows>
+		: ServiceInterface.Service
 	{
-		protected override object Run(AlwaysThrows request)
+		public object Any(AlwaysThrows request)
 		{
             if (request.StatusCode.HasValue)
             {

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/ReverseService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/ReverseService.cs
@@ -19,9 +19,9 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
 	}
 
 	public class ReverseService 
-		: ServiceBase<Reverse>
+		: ServiceInterface.Service
 	{
-		protected override object Run(Reverse request)
+		public object Any(Reverse request)
 		{
 			return new ReverseResponse { Result = Execute(request.Value) };
 		}

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/Rot13Service.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/Rot13Service.cs
@@ -19,9 +19,9 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
 	}
 
 	public class Rot13Service 
-		: ServiceBase<Rot13>
+		: ServiceInterface.Service
 	{
-		protected override object Run(Rot13 request)
+		public object Any(Rot13 request)
 		{
 			return new Rot13Response { Result = request.Value.ToRot13() };
 		}

--- a/tests/ServiceStack.WebHost.IntegrationTests/Soap11WebService.asmx.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Soap11WebService.asmx.cs
@@ -24,7 +24,7 @@ namespace ServiceStack.WebHost.IntegrationTests
 		[WebMethod]
 		public ReverseResponse Reverse(Reverse request)
 		{
-			return new ReverseService().Execute(request) as ReverseResponse;
+			return new ReverseService().Any(request) as ReverseResponse;
 		}
 	}
 }


### PR DESCRIPTION
Hi,

This is a proposed workaround for [Issue 410](https://github.com/ServiceStack/ServiceStack/issues/410).  

I'm not sure if using Service (and thus ServiceRunner), leaving DirectServiceClient unable to ever satisfy the condition in [ServiceRunner.Process](https://github.com/connectassist/ServiceStack/pull/new/master#L0R187) to call ExecuteOneWay is a problem.

Please let me know if I can address anything further.

Many thanks
