### PR TITLE
Jsv/QueryStringSerializer does not de-serialize/serialize lists of complex objects corectly

### DIFF
--- a/tests/ServiceStack.Common.Tests/QueryStringSerializerTests.cs
+++ b/tests/ServiceStack.Common.Tests/QueryStringSerializerTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Web;
+using Funq;
+using NUnit.Framework;
+using ServiceStack.ServiceHost;
+using ServiceStack.ServiceInterface.Testing;
+using ServiceStack.Text;
+using ServiceStack.WebHost.Endpoints;
+using ServiceStack.WebHost.Endpoints.Support.Mocks;
+
+namespace ServiceStack.Common.Tests
+{
+    [TestFixture]
+    public class QueryStringSerializerTests
+    {
+        [Test]
+        public void Can_deserialize_TestRequest_current_QueryStringSerializer_output()
+        {
+            // Setup
+            var testAppHost = new TestAppHost(new Container(), typeof(TestService).Assembly);
+            var restPath = new RestPath(typeof(TestRequest), "/service", "GET");
+            var restHandler = new RestHandler { RestPath = restPath };
+            
+            var requestString = "ListOfA={ListOfB:{Property:prop1},{Property:prop2}}";
+            NameValueCollection queryString = HttpUtility.ParseQueryString(requestString);
+            var httpReq = new HttpRequestMock("service", "GET", "application/json", "service", queryString, new MemoryStream(), new NameValueCollection());
+
+            var request2 = (TestRequest)restHandler.CreateRequest(httpReq, "service");
+
+            Assert.That(request2.ListOfA.Count, Is.EqualTo(1));
+            Assert.That(request2.ListOfA.First().ListOfB.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Can_deserialize_TestRequest_old_QueryStringSerializer_output()
+        {
+            // Setup
+            var testAppHost = new TestAppHost(new Container(), typeof(TestService).Assembly);
+            var restPath = new RestPath(typeof(TestRequest), "/service", "GET");
+            var restHandler = new RestHandler { RestPath = restPath };
+
+            var requestString = "ListOfA=[{ListOfB:[{Property:prop1},{Property:prop2}]}]";
+            NameValueCollection queryString = HttpUtility.ParseQueryString(requestString);
+            var httpReq = new HttpRequestMock("service", "GET", "application/json", "service", queryString, new MemoryStream(), new NameValueCollection());
+
+            var request2 = (TestRequest)restHandler.CreateRequest(httpReq, "service");
+
+            Assert.That(request2.ListOfA.Count, Is.EqualTo(1));
+            Assert.That(request2.ListOfA.First().ListOfB.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void QueryStringSerializer_TestRequest_current_output()
+        {
+            var testRequest = new TestRequest { ListOfA = new List<A> { new A { ListOfB = new List<B> { new B { Property = "prop1" }, new B { Property = "prop2" } } } } };
+            var str = QueryStringSerializer.SerializeToString(testRequest);
+            Assert.That(str, Is.EqualTo("ListOfA={ListOfB:{Property:prop1},{Property:prop2}}"));
+        }
+
+        [Test]
+        public void QueryStringSerializer_TestRequest_old_output()
+        {
+            var testRequest = new TestRequest { ListOfA = new List<A> { new A { ListOfB = new List<B> { new B { Property = "prop1" }, new B { Property = "prop2" } } } } };
+            var str = QueryStringSerializer.SerializeToString(testRequest);
+            Assert.That(str, Is.EqualTo("ListOfA=[{ListOfB:[{Property:prop1},{Property:prop2}]}]"));
+        }
+
+        public class TestService : ServiceInterface.Service
+        {
+            public object Get(TestRequest request)
+            {
+                return "OK";
+            }
+        }
+
+        public class TestRequest
+        {
+            public List<A> ListOfA { get; set; }
+        }
+
+        public class A
+        {
+            public List<B> ListOfB { get; set; }
+        }
+
+        public class B
+        {
+            public string Property { get; set; }
+        }
+    }
+}

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -165,6 +165,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
+    <Compile Include="QueryStringSerializerTests.cs" />
     <Compile Include="ReflectionExtensionsTests.cs" />
     <Compile Include="Reflection\PropertyAccessorTests.cs" />
     <Compile Include="Expressions\DelegateFactoryTests.cs" />


### PR DESCRIPTION
Before lists of complex objects used to be serialized to

```
ListOfA=[{ListOfB:[{Property:prop1},{Property:prop2}]}]
```

by the `QueryStringSerializer`, they are now serialized to

```
ListOfA={ListOfB:{Property:prop1},{Property:prop2}}
```

When de-serializing these strings with the current implementation the first ends up as the expected object while the second does not. The class structure is as follows

``` csharp
public class TestRequest
{
    public List<A> ListOfA { get; set; }
}

public class A
{
    public List<B> ListOfB { get; set; }
}

public class B
{
    public string Property { get; set; }
}
```

On the URL either way is OK, but I expect that a string produced by the `QueryStringSerializer` should be possible to pass back to a ServiceStack service.
