### PR TITLE
Fixed WinRT build

### DIFF
--- a/src/ServiceStack.Common.WinRT/ServiceStack.Common.WinRT.csproj
+++ b/src/ServiceStack.Common.WinRT/ServiceStack.Common.WinRT.csproj
@@ -159,9 +159,6 @@
     <Compile Include="..\servicestack.common\extensions\ITranslatorExtensions.cs">
       <Link>Extensions\ITranslatorExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\servicestack.common\extensions\ReflectionExtensions.cs">
-      <Link>Extensions\ReflectionExtensions.cs</Link>
-    </Compile>
     <Compile Include="..\servicestack.common\extensions\StringExtensions.cs">
       <Link>Extensions\StringExtensions.cs</Link>
     </Compile>

--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
@@ -6,12 +6,16 @@ using ServiceStack.Common.Web;
 using ServiceStack.ServiceHost;
 using ServiceStack.ServiceInterface.ServiceModel;
 using ServiceStack.Text;
-using System.Security.Cryptography;
 using ServiceStack.Logging;
-
+#if !NETFX_CORE
+using System.Security.Cryptography;
+#endif
 
 #if NETFX_CORE
 using System.Net.Http.Headers;
+using Windows.Security.Cryptography;
+using Windows.Security.Cryptography.Core;
+using Windows.Storage.Streams;
 #endif
 
 namespace ServiceStack.ServiceClient.Web
@@ -136,6 +140,18 @@ namespace ServiceStack.ServiceClient.Web
                 = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + password));
         }
 
+        #if NETFX_CORE
+        internal static string CalculateMD5Hash(string input)
+        {
+            var alg = HashAlgorithmProvider.OpenAlgorithm("MD5");
+            IBuffer buff = CryptographicBuffer.ConvertStringToBinary(input, BinaryStringEncoding.Utf8);
+            var hashed = alg.HashData(buff);
+            var res = CryptographicBuffer.EncodeToHexString(hashed);
+            return res.ToLower();
+        }
+        #endif
+
+        #if !NETFX_CORE
 		internal static string CalculateMD5Hash(string input)
 		{
 			// copied/pasted by adamfowleruk
@@ -152,8 +168,9 @@ namespace ServiceStack.ServiceClient.Web
 			}
 			return sb.ToString().ToLower(); // The RFC requires the hex values are lowercase
 		}
+        #endif
 
-		internal static string padNC(int num) 
+        internal static string padNC(int num) 
 		{
 			// by adamfowleruk
 			var pad = "";


### PR DESCRIPTION
MD5 WinRT implementation added with NETFX_CORE directive and Link to "..\servicestack.common\extensions\ReflectionExtensions.cs" removed because no more available
