### PR TITLE
Add "packages/" to .gitignore for NuGet package restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ App_Data/
 build/*.dll
 *.user
 *.userprefs
+packages/
 
 release/latest/
 *.nupkg


### PR DESCRIPTION
Needed if NuGet Package Restore is enabled.
