### PR TITLE
Pull request for #432

### DIFF
--- a/src/ServiceStack.Interfaces/ServiceHost/IHttpRequest.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/IHttpRequest.cs
@@ -75,6 +75,16 @@ namespace ServiceStack.ServiceHost
         string RemoteIp { get; }
 
         /// <summary>
+        /// The value of the X-Forwarded-For header, null if null or empty
+        /// </summary>
+        string XForwardedFor { get; }
+
+        /// <summary>
+        /// The value of the X-Real-IP header, null if null or empty
+        /// </summary>
+        string XRealIp { get; }
+
+        /// <summary>
         /// e.g. is https or not
         /// </summary>
         bool IsSecureConnection { get; }

--- a/src/ServiceStack.ServiceInterface/Testing/MockHttpRequest.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/MockHttpRequest.cs
@@ -96,6 +96,8 @@ namespace ServiceStack.ServiceInterface.Testing
         public string UserHostAddress { get; set; }
 
         public string RemoteIp { get; set; }
+        public string XForwardedFor { get; set; }
+        public string XRealIp { get; set; }
 
         public bool IsSecureConnection { get; set; }
         public string[] AcceptTypes { get; set; }

--- a/src/ServiceStack/ServiceHost/MqRequest.cs
+++ b/src/ServiceStack/ServiceHost/MqRequest.cs
@@ -108,6 +108,17 @@ namespace ServiceStack.ServiceHost
             get { return null; }
         }
 
+        public string XForwardedFor
+        {
+            get { return null; }
+        }
+
+        public string XRealIp 
+        {
+            get { return null; }
+        }
+
+
         public bool IsSecureConnection
         {
             get { return false; }

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpListenerRequestWrapper.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpListenerRequestWrapper.cs
@@ -118,12 +118,28 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
             get { return request.UserHostAddress; }
         }
 
+	    public string XForwardedFor
+	    {
+	        get
+	        {
+	            return string.IsNullOrEmpty(request.Headers[HttpHeaders.XForwardedFor]) ? null : request.Headers[HttpHeaders.XForwardedFor];
+	        }
+	    }
+
+        public string XRealIp
+        {
+            get
+            {
+                return string.IsNullOrEmpty(request.Headers[HttpHeaders.XRealIp]) ? null : request.Headers[HttpHeaders.XRealIp];
+            }
+        }
+
         private string remoteIp;
         public string RemoteIp
         {
             get
             {
-                return remoteIp ?? (remoteIp = request.Headers[HttpHeaders.XForwardedFor] ?? (request.Headers[HttpHeaders.XRealIp] ?? request.UserHostAddress));
+                return remoteIp ?? (remoteIp = XForwardedFor ?? (XRealIp ?? request.UserHostAddress));
             }
         }
 

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestWrapper.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestWrapper.cs
@@ -184,12 +184,28 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
             get { return request.UserHostAddress; }
         }
 
+        public string XForwardedFor
+        {
+            get
+            {
+                return string.IsNullOrEmpty(request.Headers[HttpHeaders.XForwardedFor]) ? null : request.Headers[HttpHeaders.XForwardedFor];
+            }
+        }
+
+        public string XRealIp
+        {
+            get
+            {
+                return string.IsNullOrEmpty(request.Headers[HttpHeaders.XRealIp]) ? null : request.Headers[HttpHeaders.XRealIp];
+            }
+        }
+
         private string remoteIp;
         public string RemoteIp
         {
             get
             {
-                return remoteIp ?? (remoteIp = request.Headers[HttpHeaders.XForwardedFor] ?? (request.Headers[HttpHeaders.XRealIp] ?? request.UserHostAddress));
+                return remoteIp ?? (remoteIp = XForwardedFor ?? (XRealIp ?? request.UserHostAddress));
             }
         }
 

--- a/src/ServiceStack/WebHost.Endpoints/Support/Mocks/HttpRequestMock.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Mocks/HttpRequestMock.cs
@@ -91,6 +91,8 @@ namespace ServiceStack.WebHost.Endpoints.Support.Mocks
 		public string UserHostAddress { get; set; }
 
         public string RemoteIp { get; set; }
+        public string XForwardedFor { get; set; }
+        public string XRealIp { get; set; }
 
 	    public bool IsSecureConnection { get; set; }
 		public string[] AcceptTypes { get; set; }

--- a/tests/ServiceStack.ServiceHost.Tests/HttpRequestMock.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/HttpRequestMock.cs
@@ -97,6 +97,16 @@ namespace ServiceStack.ServiceHost.Tests
 			get { throw new NotImplementedException(); }
 		}
 
+        public string XForwardedFor
+        {
+            get { throw new NotImplementedException(); }
+        }
+        
+        public string XRealIp
+        {
+            get { throw new NotImplementedException(); }
+        }
+
 		public bool IsSecureConnection
 		{
 			get { throw new NotImplementedException(); }

--- a/tests/ServiceStack.ServiceHost.Tests/ServiceStackHandlerUrlTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/ServiceStackHandlerUrlTests.cs
@@ -62,6 +62,8 @@ namespace ServiceStack.ServiceHost.Tests
 			public string UserHostAddress { get; private set; }
 
             public string RemoteIp { get; set; }
+            public string XForwardedFor { get; set; }
+            public string XRealIp { get; set; }
 
 		    public bool IsSecureConnection { get; private set; }
 			public string[] AcceptTypes { get; private set; }


### PR DESCRIPTION
Corrected an issue with the RemoteIp property, that would report string.Empty if a string.Empty was returned from either of the mentioned headers

I took the liberty of adding two properties to represent the referenced headers, as they are commonly used. Hopefully this is OK.

I also didn't see any test cases around evaluation of the RemoteIp property, which I'd be happy to add if you'd like.
