### PR TITLE
Better Razor Compilation Diagnostics

### DIFF
--- a/src/ServiceStack.Razor2/RazorFormat.cs
+++ b/src/ServiceStack.Razor2/RazorFormat.cs
@@ -169,7 +169,18 @@ namespace ServiceStack.Razor
                 if (catchAllPathsNotFound.Contains(pathInfo))
                     return null;
 
-                razorPage = FindByPathInfo(pathInfo);
+                try
+                {
+                    razorPage = FindByPathInfo( pathInfo );
+                }
+                catch(TemplateCompilationException tcex)
+                {
+                    if ( appHost.Config.DebugMode && tcex.HttpCompileException != null )
+                    {
+                        throw tcex.HttpCompileException;
+                    }
+                    throw;
+                }
 
                 if (WatchForModifiedPages)
                     ReloadIfNeeeded(razorPage);


### PR DESCRIPTION
This pull request moves the Razor feature in ServiceStack closer to a "first class citizen". This commit improves upon #561.

**Note: Only added support for the Razor2 project.***

Also checks for `DebugMode` to prevent leaking sensitive data.

![Screen023](https://f.cloud.github.com/assets/478118/360509/867ba2a6-a198-11e2-98e8-f3d126690300.png)

---

@mythz, before I continue working on this ... I'd really like to refactor the entire Razor2 project. I'm starting get a whiff of some bad code smell in the way the everything is handled in the Razor plugin.

![Screen027](https://f.cloud.github.com/assets/478118/360530/1e32d960-a19a-11e2-98cb-304d304bcc93.png)

... perhaps start a new issue where we could discuss Razor2 refactorings?
