### PR TITLE
Added AllowNonHttpOnlyCookies as configuration option

### DIFF
--- a/src/ServiceStack/ServiceHost/Cookies.cs
+++ b/src/ServiceStack/ServiceHost/Cookies.cs
@@ -64,7 +64,7 @@ namespace ServiceStack.ServiceHost
             var httpCookie = new HttpCookie(cookie.Name, cookie.Value) {
                 Path = cookie.Path,
                 Expires = cookie.Expires,
-                HttpOnly = true,
+                HttpOnly = !EndpointHost.Config.AllowNonHttpOnlyCookies || cookie.HttpOnly,
                 Secure = cookie.Secure
             };
             if (!string.IsNullOrEmpty(cookie.Domain))

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -63,6 +63,7 @@ namespace ServiceStack.WebHost.Endpoints
                         MetadataRedirectPath = null,
                         DefaultContentType = null,
                         AllowJsonpRequests = true,
+                        AllowNonHttpOnlyCookies = false,
                         DebugMode = false,
                         DefaultDocuments = new List<string> {
 							"default.htm",
@@ -169,6 +170,7 @@ namespace ServiceStack.WebHost.Endpoints
             this.DefaultJsonpCacheExpiration = instance.DefaultJsonpCacheExpiration;
             this.MetadataVisibility = instance.MetadataVisibility;
             this.Return204NoContentForEmptyResponse = Return204NoContentForEmptyResponse;
+            this.AllowNonHttpOnlyCookies = instance.AllowNonHttpOnlyCookies;
         }
 
         public static string GetAppConfigPath()
@@ -416,6 +418,8 @@ namespace ServiceStack.WebHost.Endpoints
 
         public TimeSpan DefaultJsonpCacheExpiration { get; set; }
         public bool Return204NoContentForEmptyResponse { get; set; }
+
+        public bool AllowNonHttpOnlyCookies { get; set; }
 
         private string defaultOperationNamespace;
         public string DefaultOperationNamespace


### PR DESCRIPTION
To allow for those rare occasions where HttpOnly cookies won't do, I've added a config option to turn the forcing of HttpOnly cookies off.  This option is false (HttpOnly forced) by default.
