### PR TITLE
ServiceStack.Api.Swagger: Fixed problem with differences in letter case

### DIFF
--- a/src/ServiceStack.Api.Swagger/ServiceStack.Api.Swagger.csproj
+++ b/src/ServiceStack.Api.Swagger/ServiceStack.Api.Swagger.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -1,49 +1,75 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using ServiceStack.ServiceHost;
 using ServiceStack.WebHost.Endpoints;
 
 namespace ServiceStack.Api.Swagger
 {
+    [DataContract]
     public class ResourceRequest
     {
+        [DataMember(Name = "apiKey")]
         public string ApiKey { get; set; }
+        [DataMember(Name = "name")]
         public string Name { get; set; }
     }
 
+    [DataContract]
     public class ResourceResponse
     {
+        [DataMember(Name = "apiVersion")]
         public string ApiVersion { get; set; }
+        [DataMember(Name = "basePath")]
         public string BasePath { get; set; }
+        [DataMember(Name = "resourcePath")]
         public string ResourcePath { get; set; }
+        [DataMember(Name = "apis")]
         public List<MethodDescription> Apis { get; set; }
     }
 
+    [DataContract]
     public class MethodDescription
     {
+        [DataMember(Name = "path")]
         public string Path { get; set; }
+        [DataMember(Name = "description")]
         public string Description { get; set; }
+        [DataMember(Name = "operations")]
         public List<MethodOperation> Operations { get; set; }
     }
 
+    [DataContract]
     public class MethodOperation
     {
+        [DataMember(Name = "httpMethod")]
         public string HttpMethod { get; set; }
+        [DataMember(Name = "nickname")]
         public string Nickname { get; set; }
+        [DataMember(Name = "summary")]
         public string Summary { get; set; }
+        [DataMember(Name = "notes")]
         public string Notes { get; set; }
+        [DataMember(Name = "parameters")]
         public List<MethodOperationParameter> Parameters { get; set; }
     }
 
+    [DataContract]
     public class MethodOperationParameter
     {
+        [DataMember(Name = "name")]
         public string Name { get; set; }
+        [DataMember(Name = "description")]
         public string Description { get; set; }
+        [DataMember(Name = "paramType")]
         public string ParamType { get; set; }
+        [DataMember(Name = "allowMultiple")]
         public bool AllowMultiple { get; set; }
+        [DataMember(Name = "required")]
         public bool Required { get; set; }
+        [DataMember(Name = "dataType")]
         public string DataType { get; set; }
     }
 

--- a/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
@@ -1,28 +1,39 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using ServiceStack.ServiceHost;
 using ServiceStack.WebHost.Endpoints;
 
 namespace ServiceStack.Api.Swagger
 {
+    [DataContract]
     public class Resources
     {
+        [DataMember(Name = "apiKey")]
         public string ApiKey { get; set; }
     }
 
+    [DataContract]
     public class ResourcesResponse
     {
+        [DataMember(Name = "swaggerVersion")]
         public string SwaggerVersion { get; set; }
+        [DataMember(Name = "apiVersion")]
         public string ApiVersion { get; set; }
+        [DataMember(Name = "basePath")]
         public string BasePath { get; set; }
+        [DataMember(Name = "apis")]
         public List<RestService> Apis { get; set; }
     }
 
+    [DataContract]
     public class RestService
     {
+        [DataMember(Name = "path")]
         public string Path { get; set; }
+        [DataMember(Name = "description")]
         public string Description { get; set; }
     }
 


### PR DESCRIPTION
Without JsConfig.EmitCamelCaseNames = true;
/api/resources
Rest: the first letter is big.
JS expect: the first letter of a small
