### PR TITLE
public ServiceClientBase.DownloadBytes methods

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -785,6 +785,26 @@ namespace ServiceStack.ServiceClient.Web
         }
 #endif
 
+        public byte[] DownloadBytes( IReturn request, string httpMethod = "GET", string acceptContentType = "*/*")
+        {
+            var url = new Uri(new Uri(BaseUri), request.ToUrl(httpMethod)).AbsoluteUri;
+            return DownloadBytes(url, httpMethod, acceptContentType);
+        }
+
+        public byte[] DownloadBytes( string url, string httpMethod = "GET", string acceptContentType = "*/*")
+        {
+            if (url == null) throw new ArgumentNullException("url");
+
+            var requestFilter = HttpWebRequestFilter;
+            requestFilter += LocalHttpWebRequestFilter;
+
+            var responseFilter = HttpWebResponseFilter;
+            responseFilter += LocalHttpWebResponseFilter;
+
+            var bytes = url.GetBytesFromUrl(acceptContentType, requestFilter, responseFilter);
+            return bytes;
+        }
+
         public virtual void SendOneWay(object request)
         {
             var requestUri = this.AsyncOneWayBaseUri.WithTrailingSlash() + request.GetType().Name;


### PR DESCRIPTION
Added pair of methods that make it much more convenient to download
bytes from a service resource. The request DTO can be used to determine
the resource URL. Also, the service client's request and response
filters are observed. This is helpful, for example, when custom headers
sent to the server.

I have been using these 2 methods as extensions and they help a lot.
