### PR TITLE
Update src/ServiceStack/Funq/AutoWireHelpers.cs

### DIFF
--- a/src/ServiceStack/Funq/AutoWireHelpers.cs
+++ b/src/ServiceStack/Funq/AutoWireHelpers.cs
@@ -26,7 +26,7 @@ namespace Funq
         {
             return type.GetConstructors()
                 .OrderByDescending(x => x.GetParameters().Length)
-                .First(ctor => !ctor.IsStatic);
+                .FirstOrDefault(ctor => !ctor.IsStatic);
         }
 
         /// <summary>


### PR DESCRIPTION
If I have BaseController class inherited from ServiceStackController and this BaseController class has constructors, Funq registration in AppHost fails during runtime.  Getting below exception.  Suggesting a change from ".First" to ".FirstOrDefault":

[InvalidOperationException: Sequence contains no matching element]
   System.Linq.Enumerable.First(IEnumerable`1 source, Func`2 predicate) +2538402
   Funq.AutoWireHelpers.GetConstructorWithMostParams(Type type) +201
   Funq.AutoWireHelpers.ConstrcutorExpression(MethodInfo resolveMethodInfo, Type type, Expression lambdaParam) +49
   Funq.AutoWireHelpers.GenerateAutoWireFn() +359
   Funq.Container.RegisterAutoWired() +43
