### PR TITLE
Sorting metadata object list

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceMetadata.cs
+++ b/src/ServiceStack/ServiceHost/ServiceMetadata.cs
@@ -175,17 +175,17 @@ namespace ServiceStack.ServiceHost
 
         public List<string> GetAllOperationNames()
         {
-            return Operations.Select(x => x.RequestType.Name).ToList();
+            return Operations.Select(x => x.RequestType.Name).OrderBy(operation => operation).ToList();
         }
 
         public List<string> GetOperationNamesForMetadata(IHttpRequest httpReq)
         {
-            return Operations.Select(x => x.RequestType.Name).ToList();
+            return GetAllOperationNames();
         }
 
         public List<string> GetOperationNamesForMetadata(IHttpRequest httpReq, Format format)
         {
-            return Operations.Select(x => x.RequestType.Name).ToList();
+            return GetAllOperationNames();
         }
 
         public bool IsVisible(IHttpRequest httpReq, Operation operation)


### PR DESCRIPTION
When there are a bunch of objects in the list, it's easier if they're sorted alphabetically.

Also moved the logic into one function that's referenced by all three functions for DRY happyness.
