### PR TITLE
Fix a small error in the sample repository code.

### DIFF
--- a/NuGet/ServiceStack.Host.AspNet/content/App_Start/WebServiceExamples.cs.pp
+++ b/NuGet/ServiceStack.Host.AspNet/content/App_Start/WebServiceExamples.cs.pp
@@ -105,8 +105,12 @@ namespace $rootnamespace$
             {
                 var newId = todos.Count > 0 ? todos.Max(x => x.Id) + 1 : 1;
                 todo.Id = newId;
+                todos.Add(todo);
             }
-            todos.Add(todo);
+            else
+            {
+                existing.PopulateWith(todo);
+            }
             return todo;
         }
 

--- a/NuGet/ServiceStack.Host.Mvc/content/App_Start/WebServiceExamples.cs.pp
+++ b/NuGet/ServiceStack.Host.Mvc/content/App_Start/WebServiceExamples.cs.pp
@@ -105,8 +105,12 @@ namespace $rootnamespace$
             {
                 var newId = todos.Count > 0 ? todos.Max(x => x.Id) + 1 : 1;
                 todo.Id = newId;
+                todos.Add(todo);
             }
-            todos.Add(todo);
+            else
+            {
+                existing.PopulateWith(todo);
+            }
             return todo;
         }
 


### PR DESCRIPTION
TodoRepository.Store(): modifying an object added another copy of that object to the repository, instead of updating the existing one.
