### PR TITLE
GetParams should not fail when `name` is null

### DIFF
--- a/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
+++ b/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
@@ -45,6 +45,10 @@ namespace ServiceStack.ServiceHost
 			if ((value = httpReq.QueryString[name]) != null) return value;
 			if ((value = httpReq.FormData[name]) != null) return value;
 
+            //IIS will assign null to params without a name: .../?some_value can be retrieved as req.Params[null]
+            //TryGetValue is not happy with null dictionary keys, so we should bail out here
+            if (string.IsNullOrEmpty(name)) return null;
+
 			Cookie cookie;
 			if (httpReq.Cookies.TryGetValue(name, out cookie)) return cookie.Value;
 


### PR DESCRIPTION
`Null` is a legal parameter name when calling `Request.QueryString[null]` - `req.GetParam(null)` works correctly when nameless parameters are present (for example `/some_route/?edit`) but otherwise fails as the control falls through to `TryGetValue` calls that do not support `null` keys.

This commit fixes the problem by bailing out before `TryGetValue` calls when `name` parameter is `null`.
