### PR TITLE
DefaultView failing test. Throws when req.Items["View"] doesn't exist.

### DIFF
--- a/tests/ServiceStack.Razor.Tests/HelloAppHost.cs
+++ b/tests/ServiceStack.Razor.Tests/HelloAppHost.cs
@@ -41,6 +41,7 @@ namespace ServiceStack.Razor.Tests
             this.Routes.Add<HelloRequest>("/hello");
             this.Routes.Add<HelloRequest>("/hello/{Name}");
             this.Routes.Add<FooRequest>("/Foo/{WhatToSay}");
+            this.Routes.Add<DefaultViewFooRequest>("/DefaultViewFoo/{WhatToSay}");
         }
 
         private void SimpleRequestFilter(IHttpRequest req, IHttpResponse res, object obj)

--- a/tests/ServiceStack.Razor.Tests/HelloRequest.cs
+++ b/tests/ServiceStack.Razor.Tests/HelloRequest.cs
@@ -1,4 +1,5 @@
 ﻿using ServiceStack.ServiceHost;
+using ServiceStack.ServiceInterface;
 
 namespace ServiceStack.Razor.Tests
 {
@@ -39,6 +40,16 @@ namespace ServiceStack.Razor.Tests
         public string FooSaid { get; set; }
     }
 
+    public class DefaultViewFooRequest
+    {
+        public string WhatToSay { get; set; }
+    }
+
+    public class DefaultViewFooResponse
+    {
+        public string FooSaid { get; set; }
+    }
+
     public class FooController : ServiceInterface.Service, IGet<FooRequest>, IPost<FooRequest>
     {
         public object Get( FooRequest request )
@@ -49,6 +60,12 @@ namespace ServiceStack.Razor.Tests
         public object Post( FooRequest request )
         {
             return new FooResponse { FooSaid = string.Format( "POST: {0}", request.WhatToSay ) };            
+        }
+
+        [DefaultView("DefaultViewFoo")]
+        public object Get(DefaultViewFooRequest request)
+        {
+            return new DefaultViewFooResponse { FooSaid = string.Format("GET: {0}", request.WhatToSay) };
         }
     }
 }

--- a/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
+++ b/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
@@ -88,6 +88,7 @@
     <Content Include="NoController.cshtml" />
     <Content Include="Views\Foobar\FooResponse.cshtml" />
     <Content Include="default4.cshtml" />
+    <Content Include="Views\Foobar\DefaultViewFoo.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/tests/ServiceStack.Razor.Tests/Views/Foobar/DefaultViewFoo.cshtml
+++ b/tests/ServiceStack.Razor.Tests/Views/Foobar/DefaultViewFoo.cshtml
@@ -1,0 +1,20 @@
+﻿@inherits ServiceStack.Razor.ViewPage<ServiceStack.Razor.Tests.DefaultViewFooResponse>
+@using System
+@using ServiceStack.Razor.Tests
+@using ServiceStack.Common
+@using ServiceStack.WebHost.Endpoints
+
+<div>
+    <h4>/Views/Foo</h4>
+    The time is: @DateTime.Now
+    <h4>Foo Was Here!</h4>
+    <h4>He said: @Model.FooSaid</h4>
+
+    <form method="POST">
+        @Html.TextBox( "foo" )
+        <button name="cmdGo" value="123">Go Button</button>
+    </form>
+
+    obob
+    <button>Button out of form</button>
+</div>


### PR DESCRIPTION
```
ERROR|DtoUtils|ServiceBase<TRequest>::Service Exception|System.Collections.Generic.KeyNotFoundException: The 
given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at ServiceStack.ServiceInterface.DefaultViewAttribute.Execute(IHttpRequest req, IHttpResponse res, Object requestDto) in c:\code\github\ServiceStack\src\ServiceStack.ServiceInterface\DefaultViewAttribute.cs:line 22
   at ServiceStack.ServiceInterface.RequestFilterAttribute.RequestFilter(IHttpRequest req, IHttpResponse res, Object requestDto) in c:\code\github\ServiceStack\src\ServiceStack.ServiceInterface\RequestFilterAttribute.cs:line 41
   at ServiceStack.ServiceHost.ServiceRunner`1.Execute(IRequestContext requestContext, Object instance, TRequest request) in c:\code\github\ServiceStack\src\ServiceStack\ServiceHost\ServiceRunner.cs:line 111
```
