### PR TITLE
Update src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.ServiceClient.Web
         internal static void AddBasicAuth(this WebRequest client, string userName, string password)
         {
             client.Headers[HttpHeaders.Authorization]
-                = "basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + password));
+                = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + password));
         }
 
         /// <summary>


### PR DESCRIPTION
In AddBasicAuth, changed the lowercase "basic " to have an uppercase "Basic ".  A lower case basic will result in an an 401 reply even if the correct credentials are supplied.
