### PR TITLE
Adaptations so that switching to 40 target framework causes no issues

### DIFF
--- a/src/ServiceStack/MetadataTypesHandler.cs
+++ b/src/ServiceStack/MetadataTypesHandler.cs
@@ -1,10 +1,10 @@
+using System.Web;
 using ServiceStack.Common;
 using ServiceStack.Common.ServiceModel;
 using ServiceStack.ServiceHost;
 using ServiceStack.ServiceInterface.ServiceModel;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints;
-using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.WebHost.Endpoints.Support;
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using System.Web;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack
 {

--- a/src/ServiceStack/MiniProfiler/UI/MiniProfilerHandler.cs
+++ b/src/ServiceStack/MiniProfiler/UI/MiniProfilerHandler.cs
@@ -2,16 +2,15 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web;
 using System.Text;
+using System.Web;
 using ServiceStack.Text;
-using ServiceStack.Common;
 using ServiceStack.MiniProfiler.Helpers;
 using ServiceStack.ServiceHost;
 using ServiceStack.WebHost.Endpoints;
-using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.WebHost.Endpoints.Support;
-//using System.Web.Routing;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.MiniProfiler.UI
 {

--- a/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
+++ b/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
@@ -7,7 +7,7 @@ using ServiceStack.Common;
 using ServiceStack.Common.Web;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints;
-using ServiceStack.WebHost.Endpoints.Extensions;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
 
 namespace ServiceStack.ServiceHost
 {

--- a/src/ServiceStack/ServiceHost/HttpResponseExtensions.cs
+++ b/src/ServiceStack/ServiceHost/HttpResponseExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Web;
 using ServiceStack.Common.Web;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints.Extensions;
@@ -123,7 +122,7 @@ namespace ServiceStack.ServiceHost
 		public static Dictionary<string, string> CookiesAsDictionary(this IHttpResponse httpRes)
 		{
 			var map = new Dictionary<string, string>();
-			var aspNet = httpRes.OriginalResponse as HttpResponse;
+			var aspNet = httpRes.OriginalResponse as System.Web.HttpResponse;
 			if (aspNet != null)
 			{
 				foreach (var name in aspNet.Cookies.AllKeys)

--- a/src/ServiceStack/WebHost.Endpoints/Metadata/BaseMetadataHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Metadata/BaseMetadataHandler.cs
@@ -7,9 +7,10 @@ using System.Web.UI;
 using ServiceStack.Common.Extensions;
 using ServiceStack.Common.Utils;
 using ServiceStack.Common.Web;
-using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.WebHost.Endpoints.Support;
 using ServiceStack.WebHost.Endpoints.Support.Metadata.Controls;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Metadata
 {

--- a/src/ServiceStack/WebHost.Endpoints/Metadata/BaseSoapMetadataHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Metadata/BaseSoapMetadataHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Web;
 using System.Web.UI;
 using System.Xml.Schema;
 using ServiceStack.ServiceHost;
@@ -22,7 +21,7 @@ namespace ServiceStack.WebHost.Endpoints.Metadata
 		
 		public string OperationName { get; set; }
     	
-    	public override void Execute(HttpContext context)
+    	public override void Execute(System.Web.HttpContext context)
     	{
 			ProcessRequest(
 				new HttpRequestWrapper(OperationName, context.Request),

--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -10,6 +10,7 @@ using ServiceStack.ServiceHost;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.WebHost.Endpoints.Support;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
 
 namespace ServiceStack.WebHost.Endpoints
 {

--- a/src/ServiceStack/WebHost.Endpoints/Support/EndpointHandlerBase.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/EndpointHandlerBase.cs
@@ -11,6 +11,8 @@ using ServiceStack.ServiceModel.Serialization;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints.Extensions;
 using HttpRequestExtensions = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestExtensions;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Support
 {

--- a/src/ServiceStack/WebHost.Endpoints/Support/NotFoundHttpHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/NotFoundHttpHandler.cs
@@ -7,6 +7,8 @@ using ServiceStack.ServiceHost;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.Logging;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Support
 {

--- a/src/ServiceStack/WebHost.Endpoints/Support/RequestInfoHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/RequestInfoHandler.cs
@@ -6,7 +6,8 @@ using System.Web;
 using ServiceStack.Common.Web;
 using ServiceStack.ServiceHost;
 using ServiceStack.Text;
-using ServiceStack.WebHost.Endpoints.Extensions;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Support
 {

--- a/src/ServiceStack/WebHost.Endpoints/Support/SoapHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/SoapHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Runtime.Serialization;
 using System.ServiceModel.Channels;
 using System.Web;
@@ -11,8 +10,9 @@ using ServiceStack.ServiceClient.Web;
 using ServiceStack.ServiceHost;
 using ServiceStack.ServiceModel.Serialization;
 using ServiceStack.Text;
-using ServiceStack.WebHost.Endpoints.Extensions;
 using ServiceStack.WebHost.Endpoints.Utils;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Support
 {

--- a/src/ServiceStack/WebHost.Endpoints/Support/StaticFileHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/StaticFileHandler.cs
@@ -31,7 +31,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Web;
 using ServiceStack.Common;
 using ServiceStack.Common.Web;
@@ -39,6 +38,8 @@ using ServiceStack.Logging;
 using ServiceStack.ServiceHost;
 using ServiceStack.Text;
 using ServiceStack.WebHost.Endpoints.Extensions;
+using HttpRequestWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpRequestWrapper;
+using HttpResponseWrapper = ServiceStack.WebHost.Endpoints.Extensions.HttpResponseWrapper;
 
 namespace ServiceStack.WebHost.Endpoints.Support
 {


### PR DESCRIPTION
Since .NET 4.0 apparently introduces a number of classes that are named like counterparts in ServiceStack, making a 4.0 build was not as straightforward as it could be. 

The following changes disambiguate the usages of the classes in question such that should someone wanting to make a build for the 4.0 framework does not run into issues.
