### PR TITLE
Eliminate double TryResolve() in Funq.Container.GetEntry()

### DIFF
--- a/src/ServiceStack/Funq/Container.cs
+++ b/src/ServiceStack/Funq/Container.cs
@@ -308,13 +308,14 @@ namespace Funq
         {
             try
             {
+                TService resolved;
                 if (CheckAdapterFirst
                     && Adapter != null
                     && typeof(TService) != typeof(IRequestContext)
-                    && !Equals(default(TService), Adapter.TryResolve<TService>()))
+                    && !Equals(default(TService), (resolved = Adapter.TryResolve<TService>())))
                 {
                     return new ServiceEntry<TService, TFunc>(
-                        (TFunc)(object)(Func<Container, TService>)(c => Adapter.TryResolve<TService>()))
+                        (TFunc)(object)(Func<Container, TService>)(c => resolved))
                     {
                         Owner = DefaultOwner,
                         Container = this,


### PR DESCRIPTION
When using an adapter for another IoC container, GetEntry() was potentially calling TryResolve() twice. If adapting a WindsorContainer and the service was transient, this was resulting in double instantiation.
