### PR TITLE
Fix for NullReferenceExceptions in AuthenticationInfo

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -460,9 +460,15 @@ namespace ServiceStack.ServiceClient.Web
 						WebHeaderCollection headers = ((HttpWebResponse) webEx.Response).Headers;
 						var doAuthHeader = headers[ServiceStack.Common.Web.HttpHeaders.WwwAuthenticate];
 						// check value of WWW-Authenticate header
-						this.authInfo = new ServiceStack.ServiceClient.Web.AuthenticationInfo(doAuthHeader);
-
-						client.AddAuthInfo(this.UserName,this.Password,authInfo);
+            if (doAuthHeader == null)
+            {
+              client.AddBasicAuth(this.UserName, this.Password);
+            }
+            else
+            {
+              this.authInfo = new ServiceStack.ServiceClient.Web.AuthenticationInfo(doAuthHeader);
+              client.AddAuthInfo(this.UserName, this.Password, authInfo);
+            }
 					}
 
 


### PR DESCRIPTION
With the release of 3.9.43, I had a few tests start failing. When trying to access services which require authentication, my assertions expect WebServiceExceptions. Instead I received NullReferenceExceptions.

I have traced the issue to here: https://github.com/ServiceStack/ServiceStack/commit/782012c58705f1d429ceb2dfed673b8b5c762aba#L0R463
where a null doAuthHeader is being passed to the AuthenticationInfo constructor, which attempts to check its properties.

I'm not sure that this is the ideal way of fixing the issue, but I've set it to fall back to the pre-3.9.43 AddBasicAuth() method if there is nothing in the WWW-Authenticate header.
