### PR TITLE
Auto-create SessionFactory in ServiceStackController

### DIFF
--- a/src/ServiceStack.FluentValidation.Mvc3/Mvc/ServiceStackController.cs
+++ b/src/ServiceStack.FluentValidation.Mvc3/Mvc/ServiceStackController.cs
@@ -54,7 +54,13 @@ namespace ServiceStack.Mvc
         }
 
         public ICacheClient Cache { get; set; }
-        public ISessionFactory SessionFactory { get; set; }
+
+        private ISessionFactory sessionFactory;
+        public ISessionFactory SessionFactory
+        {
+            get { return sessionFactory ?? new SessionFactory(Cache); }
+            set { sessionFactory = value; }
+        }
 
         /// <summary>
         /// Typed UserSession


### PR DESCRIPTION
This is consistent with the behavior in Service, which instantiates
SessionFactory to new SessionFactory(Cache) if it's found to be null.

This prevents a null reference exception when accessing
ServiceStackController.Session without first registering an
ISessionFactory in the DI container.
