### PR TITLE
Fix for including query params when calculating oAuth Signature (Get Request Token)

### DIFF
--- a/src/ServiceStack.ServiceInterface/Auth/OAuthAuthorizer.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/OAuthAuthorizer.cs
@@ -142,7 +142,19 @@ namespace ServiceStack.ServiceInterface.Auth
                 { "oauth_timestamp", MakeTimestamp () },
                 { "oauth_version", "1.0" }};
 
-            string signature = MakeSignature("POST", provider.RequestTokenUrl, headers);
+            var uri = new Uri(provider.RequestTokenUrl);
+
+            var signatureHeaders = new Dictionary<string, string>(headers);
+
+            var nvc = HttpUtility.ParseQueryString(uri.Query);
+            foreach (string key in nvc)
+            {
+                if (key != null)
+                    signatureHeaders.Add(key, OAuthUtils.PercentEncode(nvc[key]));
+            }
+
+          
+            string signature = MakeSignature("POST", uri.GetLeftPart(UriPartial.Path), signatureHeaders);
             string compositeSigningKey = MakeSigningKey(provider.ConsumerSecret, null);
             string oauth_signature = MakeOAuthSignature(compositeSigningKey, signature);
 


### PR DESCRIPTION
This allowed me to handle optional query params when getting request for LinkedIn.

https://api.linkedin.com/uas/oauth/requestToken?scope=r_basicprofile+r_emailaddress
