### PR TITLE
Fix for NullReferenceException if /auth/logout is entered into the browser directly

### DIFF
--- a/src/ServiceStack.ServiceInterface/Auth/AuthProvider.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/AuthProvider.cs
@@ -52,7 +52,7 @@ namespace ServiceStack.ServiceInterface.Auth
 
             service.RemoveSession();
 
-            if (service.RequestContext.ResponseContentType == ContentType.Html)
+            if (service.RequestContext.ResponseContentType == ContentType.Html && !String.IsNullOrEmpty(referrerUrl))
                 return service.Redirect(referrerUrl.AddHashParam("s", "-1"));
 
             return new AuthResponse();


### PR DESCRIPTION
Perhaps a trivial thing, but I was experimenting with the authentication support, and went to log out by accessing /auth/logout in the browser directly. The result was a NullReferenceException, and it took me a bit to discover what the problem was. Simple fix is to not redirect if there is no redirect URL available. (In reality, a redirect should always be available or specified - at least as a workaround to this issue.)
