### PR TITLE
Fixes #116 CookieContainer of the inner asyncClient field in ServiceClientBase is not updated

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -321,7 +321,12 @@ namespace ServiceStack.ServiceClient.Web
             set { asyncClient.StoreCookies = storeCookies = value; }
         }
 
-        public CookieContainer CookieContainer { get; set; }
+        private CookieContainer _cookieContainer;
+        public CookieContainer CookieContainer
+        {
+            get { return _cookieContainer; }
+            set { asyncClient.CookieContainer = _cookieContainer = value; }
+        }
 
         private bool allowAutoRedirect = true;
         public bool AllowAutoRedirect


### PR DESCRIPTION
Set the async client cookie container when the container is replaced
on the base service client.
