### PR TITLE
Added AlwaysSendAuthHeader support to the async client methods.

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
@@ -48,6 +48,8 @@ namespace ServiceStack.ServiceClient.Web
 
         public ICredentials Credentials { get; set; }
 
+        public bool AlwaysSendBasicAuthHeader { get; set; }
+
         public bool StoreCookies { get; set; }
 
         public CookieContainer CookieContainer { get; set; }
@@ -362,10 +364,8 @@ namespace ServiceStack.ServiceClient.Web
             }
 #endif
 
-            if (this.Credentials != null)
-            {
-                webRequest.Credentials = this.Credentials;
-            }
+            if (this.Credentials != null) webRequest.Credentials = this.Credentials;
+            if (this.AlwaysSendBasicAuthHeader) webRequest.AddBasicAuth(this.UserName, this.Password);
 
             ApplyWebRequestFilters(webRequest);
 

--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -291,8 +291,12 @@ namespace ServiceStack.ServiceClient.Web
         /// Determines if the basic auth header should be sent with every request.
         /// By default, the basic auth header is only sent when "401 Unauthorized" is returned.
         /// </summary>
-        public bool AlwaysSendBasicAuthHeader { get; set; }
-
+        private bool alwaysSendBasicAuthHeader;
+        public bool AlwaysSendBasicAuthHeader
+        {
+            get { return alwaysSendBasicAuthHeader; }
+            set { asyncClient.AlwaysSendBasicAuthHeader = alwaysSendBasicAuthHeader = value;}
+        }
 
         /// <summary>
         /// Specifies if cookies should be stored


### PR DESCRIPTION
I just followed the same pattern as other properties, copying the value from ServiceClientBase to the inner AsyncServiceClient.
