### PR TITLE
Fix NullReferenceException in BasicAppHost.Dispose() when .Init() was not called (#656)

### DIFF
--- a/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
+++ b/src/ServiceStack.ServiceInterface/Testing/BasicAppHost.cs
@@ -115,7 +115,7 @@ namespace ServiceStack.ServiceInterface.Testing
 
                 if (disposing)
                 {
-                    if (EndpointHost.Config.ServiceManager != null)
+                    if (EndpointHost.Config != null && EndpointHost.Config.ServiceManager != null)
                     {
                         EndpointHost.Config.ServiceManager.Dispose();
                     }

--- a/tests/ServiceStack.ServiceHost.Tests/BasicAppHostTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/BasicAppHostTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ServiceStack.ServiceInterface.Testing;
+using NUnit.Framework;
+
+namespace ServiceStack.ServiceHost.Tests
+{
+    [TestFixture]
+    public class BasicAppHostTests
+    {
+        [Test]
+        public void Can_dispose_without_init()
+        {
+            BasicAppHost appHost = new BasicAppHost();
+            appHost.Dispose();
+        }
+    }
+}

--- a/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
+++ b/tests/ServiceStack.ServiceHost.Tests/ServiceStack.ServiceHost.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="AppData\NorthwindCustomers.cs" />
     <Compile Include="AppData\FormatHelpers.cs" />
     <Compile Include="AppData\NorthwindHelpers.cs" />
+    <Compile Include="BasicAppHostTests.cs" />
     <Compile Include="Formats\MarkdownFormatExtensions.cs" />
     <Compile Include="Formats_Razor\CustomRazorBasePage.cs" />
     <Compile Include="Formats_Razor\IntroductionExampleRazorTests.cs" />


### PR DESCRIPTION
Based off a new fork of ServiceStack to avoid extraneous commits.
