### PR TITLE
Add ReadWriteTimeout property to ServiceClientBase

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -232,6 +232,18 @@ namespace ServiceStack.ServiceClient.Web
                 this.asyncClient.Timeout = value;
             }
         }
+        
+        private TimeSpan? readWriteTimeout;
+    	public TimeSpan? ReadWriteTimeout
+		{
+			get { return this.readWriteTimeout; }
+			set
+			{
+				this.readWriteTimeout = value;
+                // TODO implement ReadWriteTimeout in asyncClient
+				//this.asyncClient.ReadWriteTimeout = value;
+			}
+		}
 
         public virtual string Accept
         {
@@ -590,6 +602,7 @@ namespace ServiceStack.ServiceClient.Web
 
                 if (Proxy != null) client.Proxy = Proxy;
                 if (this.Timeout.HasValue) client.Timeout = (int)this.Timeout.Value.TotalMilliseconds;
+                if (this.ReadWriteTimeout.HasValue) client.ReadWriteTimeout = (int)this.ReadWriteTimeout.Value.TotalMilliseconds;
                 if (this.credentials != null) client.Credentials = this.credentials;
                 if (this.AlwaysSendBasicAuthHeader) client.AddBasicAuth(this.UserName, this.Password);
 


### PR DESCRIPTION
I added the TimeSpan? ReadWriteTimeout property to ServiceClientBase class to support two different timeout values as HttpWebRequest does.
(The other one is the Timeout property that is already implemented)

The HttpWebRequest.Timeout is the timeout to reach the HTTP server and the ReadWriteTimeout is the additional timeout value to get the response data.

By having this two different timeouts, you can (for example) set the .Timeout to 5000 and .ReadWriteTimeout to a much larger timeout value if you want to download a lot of data and if the url is wrong, or the server is down, you don't have to wait till the long timeout happens.
