### PR TITLE
TextBoxFor generates valid id attribute and LabelFor references it

### DIFF
--- a/src/ServiceStack.sln
+++ b/src/ServiceStack.sln
@@ -60,6 +60,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Authentication
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Api.Swagger", "ServiceStack.Api.Swagger\ServiceStack.Api.Swagger.csproj", "{01D3F057-7984-498F-8B0A-EB375701E204}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Tests", "..\tests\ServiceStack.Tests\ServiceStack.Tests.csproj", "{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -624,6 +626,31 @@ Global
 		{01D3F057-7984-498F-8B0A-EB375701E204}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{01D3F057-7984-498F-8B0A-EB375701E204}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{01D3F057-7984-498F-8B0A-EB375701E204}.Release|x86.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoDebug|Any CPU.Build.0 = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoDebug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoDebug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoDebug|x86.ActiveCfg = Debug|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoRelease|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoRelease|Mixed Platforms.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoRelease|x86.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoTouch|Any CPU.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoTouch|Any CPU.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoTouch|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoTouch|Mixed Platforms.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.MonoTouch|x86.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -640,6 +667,7 @@ Global
 		{B7F650D2-6D7E-48BE-ADCE-19076249B3B7} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{1A5796C5-8AB6-4676-AC20-83594AED1798} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{F35A169D-E832-4EA3-A2F0-61C091F3DCD9} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
+		{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = ..\tests\RazorRockstars.Console\RazorRockstars.Console.csproj

--- a/src/ServiceStack/Html/InputExtensions.cs
+++ b/src/ServiceStack/Html/InputExtensions.cs
@@ -409,6 +409,10 @@ namespace ServiceStack.Html
 					break;
 			}
 
+			if (setId) {
+				tagBuilder.GenerateId(fullName);
+			}
+
 			return tagBuilder.ToMvcHtmlString(TagRenderMode.SelfClosing);
 		}
 

--- a/src/ServiceStack/Html/LabelExtensions.cs
+++ b/src/ServiceStack/Html/LabelExtensions.cs
@@ -64,7 +64,7 @@ namespace ServiceStack.Html
 			}
 
 			var tag = new TagBuilder("label");
-			tag.Attributes.Add("for", htmlFieldName);
+			tag.Attributes.Add("for", TagBuilder.CreateSanitizedId(htmlFieldName));
 			tag.SetInnerText(resolvedLabelText);
 			return tag.ToMvcHtmlString(TagRenderMode.Normal);
 		}

--- a/src/ServiceStack/Html/TagBuilder.cs
+++ b/src/ServiceStack/Html/TagBuilder.cs
@@ -99,7 +99,7 @@ namespace ServiceStack.Html
 
 	public class TagBuilder
 	{
-		//private string idAttributeDotReplacement;
+		private const string IdAttributeDotReplacement = "_";
 
 		private const string AttributeFormat = @" {0}=""{1}""";
 		private const string ElementFormatEndTag = "</{0}>";
@@ -150,11 +150,20 @@ namespace ServiceStack.Html
 			}
 		}
 
-		internal static string CreateSanitizedId(string originalId, string dotReplacement)
+		public static string CreateSanitizedId(string originalId)
+		{
+			return CreateSanitizedId(originalId, TagBuilder.IdAttributeDotReplacement);
+		}
+
+		internal static string CreateSanitizedId(string originalId, string invalidCharReplacement)
 		{
 			if (String.IsNullOrEmpty(originalId))
 			{
 				return null;
+			}
+
+			if (invalidCharReplacement == null) {
+				throw new ArgumentNullException("invalidCharReplacement");
 			}
 
 			char firstChar = originalId[0];
@@ -176,11 +185,21 @@ namespace ServiceStack.Html
 				}
 				else
 				{
-					sb.Append(dotReplacement);
+					sb.Append(invalidCharReplacement);
 				}
 			}
 
 			return sb.ToString();
+		}
+
+		public void GenerateId(string name)
+		{
+			if (!Attributes.ContainsKey("id")) {
+				string sanitizedId = CreateSanitizedId(name, IdAttributeDotReplacement);
+				if (!String.IsNullOrEmpty(sanitizedId)) {
+					Attributes["id"] = sanitizedId;
+				}
+			}
 		}
 		
 		private string GetAttributesString()

