### PR TITLE
Fix OpenID authentication problems with myopenid.com etc.

### DIFF
--- a/src/ServiceStack.Authentication.OpenId/OpenIdOAuthProvider.cs
+++ b/src/ServiceStack.Authentication.OpenId/OpenIdOAuthProvider.cs
@@ -38,8 +38,9 @@ namespace ServiceStack.Authentication.OpenId
             var tokens = Init(authService, ref session, request);
 
             var httpReq = authService.RequestContext.Get<IHttpRequest>();
-            var httpMethod = httpReq.HttpMethod;
-            if (httpMethod == HttpMethods.Post)
+            var isOpenIdRequest = !httpReq.GetParam("openid.mode").IsNullOrEmpty();
+
+            if (!isOpenIdRequest)
             {
                 var openIdUrl = httpReq.GetParam("OpenIdUrl") ?? base.AuthRealm;
                 if (openIdUrl.IsNullOrEmpty())
@@ -80,7 +81,7 @@ namespace ServiceStack.Authentication.OpenId
                 }
             }
 
-            if (httpMethod == HttpMethods.Get)
+            if (isOpenIdRequest)
             {
                 using (var openid = new OpenIdRelyingParty())
                 {

--- a/tests/ServiceStack.WebHost.IntegrationTests/Default.aspx
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Default.aspx
@@ -194,6 +194,13 @@
 				<button class="btn" type="submit">Sign In with Google OpenId</button>
 			</p>
         </form>
+
+        <form action="api/auth/OpenId" method="POST">
+            <p>
+                <input type="text" name="OpenIdUrl" placeholder="e.g. http://{user}.myopenid.com"/>
+				<button class="btn" type="submit">Sign In with OpenId</button>
+			</p>
+        </form>
     
         <form action="api/auth/credentials" method="POST">
             <div>

--- a/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
@@ -138,6 +138,7 @@ namespace ServiceStack.WebHost.IntegrationTests
 						new FacebookAuthProvider(appSettings), 
 						new TwitterAuthProvider(appSettings), 
                         new GoogleOpenIdOAuthProvider(appSettings), 
+                        new OpenIdOAuthProvider(appSettings), 
                         new DigestAuthProvider(appSettings),
 						new BasicAuthProvider(appSettings), 
 					}));


### PR DESCRIPTION
OpenID authentication responses from an OpenID Provider (OP) can not only come via HTTP Redirect/GET (e.g. Google), but also via HTML FORM Redirection/POST (e.g. myopenid.com), which the current implementation does not support.

This update changes the decision criteria of whether a request is coming from an OP or not to testing for the presence of the parameter "openid.mode", which is a required filed for [all OpenID HTTP messages](https://openid.net/specs/openid-authentication-2_0.html#http_encoding). (Not using "openid.ns" because it is not present in OpenID 1.1.)

See also https://openid.net/specs/openid-authentication-2_0.html
