### PR TITLE
Exposed protobuf RuntimeTypeModel as public

### DIFF
--- a/src/ServiceStack.Plugins.ProtoBuf/ProtoBufFormat.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/ProtoBufFormat.cs
@@ -1,5 +1,9 @@
-﻿using ProtoBuf;
+﻿using System;
+using System.IO;
+using ProtoBuf;
+using ProtoBuf.Meta;
 using ServiceStack.Common.Web;
+using ServiceStack.ServiceHost;
 using ServiceStack.WebHost.Endpoints;
 
 namespace ServiceStack.Plugins.ProtoBuf
@@ -8,9 +12,25 @@ namespace ServiceStack.Plugins.ProtoBuf
 	{
 		public void Register(IAppHost appHost)
 		{
-			appHost.ContentTypeFilters.Register(ContentType.ProtoBuf,
-				(reqCtx, res, stream) => Serializer.NonGeneric.Serialize(stream, res),
-				Serializer.NonGeneric.Deserialize);
+		    appHost.ContentTypeFilters.Register(ContentType.ProtoBuf, Serialize, Deserialize);
 		}
+
+	    private static RuntimeTypeModel model;
+
+        public static RuntimeTypeModel Model
+        {
+            get { return model ?? (model = TypeModel.Create()); }
+        }
+
+        public static void Serialize(IRequestContext requestContext, object dto, Stream outputStream)
+        {
+            Model.Serialize(outputStream, dto);
+        }
+
+	    public static object Deserialize(Type type, Stream fromStream)
+	    {
+	        var obj = Model.Deserialize(fromStream, null, type);
+	        return obj;
+	    }
 	}
 }


### PR DESCRIPTION
Public static _RuntimeTypeModel_ allows the developer to use precompilation of types and set
things like _UseImplicitZeroDefaults_. Up till now we were using _Serialize.NonGeneric_ which defaults to _RuntimeTypeModel.Default_ which is a bit limiting.

For example:

```
ProtoBufFormat.Model.UseImplicitZeroDefaults = false;
ProtoBufFormat.Model.Add(typeof(MyType),false);
ProtoBufFormat.Model.Compile();
```
