### PR TITLE
Ignore exceptions from template compilation on background threads

### DIFF
--- a/src/ServiceStack/Html/TemplateProvider.cs
+++ b/src/ServiceStack/Html/TemplateProvider.cs
@@ -88,7 +88,7 @@ namespace ServiceStack.Html
                 Log.InfoFormat("Starting {0} threads..", threadsToRun);
 
                 threadsToRun.Times(x => {
-                    ThreadPool.QueueUserWorkItem(waitHandle => CompileAllPages());
+                    ThreadPool.QueueUserWorkItem(waitHandle => { try { CompileAllPages(); } catch { } });
                 });
             }
             else


### PR DESCRIPTION
Fixes issue #546 by swallowing template compilation exceptions occurring on background threads.
