### PR TITLE
Remove useless quotes from ToUrl

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
@@ -142,7 +142,7 @@ namespace ServiceStack.ServiceClient.Web
 
     public class RestRoute
     {
-        private static readonly char[] ArrayBrackets = new[] { '[', ']' };
+        private static readonly char[] ArrayBrackets = new[] { '[', ']', '"' };
 
         private static string FormatValue(object value)
         {


### PR DESCRIPTION
When the object serialization contains non JSV values (like ':') JSV add quotes.
Since ToUrl use it to create Url, you'll have extra " " when the serializes query containts : ...
