### PR TITLE
Fixed SL5 compilation

### DIFF
--- a/src/ServiceStack.Common.SL5/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Common.SL5/Properties/AssemblyInfo.cs
@@ -21,15 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a3b1457d-b68b-4372-9716-181615846071")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Common.SL5/ServiceStack.Common.SL5.csproj
+++ b/src/ServiceStack.Common.SL5/ServiceStack.Common.SL5.csproj
@@ -57,6 +57,9 @@
     <Reference Include="System.Windows.Browser" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Common\ActionExecExtensions.cs">
       <Link>ActionExecExtensions.cs</Link>
     </Compile>
@@ -110,9 +113,6 @@
     </Compile>
     <Compile Include="..\ServiceStack.Common\Extensions\ITranslatorExtensions.cs">
       <Link>Extensions\ITranslatorExtensions.cs</Link>
-    </Compile>
-    <Compile Include="..\ServiceStack.Common\Extensions\ReflectionExtensions.cs">
-      <Link>Extensions\ReflectionExtensions.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Common\Extensions\StringExtensions.cs">
       <Link>Extensions\StringExtensions.cs</Link>
@@ -243,6 +243,9 @@
     <Compile Include="..\ServiceStack.Common\ServiceClient.Web\JsvServiceClient.cs">
       <Link>ServiceClient.Web\JsvServiceClient.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\RouteMember.cs">
+      <Link>ServiceClient.Web\RouteMember.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Common\ServiceClient.Web\ServiceClientBase.cs">
       <Link>ServiceClient.Web\ServiceClientBase.cs</Link>
     </Compile>
@@ -251,6 +254,9 @@
     </Compile>
     <Compile Include="..\ServiceStack.Common\ServiceClient.Web\Soap12ServiceClient.cs">
       <Link>ServiceClient.Web\Soap12ServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\UrlExtensions.cs">
+      <Link>ServiceClient.Web\UrlExtensions.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Common\ServiceClient.Web\WcfServiceClient.cs">
       <Link>ServiceClient.Web\WcfServiceClient.cs</Link>
@@ -378,6 +384,9 @@
     <Compile Include="..\ServiceStack.Common\Utils\ReflectionUtils.cs">
       <Link>Utils\ReflectionUtils.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\ResponseStatusUtils.cs">
+      <Link>Utils\ResponseStatusUtils.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Common\Web\CompressedFileResult.cs">
       <Link>Web\CompressedFileResult.cs</Link>
     </Compile>
@@ -392,9 +401,6 @@
     </Compile>
     <Compile Include="..\ServiceStack.Common\Web\EndPoint.cs">
       <Link>Web\EndPoint.cs</Link>
-    </Compile>
-    <Compile Include="..\ServiceStack.Common\Web\EndpointType.cs">
-      <Link>Web\EndpointType.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Common\Web\HttpError.cs">
       <Link>Web\HttpError.cs</Link>
@@ -446,7 +452,7 @@
       <FlavorProperties GUID="{A1591282-1198-4647-A2B1-27E5FF5F6F3B}">
         <SilverlightProjectProperties />
       </FlavorProperties>
-      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="982416db-c143-4028-a0c3-cf41892d18d3" />
+      <UserProperties ProjectLinkReference="982416db-c143-4028-a0c3-cf41892d18d3" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/ServiceStack.Common/ReflectionExtensions.cs
+++ b/src/ServiceStack.Common/ReflectionExtensions.cs
@@ -41,7 +41,7 @@ namespace ServiceStack.Common
             return assembly.GetCustomAttributes()
                 .OfType<DebuggableAttribute>()
                 .Any();
-#elif WINDOWS_PHONE
+#elif WINDOWS_PHONE || SILVERLIGHT
             return assembly.GetCustomAttributes(false)
                 .OfType<DebuggableAttribute>()
                 .Any();

--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -93,7 +93,7 @@ namespace ServiceStack.ServiceClient.Web
         /// <summary>
         /// Gets the collection of headers to be added to outgoing requests.
         /// </summary>
-#if NETFX_CORE || WINDOWS_PHONE
+#if NETFX_CORE || WINDOWS_PHONE || SILVERLIGHT
         public Dictionary<string, string> Headers { get; private set; } 
 #else
         public NameValueCollection Headers { get; private set; }
@@ -118,7 +118,7 @@ namespace ServiceStack.ServiceClient.Web
                 LocalHttpWebResponseFilter = this.LocalHttpWebResponseFilter
             };
             this.StoreCookies = true; //leave
-#if NETFX_CORE || WINDOWS_PHONE
+#if NETFX_CORE || WINDOWS_PHONE || SILVERLIGHT
             this.Headers = new Dictionary<string, string>();
 #else
             this.Headers = new NameValueCollection();

--- a/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
@@ -97,7 +97,7 @@ namespace ServiceStack.ServiceClient.Web
             var restRoutes = requestType.AttributesOfType<RouteAttribute>()
                 .Select(attr => new RestRoute(requestType, attr.Path, attr.Verbs))
                 .ToList();
-#elif WINDOWS_PHONE
+#elif WINDOWS_PHONE || SILVERLIGHT
             var restRoutes = requestType.AttributesOfType<RouteAttribute>()
                 .Select(attr => new RestRoute(requestType, attr.Path, attr.Verbs))
                 .ToList();

--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
@@ -151,7 +151,7 @@ namespace ServiceStack.ServiceClient.Web
         }
         #endif
 
-        #if !NETFX_CORE
+        #if !NETFX_CORE && !SILVERLIGHT
 		internal static string CalculateMD5Hash(string input)
 		{
 			// copied/pasted by adamfowleruk
@@ -181,6 +181,7 @@ namespace ServiceStack.ServiceClient.Web
 			return ret;
 		}
 
