### PR TITLE
Eliminate default member values from route query

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/RouteMember.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/RouteMember.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using ServiceStack.Text;
 
 namespace ServiceStack.ServiceClient.Web
 {
@@ -18,7 +19,9 @@ namespace ServiceStack.ServiceClient.Web
 
 		public override object GetValue(object target)
 		{
-			return field.GetValue(target);
+			var v = field.GetValue(target);
+			if (Equals(v, field.FieldType.GetDefaultValue())) return null;
+			return v;
 		}
 	}
 
@@ -33,7 +36,9 @@ namespace ServiceStack.ServiceClient.Web
 
 		public override object GetValue(object target)
 		{
-			return property.GetValue(target, null);
+			var v = property.GetValue(target, null);
+			if (Equals(v, property.PropertyType.GetDefaultValue())) return null;
+			return v;
 		}
 	}
 }


### PR DESCRIPTION
Generating a route from a request DTO currently produces redundant
parameters for value types that are equal to their default value.

This change modifies RouteMember so that it only returns a non-null value to be
contributed to the route if the current value is not equal to that type's
default value.

So previously:

``` c#
public enum GenderKey
{
    None = 0,
    Male,
    Female
}

[Route("/clients/{Id}", "GET")]
public class ClientResource
{
    public int Id { get; set; }
    public GenderKey Gender { get; set; }
}
```

Might have generated a request like:
`GET /clients/25?gender=None`

With this change it will now generate:
`GET /clients/25`
