### PR TITLE
Set HttpOnly to true to protect cookies

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -53,6 +53,7 @@ namespace ServiceStack.ServiceHost
 			var httpCookie = new HttpCookie(cookie.Name, cookie.Value) {
 				Path = cookie.Path,
 				Expires = cookie.Expires,
+				HttpOnly = true
 			};
 			if (string.IsNullOrEmpty(httpCookie.Domain))
 			{


### PR DESCRIPTION
This is a re-submit of #408, which rightly suggests that all cookies should be set as HttpOnly by default.
