### PR TITLE
Add Container to IAppHost

### DIFF
--- a/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/TestAppHost.cs
@@ -103,5 +103,7 @@ namespace ServiceStack.ServiceInterface.Testing
         {
             throw new NotImplementedException();
         }
+
+        public Container Container { get; set; }
     }
 }

--- a/src/ServiceStack/WebHost.Endpoints/IAppHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/IAppHost.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Funq;
 using ServiceStack.Html;
 using ServiceStack.IO;
 using ServiceStack.ServiceHost;
@@ -120,6 +121,11 @@ namespace ServiceStack.WebHost.Endpoints
         /// Create a service runner for IService actions
         /// </summary>
 	    IServiceRunner<TRequest> CreateServiceRunner<TRequest>(ActionContext actionContext);
+
+        /// <summary>
+        /// The IOC container for this AppHost
+        /// </summary>
+        Container Container { get; }
 	}
 
 	public interface IHasAppHost

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/ViewTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Funq;
 using NUnit.Framework;
 using ServiceStack.Common.Utils;
 using ServiceStack.Common.Web;
@@ -120,6 +121,8 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 		    {
 		        throw new NotImplementedException();
 		    }
+
+            public Container Container { get; set; }
 		}
 
 		public string GetHtml(object dto, string format)


### PR DESCRIPTION
In writing plugins that modify the IOC container heavily, I became annoyed that the container is not a member of `IApphost`, so it is a bit of a pain to access in the plugin's `Register` method. Especially since every implementation of `IAppHost` already exposes a public `Container` property. I simply made that property an official part of the interface for convenience.
