### PR TITLE
Fix commented auth code in AppHost.cs.pp

### DIFF
--- a/NuGet/ServiceStack.Host.AspNet/content/App_Start/AppHost.cs.pp
+++ b/NuGet/ServiceStack.Host.AspNet/content/App_Start/AppHost.cs.pp
@@ -54,7 +54,7 @@ namespace $rootnamespace$.App_Start
 			var appSettings = new AppSettings();
 
 			//Default route: /auth/{provider}
-			Plugins.Add(new AuthFeature(this, () => new CustomUserSession(),
+			Plugins.Add(new AuthFeature(() => new CustomUserSession(),
 				new IAuthProvider[] {
 					new CredentialsAuthProvider(appSettings), 
 					new FacebookAuthProvider(appSettings), 

--- a/NuGet/ServiceStack.Host.Mvc/content/App_Start/AppHost.cs.pp
+++ b/NuGet/ServiceStack.Host.Mvc/content/App_Start/AppHost.cs.pp
@@ -70,7 +70,7 @@ namespace $rootnamespace$.App_Start
 			var appSettings = new AppSettings();
 
 			//Default route: /auth/{provider}
-			Plugins.Add(new AuthFeature(this, () => new CustomUserSession(),
+			Plugins.Add(new AuthFeature(() => new CustomUserSession(),
 				new IAuthProvider[] {
 					new CredentialsAuthProvider(appSettings), 
 					new FacebookAuthProvider(appSettings), 


### PR DESCRIPTION
Constructor of `AuthFeature` has only two parameters, so the commented code in `AppHost.cs.pp` (both for the ASP.NET and MVC NuGet packages) will not build if uncommented as it has three parameters.