+#if !SILVERLIGHT
 		internal static void AddAuthInfo(this WebRequest client,string userName,string password,AuthenticationInfo authInfo) {
 			
 			if ("basic".Equals (authInfo.method)) {
@@ -219,7 +220,7 @@ namespace ServiceStack.ServiceClient.Web
 			client.Headers [ServiceStack.Common.Web.HttpHeaders.Authorization] = header;
 
 		}
-
+#endif
         /// <summary>
         /// Naming convention for the request's Response DTO
         /// </summary>

--- a/src/ServiceStack.Common/ServiceClient.Web/WebServiceException.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebServiceException.cs
@@ -8,7 +8,7 @@ using ServiceStack.Text;
 
 namespace ServiceStack.ServiceClient.Web
 {
-#if !NETFX_CORE && !WINDOWS_PHONE
+#if !NETFX_CORE && !WINDOWS_PHONE && !SILVERLIGHT
     [Serializable]
 #endif
     public class WebServiceException
@@ -17,7 +17,7 @@ namespace ServiceStack.ServiceClient.Web
         public WebServiceException() { }
         public WebServiceException(string message) : base(message) { }
         public WebServiceException(string message, Exception innerException) : base(message, innerException) { }
-#if !NETFX_CORE && !WINDOWS_PHONE
+#if !NETFX_CORE && !WINDOWS_PHONE && !SILVERLIGHT
         public WebServiceException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 #endif
 

--- a/src/ServiceStack.Common/StreamExtensions.cs
+++ b/src/ServiceStack.Common/StreamExtensions.cs
@@ -102,7 +102,7 @@ namespace ServiceStack.Common
             stream.Close(); //For documentation purposes. In reality it won't call this Ext method.
 #endif
         }
-
+#if !SILVERLIGHT
         public static string ToMd5Hash(this Stream stream)
         {
             var hash = MD5.Create().ComputeHash(stream);
@@ -124,6 +124,6 @@ namespace ServiceStack.Common
             }
             return sb.ToString();
         }
-
+#endif
     }
 }

--- a/src/ServiceStack.Common/Utils/ReflectionUtils.cs
+++ b/src/ServiceStack.Common/Utils/ReflectionUtils.cs
@@ -391,7 +391,7 @@ namespace ServiceStack.Common.Utils
             var genericCollectionType =
                 type.GetTypeInfo().ImplementedInterfaces
                     .FirstOrDefault(t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof (ICollection<>));
-#elif WINDOWS_PHONE
+#elif WINDOWS_PHONE || SILVERLIGHT
             var genericCollectionType =
                 type.GetInterfaces()
                     .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof (ICollection<>));

--- a/src/ServiceStack.Interfaces.SL5/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Interfaces.SL5/Properties/AssemblyInfo.cs
@@ -21,15 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3ba1c3b3-34a1-4307-824b-1eecc8345149")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
+++ b/src/ServiceStack.Interfaces.SL5/ServiceStack.Interfaces.SL5.csproj
@@ -57,6 +57,9 @@
     <Reference Include="System.Windows.Browser" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheClearable.cs">
       <Link>CacheAccess\ICacheClearable.cs</Link>
     </Compile>
@@ -528,11 +531,14 @@
     <Compile Include="..\ServiceStack.Interfaces\ServiceHost\RestServiceAttribute.cs">
       <Link>ServiceHost\RestServiceAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\ServiceAttribute.cs">
-      <Link>ServiceHost\ServiceAttribute.cs</Link>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\RouteAttribute.cs">
+      <Link>ServiceHost\RouteAttribute.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\CollectionTypes.cs">
       <Link>ServiceInterface.ServiceModel\CollectionTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ErrorResponse.cs">
+      <Link>ServiceInterface.ServiceModel\ErrorResponse.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ICacheByDateModified.cs">
       <Link>ServiceInterface.ServiceModel\ICacheByDateModified.cs</Link>
@@ -545,6 +551,9 @@
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\IHasResponseStatus.cs">
       <Link>ServiceInterface.ServiceModel\IHasResponseStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\IResponseStatusConvertible.cs">
+      <Link>ServiceInterface.ServiceModel\IResponseStatusConvertible.cs</Link>
     </Compile>
     <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\Property.cs">
       <Link>ServiceInterface.ServiceModel\Property.cs</Link>

--- a/src/ServiceStack.Interfaces/ServiceHost/RouteAttribute.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/RouteAttribute.cs
@@ -111,7 +111,7 @@ namespace ServiceStack.ServiceHost
 		/// </value>
 		public string Verbs { get; set; }
 
-#if NETFX_CORE || WINDOWS_PHONE
+#if NETFX_CORE || WINDOWS_PHONE || SILVERLIGHT
         /// <summary>
         /// Required when using a TypeDescriptor to make it unique
         /// </summary>


### PR DESCRIPTION
Aligned version number with the rest of ServiceStack and added missing file
links and excluded few blocks that can't compile in Silverlight 'mode'.

Demis, could you please let us know when is the next version coming out (pushed to NuGet)? I ask because I specifically fixed the SL5 build so that my company can actually use the SL 'port' of ServiceStack, the one currently on NuGet should be considered broken because the project ServiceStack.Interfaces (for SL5) is missing a crucial interface (IReturn) so the library to share contracts between the server/service and client **cannot** be built (for SL5) at all.

If you have any questions about the pull request, do not hesitate to contact me.

Thanks for all the hard work in making ServiceStack, it really is appreciated!

P.S. This is my first (OK, technically _second_ ;) since I have sent one almost identical to this one for ServiceStack.Text minutes ago) pull request, I apologize if I did something incorrectly, be glad to correct, just let me know. Cheers!