--- a/tests/ServiceStack.Tests/Html/InputExtensionTests.cs
+++ b/tests/ServiceStack.Tests/Html/InputExtensionTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using ServiceStack.Html;
+using ServiceStack.Tests.Html.Support.Types;
+
+namespace ServiceStack.Tests.Html
+{
+	[TestFixture]
+	public class InputExtensionTests
+	{
+		HtmlHelper<Person> html;
+
+		[SetUp]
+		public void SetUp()
+		{
+			html = new HtmlHelper<Person>();
+		}
+
+		[Test]
+		public void TextBoxFor_ValidModelValue_GeneratesBothNameAndIdAttributes()
+		{
+			MvcHtmlString result = html.TextBoxFor(p => p.First);
+
+			Assert.AreEqual(@"<input id=""First"" name=""First"" type=""text"" value="""" />", result.ToHtmlString());
+		}
+
+		[Test]
+		public void TextBoxFor_NestedProperty_GeneratesNameAttributeWithDotAndIDWithUnderscore()
+		{
+			MvcHtmlString result = html.TextBoxFor(p => p.Home.City);
+
+			Assert.AreEqual(@"<input id=""Home_City"" name=""Home.City"" type=""text"" value="""" />", result.ToHtmlString());
+		}
+	}
+}

--- a/tests/ServiceStack.Tests/Html/LabelExtensionsTests.cs
+++ b/tests/ServiceStack.Tests/Html/LabelExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using ServiceStack.Html;
+using ServiceStack.Tests.Html.Support.Types;
+
+namespace ServiceStack.Tests.Html
+{
+	[TestFixture]
+	public class LabelExtensionsTests
+	{
+		HtmlHelper<Person> html;
+
+		[SetUp]
+		public void SetUp()
+		{
+			html = new HtmlHelper<Person>();
+		}
+
+		[Test]
+		public void LabelFor_SimpleProperty_ForAttributeIsSameAsName()
+		{
+			MvcHtmlString result = html.LabelFor(p => p.First);
+
+			Assert.AreEqual(@"<label for=""First"">First</label>", result.ToHtmlString());
+		}
+
+		[Test]
+		public void LabelFor_NestedProperty_ForAttributeReferencesElementIDWithUnderscores()
+		{
+			MvcHtmlString result = html.LabelFor(p => p.Home.City);
+
+			Assert.AreEqual(@"<label for=""Home_City"">City</label>", result.ToHtmlString());
+		}
+	}
+}

--- a/tests/ServiceStack.Tests/Properties/AssemblyInfo.cs
+++ b/tests/ServiceStack.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceStack.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bc7db2d8-69a7-403f-99f7-3ad8d9e363d7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/ServiceStack.Tests/ServiceStack.Tests.csproj
+++ b/tests/ServiceStack.Tests/ServiceStack.Tests.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{93AEB5A2-C491-4C12-9014-5BBBEB89B6FF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceStack.Tests</RootNamespace>
+    <AssemblyName>ServiceStack.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\lib\tests\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Html\InputExtensionTests.cs" />
+    <Compile Include="Html\LabelExtensionsTests.cs" />
+    <Compile Include="Support\Types\Person.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ServiceStack\ServiceStack.csproj">
+      <Project>{680a1709-25eb-4d52-a87f-ee03ffd94baa}</Project>
+      <Name>ServiceStack</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/ServiceStack.Tests/Support/Types/Person.cs
+++ b/tests/ServiceStack.Tests/Support/Types/Person.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace ServiceStack.Tests.Html.Support.Types
+{
+	class Person
+	{
+		public string First { get; set; }
+		public string Last { get; set; }
+
+		public Address Work { get; set; }
+		public Address Home { get; set; }
+	}
+
+	class Address
+	{
+		public string Street { get; set; }
+		public string StreetNo { get; set; }
+		public string ZIP { get; set; }
+		public string City { get; set; }
+		public string State { get; set; }
+	}
+}


### PR DESCRIPTION
Updated `InputExtensions.InputHelper` and `LabelExtensions.LabelFor` to generate a valid `id`/`for` attribute based on the field name. Copied relevant code lines from System.Web.Mvc source.
Relevant unit tests are included.
Closes #529
