### PR TITLE
DeleteCookie should flow through the same path as AddCookie

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -43,9 +43,10 @@ namespace ServiceStack.ServiceHost
 		/// </summary>
 		public void DeleteCookie(string cookieName)
 		{
-			var cookie = String.Format("{0}=;expires={1};path=/",
-				cookieName, DateTime.UtcNow.AddDays(-1).ToString("R"));
-			httpRes.AddHeader(HttpHeaders.SetCookie, cookie);
+			var cookie = new Cookie(cookieName, string.Empty, "/") {
+				Expires = DateTime.UtcNow.AddDays(-1)
+			};
+			AddCookie(cookie);
 		}
 
 		public HttpCookie ToHttpCookie(Cookie cookie)


### PR DESCRIPTION
This allows the expired cookie to get the correct domain value from
configuration at system.web/httpCookies
