### PR TITLE
Use request.RemoteEndPoint instead of request.UserHostAddress to supply the value for IHttpRequest.RemoteIp

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpListenerRequestWrapper.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpListenerRequestWrapper.cs
@@ -139,7 +139,10 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
         {
             get
             {
-                return remoteIp ?? (remoteIp = XForwardedFor ?? (XRealIp ?? request.UserHostAddress));
+                return remoteIp ?? 
+                    (remoteIp = XForwardedFor ?? 
+                                (XRealIp ?? 
+                                ((request.RemoteEndPoint != null) ? request.RemoteEndPoint.ToString() : null)));
             }
         }
 


### PR DESCRIPTION
Per the documentation (and actual behavior) request.UserHostAddress
returns the DNS/IP of the server. For the IHttpRequest.RemoteIp
property we want the remote client's IP address, and for that we need
to use request.RemoteEndPoint.
