### PR TITLE
Adding Header collection to ServiceClientBase

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -85,6 +87,11 @@ namespace ServiceStack.ServiceClient.Web
             }
         }
 
+        /// <summary>
+        /// Gets the collection of headers to be added to outgoing requests.
+        /// </summary>
+        public NameValueCollection Headers { get; private set; } 
+
         public const string DefaultHttpMethod = "POST";
 
         readonly AsyncServiceClient asyncClient;
@@ -105,6 +112,7 @@ namespace ServiceStack.ServiceClient.Web
                 LocalHttpWebResponseFilter = this.LocalHttpWebResponseFilter
             };
             this.StoreCookies = true; //leave
+            this.Headers = new NameValueCollection();
 
 #if SILVERLIGHT
             asyncClient.HandleCallbackOnUIThread = this.HandleCallbackOnUIThread = true;
@@ -569,6 +577,7 @@ namespace ServiceStack.ServiceClient.Web
             {
                 client.Accept = Accept;
                 client.Method = httpMethod;
+                client.Headers.Add(Headers);
 
                 if (Proxy != null) client.Proxy = Proxy;
                 if (this.Timeout.HasValue) client.Timeout = (int)this.Timeout.Value.TotalMilliseconds;

--- a/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
+++ b/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
@@ -191,6 +191,7 @@
       <DependentUpon>Default.aspx</DependentUpon>
     </Compile>
     <Compile Include="Services\CachedProtoBufEmailService.cs" />
+    <Compile Include="Services\CustomHeadersService.cs" />
     <Compile Include="Services\EndpointAccessService.cs" />
     <Compile Include="Services\HelloImage.cs" />
     <Compile Include="Services\IocServiceTests.cs" />
@@ -202,6 +203,7 @@
       <DependentUpon>Test.aspx</DependentUpon>
     </Compile>
     <Compile Include="Tests\BinarySerializedTests.cs" />
+    <Compile Include="Tests\CustomHeadersTests.cs" />
     <Compile Include="Tests\ExceptionHandlingTests.cs" />
     <Compile Include="Tests\ProtoBufServiceTests.cs" />
     <Compile Include="Services\ContentManagerOnly.cs" />

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/CustomHeadersService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/CustomHeadersService.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.Serialization;
+using ServiceStack.ServiceHost;
+
+namespace ServiceStack.WebHost.IntegrationTests.Services
+{
+    [Route("/customHeaders")]
+    [DataContract]
+    public class CustomHeaders : IReturn<CustomHeadersResponse>
+    { }
+
+    [DataContract]
+    public class CustomHeadersResponse
+    {
+        [DataMember(Order = 1)]
+        public string Foo { get; set; }
+        [DataMember(Order = 2)]
+        public string Bar { get; set; }
+    }
+
+    public class CustomHeadersService : ServiceInterface.Service
+    {
+        public CustomHeadersResponse Any(CustomHeaders c)
+        {
+            var response = new CustomHeadersResponse
+                {
+                    Foo = Request.Headers["Foo"], 
+                    Bar = Request.Headers["Bar"]
+                };
+            return response;
+        }
+
+    }
+}

--- a/tests/ServiceStack.WebHost.IntegrationTests/Tests/CustomHeadersTests.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Tests/CustomHeadersTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using ServiceStack.Plugins.ProtoBuf;
+using ServiceStack.ServiceClient.Web;
+using ServiceStack.WebHost.IntegrationTests.Services;
+
+namespace ServiceStack.WebHost.IntegrationTests.Tests
+{
+    [TestFixture]
+    public class CustomHeadersTests
+    {
+        [Test]
+        public void GetRequest()
+        {
+            var client = new JsonServiceClient(Config.ServiceStackBaseUri);
+            client.Headers.Add("Foo","abc123");
+            var response = client.Get(new CustomHeaders());
+            Assert.That(response.Foo, Is.EqualTo("abc123"));
+            Assert.That(response.Bar, Is.Null);
+        }
+
+        [Test]
+        public void PostRequest()
+        {
+            var client = new XmlServiceClient(Config.ServiceStackBaseUri);
+            client.Headers.Add("Bar", "abc123");
+            client.Headers.Add("Foo", "xyz");
+            var response = client.Post(new CustomHeaders());
+            Assert.That(response.Bar, Is.EqualTo("abc123"));
+            Assert.That(response.Foo, Is.EqualTo("xyz"));
+        }
+
+        [Test]
+        public void Delete()
+        {
+            var client = new ProtoBufServiceClient(Config.ServiceStackBaseUri);
+            client.Headers.Add("Bar", "abc123");
+            client.Headers.Add("Foo", "xyz");
+            var response = client.Delete(new CustomHeaders());
+            Assert.That(response.Bar, Is.EqualTo("abc123"));
+            Assert.That(response.Foo, Is.EqualTo("xyz"));
+        }
+    }
+}


### PR DESCRIPTION
This old forum post details a need for attaching custom http headers to an outgoing request: 

https://groups.google.com/forum/?fromgroups=#!topic/servicestack/VJzJafUvgfY

As that thread seems to have been abandoned, I implemented a headers collection on `ServiceClientBase` and added some integration tests.
