### PR TITLE
Switched to GlobalAssemblyInfo.cs for AssemblyVersion attributes.

### DIFF
--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack.Api.Swagger/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Api.Swagger/Properties/AssemblyInfo.cs
@@ -23,18 +23,5 @@ using System.Runtime.Serialization;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1dfebd7c-72e5-423e-8e0b-6da176ba34b8")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]
-[assembly: AssemblyFileVersion("3.9.43.0")]
-
 [assembly: ContractNamespace("http://schemas.servicestack.net/types",
     ClrNamespace = "ServiceStack.Api.Swagger")]

--- a/src/ServiceStack.Api.Swagger/ServiceStack.Api.Swagger.csproj
+++ b/src/ServiceStack.Api.Swagger/ServiceStack.Api.Swagger.csproj
@@ -42,6 +42,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SwaggerAllowableValuesAttribute.cs" />
     <Compile Include="SwaggerApiService.cs" />

--- a/src/ServiceStack.Authentication.OpenId/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Authentication.OpenId/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f6e833d0-068e-4276-abd0-1462055501d5")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Authentication.OpenId/ServiceStack.Authentication.OpenId.csproj
+++ b/src/ServiceStack.Authentication.OpenId/ServiceStack.Authentication.OpenId.csproj
@@ -48,6 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="GoogleOpenIdOAuthProvider.cs" />
     <Compile Include="MyOpenIdOAuthProvider.cs" />
     <Compile Include="OpenIdOAuthProvider.cs" />

--- a/src/ServiceStack.Common/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Common/Properties/AssemblyInfo.cs
@@ -23,18 +23,6 @@ using System.Runtime.Serialization;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3871f659-64fb-4dfb-a49f-17dc2f8a47e2")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]
-
 // CCB Custom
 [assembly: ContractNamespace("http://schemas.servicestack.net/types",
  ClrNamespace = "ServiceStack.Common.ServiceClient.Web")]

--- a/src/ServiceStack.Common/ServiceStack.Common.csproj
+++ b/src/ServiceStack.Common/ServiceStack.Common.csproj
@@ -93,6 +93,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ActionExecExtensions.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/ServiceStack.FluentValidation.Mvc3/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.FluentValidation.Mvc3/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f8c09c29-d35a-45c3-a6be-a3c429c2d57e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.FluentValidation.Mvc3/ServiceStack.FluentValidation.Mvc3.csproj
+++ b/src/ServiceStack.FluentValidation.Mvc3/ServiceStack.FluentValidation.Mvc3.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CustomizeValidatorAttribute.cs" />
     <Compile Include="FluentValidationModelMetadataProvider.cs" />
     <Compile Include="FluentValidationModelValidator.cs" />

--- a/src/ServiceStack.Interfaces/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Interfaces/Properties/AssemblyInfo.cs
@@ -23,17 +23,5 @@ using System.Runtime.Serialization;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d13ebd2a-6589-453d-bf31-4c744a59e993")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]
-
 [assembly: ContractNamespace("http://schemas.servicestack.net/types", 
 	ClrNamespace = "ServiceStack.ServiceInterface.ServiceModel")]

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
@@ -86,6 +86,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CacheAccess\ICacheClearable.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/ServiceStack.Plugins.MsgPack/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Plugins.MsgPack/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("02fa8940-a0c1-42ef-82f8-34593498cc6e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Plugins.MsgPack/ServiceStack.Plugins.MsgPack.csproj
+++ b/src/ServiceStack.Plugins.MsgPack/ServiceStack.Plugins.MsgPack.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MsgPackFormat.cs" />
     <Compile Include="MsgPackServiceClient.cs" />

--- a/src/ServiceStack.Plugins.ProtoBuf/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2f1f3b1a-97f5-4447-bde5-75d3d8f9770d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Plugins.ProtoBuf/ServiceStack.Plugins.ProtoBuf.csproj
+++ b/src/ServiceStack.Plugins.ProtoBuf/ServiceStack.Plugins.ProtoBuf.csproj
@@ -38,6 +38,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ProtoBufFormat.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtoBufServiceClient.cs" />

--- a/src/ServiceStack.Razor/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Razor/Properties/AssemblyInfo.cs
@@ -20,21 +20,8 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("432F7A9F-E887-4F14-876F-6E3BCF4BCE2E")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else
 [assembly: AssemblyConfiguration("Release")]
 #endif
-
-[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack.Razor/ServiceStack.Razor.csproj
+++ b/src/ServiceStack.Razor/ServiceStack.Razor.csproj
@@ -76,6 +76,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Compilation\CompilerServiceBase.cs" />
     <Compile Include="Compilation\CompilerServices.cs" />
     <Compile Include="Compilation\CSharp\CSharpDirectCompilerService.cs" />

--- a/src/ServiceStack.Razor2/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Razor2/Properties/AssemblyInfo.cs
@@ -20,21 +20,8 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("432F7A9F-E887-4F14-876F-6E3BCF4BCE2E")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else
 [assembly: AssemblyConfiguration("Release")]
 #endif
-
-[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack.Razor2/ServiceStack.Razor2.csproj
+++ b/src/ServiceStack.Razor2/ServiceStack.Razor2.csproj
@@ -47,6 +47,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Compilation\CompilerServiceBase.cs" />
     <Compile Include="Compilation\CompilerServices.cs" />
     <Compile Include="Compilation\CSharp\CSharpDirectCompilerService.cs" />

--- a/src/ServiceStack.ServiceInterface/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.ServiceInterface/Properties/AssemblyInfo.cs
@@ -23,19 +23,6 @@ using System.Runtime.Serialization;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b1eeca45-c9f8-457d-a6ee-98ac3b071639")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]
-//[assembly: AssemblyFileVersion("1.0.0.0")]
-
 //Default DataContract namespace instead of tempuri.org
 [assembly: ContractNamespace("http://schemas.servicestack.net/types",
     ClrNamespace = "ServiceStack.ServiceInterface")]

--- a/src/ServiceStack.ServiceInterface/ServiceStack.ServiceInterface.csproj
+++ b/src/ServiceStack.ServiceInterface/ServiceStack.ServiceInterface.csproj
@@ -101,6 +101,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="AddHeaderAttribute.cs" />
     <Compile Include="Admin\RequestLogsFeature.cs" />
     <Compile Include="ApplyTo.cs" />

--- a/src/ServiceStack/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack/Properties/AssemblyInfo.cs
@@ -20,15 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("06704d66-af8e-411f-8260-8d05de5ce6ad")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -106,6 +106,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CacheAccess.Providers\BasicPersistenceProviderCacheBase.cs" />
     <Compile Include="CacheAccess.Providers\CacheClientExtensions.cs" />
     <Compile Include="CacheAccess.Providers\FileAndCacheTextManager.cs" />


### PR DESCRIPTION
I submitted a pull request for the equivalent thing in ServiceStack.OrmLite, after noticing that not every DLL was getting the proper 3.9.43 version in this latest release. (Some showed 1.0.0.0, like ServiceStack.ServiceInterface.dll.)

Lacking the appropriate VS project types, I did not modify the Android, WP, or SL projects, but all projects in ServiceStack.sln have been adjusted to use this mechanism. The others could be modified by someone else, or by manually editing the .csproj files to add the three-line reference to GlobalAssemblyInfo.cs.
