### PR TITLE
Allows Sequential Compilation in DebugMode

### DIFF
--- a/src/ServiceStack.Razor/RazorFormat.cs
+++ b/src/ServiceStack.Razor/RazorFormat.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Razor
 				{"rzr", typeof(ViewPage<>) },
 			};
             this.TemplateProvider = new TemplateProvider(DefaultTemplateName) {
-                CompileInParallelWithNoOfThreads = 0,
+                CompileInParallelWithNoOfThreads = null,
             };
             //Skip scanning common VS.NET extensions
             this.SkipPaths = new List<string> {
@@ -144,7 +144,7 @@ namespace ServiceStack.Razor
                 WatchForModifiedPages = appHost.Config.DebugMode;
 
             //Default to parallel execution in DebugMode
-            if (this.TemplateProvider.CompileInParallelWithNoOfThreads <= 0)
+            if (!this.TemplateProvider.CompileInParallelWithNoOfThreads.HasValue)
                 this.TemplateProvider.CompileInParallelWithNoOfThreads = appHost.Config.DebugMode
                     ? Environment.ProcessorCount * 2
                     : 0;

--- a/src/ServiceStack.Razor2/RazorFormat.cs
+++ b/src/ServiceStack.Razor2/RazorFormat.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Razor
 				{"rzr", typeof(ViewPage<>) },
 			};
             this.TemplateProvider = new TemplateProvider(DefaultTemplateName) {
-                CompileInParallelWithNoOfThreads = 0,
+                CompileInParallelWithNoOfThreads = null,
             };
             //Skip scanning common VS.NET extensions
             this.SkipPaths = new List<string> {
@@ -144,7 +144,7 @@ namespace ServiceStack.Razor
                 WatchForModifiedPages = appHost.Config.DebugMode;
 
             //Default to parallel execution in DebugMode
-            if (this.TemplateProvider.CompileInParallelWithNoOfThreads <= 0)
+            if (!this.TemplateProvider.CompileInParallelWithNoOfThreads.HasValue)
                 this.TemplateProvider.CompileInParallelWithNoOfThreads = appHost.Config.DebugMode
                     ? Environment.ProcessorCount * 2
                     : 0;

--- a/src/ServiceStack/Html/TemplateProvider.cs
+++ b/src/ServiceStack/Html/TemplateProvider.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.Html
 {
     public class TemplateProvider
     {
-        public int CompileInParallelWithNoOfThreads { get; set; }
+        public int? CompileInParallelWithNoOfThreads { get; set; }
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(TemplateProvider));
 
@@ -82,7 +82,7 @@ namespace ServiceStack.Html
 
             if (compileInParallel)
             {
-                var threadsToRun = Math.Min(CompileInParallelWithNoOfThreads, compilePages.Count);
+                var threadsToRun = Math.Min(CompileInParallelWithNoOfThreads.GetValueOrDefault(), compilePages.Count);
                 if (threadsToRun <= runningThreads) return;
 
                 Log.InfoFormat("Starting {0} threads..", threadsToRun);


### PR DESCRIPTION
## Tiny Problem

ServiceStack overwrites specified `CompileInParallelWithNoOfThreads` values.

Consider the following ServiceStack configuration code:

``` cs
public class HelloAppHost : AppHostBase
{
    public override void Configure( Funq.Container container )
    {
        var razor = new RazorFormat
            {
                TemplateProvider =
                    {
                        CompileInParallelWithNoOfThreads = 0
                    }
            };

        this.Plugins.Add( razor );

        this.Routes.Add<Hello>( "/hello" );
        this.Routes.Add<Hello>( "/hello/{Name}" );
    }
}
```

I'd like ServiceStack to compile my Razor pages sequentially **while in DebugMode** to help simplify some debugging and page compilation errors.

Currently, **ServiceStack** **_overwrites**_ my setting in the RazorPlugin's `Configure` method:

``` cs
    public class RazorFormat : IRazorViewEngine, IPlugin, IRazorPlugin
    {
        public void Configure(IAppHost appHost)
        {
            this.AppHost = appHost;
            appHost.ViewEngines.Add(this);

            //Default to watching modfied pages in DebugMode
            if (!WatchForModifiedPages)
                WatchForModifiedPages = appHost.Config.DebugMode;

            //Default to parallel execution in DebugMode
            if (this.TemplateProvider.CompileInParallelWithNoOfThreads <= 0)
                this.TemplateProvider.CompileInParallelWithNoOfThreads = appHost.Config.DebugMode
                    ? Environment.ProcessorCount * 2
                    : 0;

```

In my case, sets `CompileInParallelWithNoOfThreads = 24` on my 6 core processor CPU with HT. :(
## Patch

This pull request resolves the issue by tweaking the `CompileInParallelWithNoOfThreads` into a nullable `int?` type so that values already set are not overwritten:

``` cs
 if (!this.TemplateProvider.CompileInParallelWithNoOfThreads.HasValue)
                 this.TemplateProvider.CompileInParallelWithNoOfThreads = appHost.Config.DebugMode
                     ? Environment.ProcessorCount * 2
                     : 0;
```
