### PR TITLE
Resolves Issue #573

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Support/Markdown/TextBlock.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Markdown/TextBlock.cs
@@ -200,9 +200,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Markdown
 			object memberExprValue;
 			if (ScopeArgs.TryGetValue(this.varName, out memberExprValue))
 			{
-				valueFn = this.ReferencesSelf
-					? Convert.ToString
-					: DataBinder.CompileToString(memberExprValue.GetType(), modelMemberExpr);
+				InitializeValueFn(memberExprValue);
 			}
 			else
 			{
@@ -210,6 +208,13 @@ namespace ServiceStack.WebHost.Endpoints.Support.Markdown
 			}
 		}
 
+        private void InitializeValueFn(object memberExprValue)
+        {
+            valueFn = this.ReferencesSelf 
+                ? Convert.ToString 
+                : DataBinder.CompileToString(memberExprValue.GetType(), modelMemberExpr);
+        }
+        
 		public override void Write(MarkdownViewBase instance, TextWriter textWriter, Dictionary<string, object> scopeArgs)
 		{
 			object memberExprValue;
@@ -236,7 +241,10 @@ namespace ServiceStack.WebHost.Endpoints.Support.Markdown
 					textWriter.Write(memberExprValue);
 					return;
 				}
-
+                if (valueFn == null)
+                {
+                    InitializeValueFn(memberExprValue);
+                }
 				var strValue = this.ReferencesSelf
 					? Convert.ToString(memberExprValue)
 					: valueFn(memberExprValue);

--- a/tests/ServiceStack.ServiceHost.Tests/Formats/TextBlockTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/Formats/TextBlockTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using ServiceStack.Common.Utils;
 using ServiceStack.WebHost.Endpoints.Formats;
 using ServiceStack.WebHost.Endpoints.Support.Markdown;
+using ServiceStack.ServiceHost.Tests.Formats_Razor;
 
 namespace ServiceStack.ServiceHost.Tests.Formats
 {
@@ -38,6 +39,24 @@ namespace ServiceStack.ServiceHost.Tests.Formats
 			Assert.That(statements[0].Condition, Is.EqualTo("var link in Model.Links"));
 			Assert.That(statements[0].Statement, Is.EqualTo("  - @link.Name - @link.Href\r\n"));
 		}
+
+        [Test]
+        public void Does_handle_foreach_when_enumerable_is_empty_first_time()
+        {
+            var content = (string)dynamicListPageContent.Clone();
+            var markdownPage = new MarkdownPage(new MarkdownFormat(), dynamicListPagePath, "", content);
+            markdownPage.Compile();
+            var model = new Person { Links = new List<Link>() };
+            var scopeArgs = new Dictionary<string, object> { { "Model", model } };
+            markdownPage.RenderToHtml(scopeArgs);             // First time the list is empty
+
+            var expected = "A new list item";
+            model.Links.Add(new Link { Name = expected } );
+            var html = markdownPage.RenderToHtml(scopeArgs);  // Second time the list has 1 item
+
+            Console.WriteLine(html);
+            Assert.That(html, Contains.Substring(expected));
+        }
 
 		[Test]
 		public void Does_replace_multiple_statements_with_expr_placeholders()


### PR DESCRIPTION
The null reference was for MemberExprBlock.valueFn in Write(….).
valueFn would ideally be initialized during
ForEachStatementExprBlock.OnFirstRun(). However, at that time
memberExprEnumerator is empty, thus DoFirstRun does not get called for
each of the ChildBlocks. As far as I can tell, the reason for this is
that there is no value to set in ScopeArgs from which
MemberExprBlock.OnFirstRun would get the item's type...  So a redesign
of this mechanic may be necessary to resolve this in a more elegant way.
