### PR TITLE
Improve Razor diagnostic experience when not using a debugger

### DIFF
--- a/src/ServiceStack.Razor/ViewPageRef.cs
+++ b/src/ServiceStack.Razor/ViewPageRef.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading;
 using ServiceStack.Text;
 using ServiceStack.Logging;
@@ -90,6 +91,14 @@ namespace ServiceStack.Razor
                 {
                     Service.Compile(this, this.Contents, PageName);
                     Log.InfoFormat("Compiled {0} in {1}ms", this.FilePath, sw.ElapsedMilliseconds);
+                }
+                catch (TemplateCompilationException tcex)
+                {
+                    var errors = new StringBuilder();
+                    foreach (var error in tcex.Errors)
+                        errors.AppendLine(" -- {0}".Fmt(error));
+                    Log.Error("Error compiling {0} with errors:{1}{2}".Fmt(this.FilePath, Environment.NewLine, errors), tcex);
+                    throw;
                 }
                 catch (Exception ex)
                 {                    


### PR DESCRIPTION
Improve the experience of Razor view template exceptions by including
the error messages in the output. When running outside of a debugger,
this information is otherwise nearly impossible to retrieve.

An example output (this happens to be running under Mono on a mac):

```
ERROR: Error compiling /Views/Example.cshtml with errors:
 -- /var/folders/tw/gm7sjw2n5m1fg8mp75g36ww80000gn/T/1a800d9b/15e87bd7.0.cs(53,12) : error CS0029: Cannot implicitly convert type `string' to `bool'
, Exception: Unable to compile template. Check the Errors list for details.

Unhandled Exception:
ServiceStack.Razor.Templating.TemplateCompilationException: Unable to compile template. Check the Errors list for details.
  at ServiceStack.Razor.Compilation.CompilerServiceBase.CompileType (ServiceStack.Razor.Compilation.TypeContext context) [0x00000] in <filename unknown>:0 
  at ServiceStack.Razor.Templating.TemplateService.CreateTemplate (System.String template, System.Type modelType) [0x00000] in <filename unknown>:0 
  at ServiceStack.Razor.Templating.TemplateService.Compile (ServiceStack.Razor.ViewPageRef viewPageRef, System.String template, System.Type modelType, System.String name) [0x00000] in <filename unknown>:0 
  at ServiceStack.Razor.Templating.TemplateService.Compile (ServiceStack.Razor.ViewPageRef viewPageRef, System.String template, System.String name) [0x00000] in <filename unknown>:0 
  at ServiceStack.Razor.ViewPageRef.Compile (Boolean force) [0x00000] in <filename unknown>:0
```
