### PR TITLE
Moved call to CreateServiceManager to Init to allow dependency injection to take place

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Support/HttpListenerBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/HttpListenerBase.cs
@@ -44,6 +44,9 @@ namespace ServiceStack.WebHost.Endpoints.Support
 
 		public event DelReceiveWebRequest ReceiveWebRequest;
 
+        private string serviceName;
+        private Assembly[] assembliesWithServices;
+
 		protected HttpListenerBase()
 		{
             this.startTime = DateTime.UtcNow;
@@ -55,7 +58,8 @@ namespace ServiceStack.WebHost.Endpoints.Support
 		protected HttpListenerBase(string serviceName, params Assembly[] assembliesWithServices)
 			: this()
 		{
-			EndpointHost.ConfigureHost(this, serviceName, CreateServiceManager(assembliesWithServices));
+            this.serviceName = serviceName;
+            this.assembliesWithServices = assembliesWithServices;
 		}
 
 		protected virtual ServiceManager CreateServiceManager(params Assembly[] assembliesWithServices)
@@ -72,7 +76,9 @@ namespace ServiceStack.WebHost.Endpoints.Support
 
 			Instance = this;
 
-			var serviceManager = EndpointHost.Config.ServiceManager;
+            EndpointHost.ConfigureHost(this, serviceName, CreateServiceManager(assembliesWithServices));
+            
+            var serviceManager = EndpointHost.Config.ServiceManager;
 			if (serviceManager != null)
 			{
 				serviceManager.Init();


### PR DESCRIPTION
Currently `CreateServiceManager` is called from the constructor. This is causing `CreateServiceManager` overrides that are expecting a dependency-injected value to not work well due to `CreateServiceManager` got called even before the injected value can be taken out by our code.

p/s: On top of that, I think the parameterless protected constructor should be made private since it does not look as if it was meant to be used in the first place.
