### PR TITLE
Add specific exception (RequestBindingException) for when binding fails

### DIFF
--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -298,6 +298,7 @@
     <Compile Include="WebHost.Endpoints\Extensions\HttpListenerRequestWrapper.cs" />
     <Compile Include="WebHost.Endpoints\AppDelegates.cs" />
     <Compile Include="WebHost.Endpoints\ActionHandler.cs" />
+    <Compile Include="WebHost.Endpoints\RequestBindingException.cs" />
     <Compile Include="WebHost.Endpoints\Support\Markdown\Evaluator.cs" />
     <Compile Include="WebHost.Endpoints\Support\Markdown\ITemplateWriter.cs" />
     <Compile Include="WebHost.Endpoints\Support\Markdown\Markdown.cs" />

--- a/src/ServiceStack/WebHost.Endpoints/RequestBindingException.cs
+++ b/src/ServiceStack/WebHost.Endpoints/RequestBindingException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace ServiceStack.WebHost.Endpoints
+{
+	public class RequestBindingException : SerializationException
+	{
+		public RequestBindingException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+	}
+}

--- a/src/ServiceStack/WebHost.Endpoints/RestHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/RestHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using ServiceStack.Common.Web;
 using ServiceStack.Logging;
 using ServiceStack.MiniProfiler;
@@ -95,14 +96,24 @@ namespace ServiceStack.WebHost.Endpoints
             var requestType = restPath.RequestType;
             using (Profiler.Current.Step("Deserialize Request"))
             {
+	            try
+	            {
+					var requestDto = GetCustomRequestFromBinder(httpReq, requestType);
+					if (requestDto != null) return requestDto;
 
-                var requestDto = GetCustomRequestFromBinder(httpReq, requestType);
-                if (requestDto != null) return requestDto;
+					var requestParams = httpReq.GetRequestParams();
+					requestDto = CreateContentTypeRequest(httpReq, requestType, httpReq.ContentType);
 
-                var requestParams = httpReq.GetRequestParams();
-                requestDto = CreateContentTypeRequest(httpReq, requestType, httpReq.ContentType);
-
-                return restPath.CreateRequest(httpReq.PathInfo, requestParams, requestDto);
+					return restPath.CreateRequest(httpReq.PathInfo, requestParams, requestDto);
+	            }
+				catch (SerializationException e)
+	            {
+					throw new RequestBindingException("Unable to bind request", e);
+	            }
+				catch(ArgumentException e)
+				{
+					throw new RequestBindingException("Unable to bind request", e);
+				}
             }
         }
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/RestHandlerTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/RestHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Specialized;
+using Moq;
+using NUnit.Framework;
+using ServiceStack.ServiceHost;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+	[TestFixture]
+	public class RestHandlerTests
+	{
+		[Test]
+		public void Throws_binding_exception_when_unable_to_match_path_values()
+		{
+			var path = "/request/{will_not_match_property_id}/pathh";
+			var request = ConfigureRequest(path);
+			var response = new Mock<IHttpResponse>().Object;
+			ConfigureHost();
+
+			var handler = new RestHandler
+			{
+				RestPath = new RestPath(typeof(RequestType), path)
+			};
+
+			Assert.Throws<RequestBindingException>(() => handler.ProcessRequest(request, response, string.Empty));
+		}
+
+		[Test]
+		public void Throws_binding_exception_when_unable_to_bind_request()
+		{
+			var path = "/request/{id}/path";
+			var request = ConfigureRequest(path);
+			var response = new Mock<IHttpResponse>().Object;
+			ConfigureHost();
+
+			var handler = new RestHandler
+			{
+				RestPath = new RestPath(typeof(RequestType), path)
+			};
+
+			Assert.Throws<RequestBindingException>(() => handler.ProcessRequest(request, response, string.Empty));
+		}
+
+		private IHttpRequest ConfigureRequest(string path)
+		{
+			var request = new Mock<IHttpRequest>();
+			request.Expect(x => x.QueryString).Returns(new NameValueCollection());
+			request.Expect(x => x.PathInfo).Returns(path);
+
+			return request.Object;
+		}
+
+		private void ConfigureHost()
+		{
+			var host = ServiceHostTestBase.CreateAppHost();
+			EndpointHost.ConfigureHost(host, string.Empty, new ServiceManager(true, typeof(RestHandlerTests).Assembly));		
+		}
+
+		public class RequestType
+		{
+			public int Id { get; set; }
+		}
+	}
+}

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="EncodingTests.cs" />
     <Compile Include="ExceptionHandling2Tests.cs" />
     <Compile Include="IntegrationTests\MovieSoap11Tests.cs" />
+    <Compile Include="RestHandlerTests.cs" />
     <Compile Include="RouteInferenceTests.cs" />
     <Compile Include="ServiceClientsBuiltInResponseTests.cs" />
     <Compile Include="Support\Services\TestRestService.cs" />


### PR DESCRIPTION
Related to Issue #649

Added functionality to catch SerializationExceptions during Binding and throw them as RequestBindingExceptions. This allows for them to be caught during ExceptionHandling so that a 400 type response can be given.

Please clean up as needs be. I've followed the existing code as best I could and added 2 tests around RestHandler. 
