### PR TITLE
Ensure default values are included in explicit routes

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/RouteMember.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/RouteMember.cs
@@ -5,7 +5,7 @@ namespace ServiceStack.ServiceClient.Web
 {
 	internal abstract class RouteMember
 	{
-		public abstract object GetValue(object target);
+		public abstract object GetValue(object target, bool excludeDefault);
 	}
 
 	internal class FieldRouteMember : RouteMember
@@ -17,10 +17,10 @@ namespace ServiceStack.ServiceClient.Web
 			this.field = field;
 		}
 
-		public override object GetValue(object target)
+		public override object GetValue(object target, bool excludeDefault)
 		{
 			var v = field.GetValue(target);
-			if (Equals(v, field.FieldType.GetDefaultValue())) return null;
+			if (excludeDefault && Equals(v, field.FieldType.GetDefaultValue())) return null;
 			return v;
 		}
 	}
@@ -34,10 +34,10 @@ namespace ServiceStack.ServiceClient.Web
 			this.property = property;
 		}
 
-		public override object GetValue(object target)
+		public override object GetValue(object target, bool excludeDefault)
 		{
 			var v = property.GetValue(target, null);
-			if (Equals(v, property.PropertyType.GetDefaultValue())) return null;
+			if (excludeDefault && Equals(v, property.PropertyType.GetDefaultValue())) return null;
 			return v;
 		}
 	}

--- a/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
@@ -246,7 +246,7 @@ namespace ServiceStack.ServiceClient.Web
             foreach (var variable in this.variablesMap)
             {
                 var property = variable.Value;
-                var value = property.GetValue(request);
+                var value = property.GetValue(request, false);
                 if (value == null)
                 {
                     unmatchedVariables.Add(variable.Key);
@@ -277,7 +277,7 @@ namespace ServiceStack.ServiceClient.Web
 
             foreach (var queryProperty in propertyMap)
             {
-                var value = queryProperty.Value.GetValue(request);
+                var value = queryProperty.Value.GetValue(request, true);
                 if (value == null)
                 {
                     continue;

--- a/tests/ServiceStack.Common.Tests/UrlExtensionTests.cs
+++ b/tests/ServiceStack.Common.Tests/UrlExtensionTests.cs
@@ -172,5 +172,13 @@ namespace ServiceStack.Common.Tests
 			var url = new RequestWithValueTypes { Id = 1, Gender2 = Gender.Male }.ToUrl("GET");
 			Assert.That(url, Is.EqualTo("/route/1?gender2=Male"));
 		}
+
+
+		[Test]
+		public void Can_use_default_for_non_nullable_value_types_on_path()
+		{
+			var url = new RequestWithValueTypes { Id = 0 }.ToUrl("GET");
+			Assert.That(url, Is.EqualTo("/route/0"));
+		}
 	}
 }


### PR DESCRIPTION
Address the issue identified in
http://stackoverflow.com/q/15650973/246811 where routes would not be
matched when default values of primitive types were used.

Added a unit test to reflect the expected behaviour.

This is related to a previous pull request (https://github.com/ServiceStack/ServiceStack/pull/515).
