### PR TITLE
Failing test for Html.CheckBoxFor() - cannot submit bool=true

### DIFF
--- a/tests/ServiceStack.Razor.Tests/CheckBoxService.cs
+++ b/tests/ServiceStack.Razor.Tests/CheckBoxService.cs
@@ -1,0 +1,32 @@
+﻿using ServiceStack.ServiceHost;
+
+namespace ServiceStack.Razor.Tests
+{
+    public class CheckBoxService : ServiceInterface.Service
+    {
+        public CheckBoxData Get(GetCheckBox request)
+        {
+            return new CheckBoxData
+                       {
+                           BooleanValue = true
+                       };
+        }
+
+        public CheckBoxData Post(CheckBoxData request)
+        {
+            return Get(new GetCheckBox());
+        }
+    }
+
+    [Route("/checkbox", "GET")]
+    public class GetCheckBox
+    {
+        
+    }
+
+    [Route("/checkbox", "POST")]
+    public class CheckBoxData
+    {
+        public bool BooleanValue { get; set; }
+    }
+}

--- a/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
+++ b/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
@@ -72,6 +72,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CheckBoxService.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
@@ -89,6 +90,7 @@
     <Content Include="Views\Foobar\FooResponse.cshtml" />
     <Content Include="default4.cshtml" />
     <Content Include="Views\Foobar\DefaultViewFoo.cshtml" />
+    <Content Include="Views\CheckBoxData.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/tests/ServiceStack.Razor.Tests/Views/CheckBoxData.cshtml
+++ b/tests/ServiceStack.Razor.Tests/Views/CheckBoxData.cshtml
@@ -1,0 +1,14 @@
+﻿@inherits ServiceStack.Razor.ViewPage<ServiceStack.Razor.Tests.CheckBoxData>
+@using System
+
+<div>
+    <h4>Html CheckBox Helper</h4>
+    <h4>/Views/CheckBox</h4>
+    The time is: @DateTime.Now
+
+    <form method="POST" action="/checkbox">
+        @Html.CheckBoxFor(x => x.BooleanValue) Boolean Value
+        <br />
+        <input type="submit" value="Submit"/>
+    </form>
+</div>


### PR DESCRIPTION
Html.CheckBoxFor creates a second hidden input for the bool to ensure that
the false value is set with the post. But in the case of a true value,
both the checkbox and hidden input values are sent with the form.
ServiceStack sees this data as a list and has trouble deserializing the
list into a bool.

StackTrack:

```
ERROR|EndpointHandlerBase|Error occured while Processing Request: Unable to bind request|ServiceStack.WebHost.Endpoints.RequestBindingException: Unable to bind request ---> System.Runtime.Serialization.SerializationException: KeyValueDataContractDeserializer: Error converting to type: String was not recognized as a valid Boolean. ---> System.FormatException: String was not recognized as a valid Boolean.
   at System.Boolean.Parse(String value)
   at ServiceStack.Text.Common.DeserializeBuiltin`1.<GetParseFn>b__0(String value)
   at ServiceStack.Text.Common.JsReader`1.<>c__DisplayClassb`1.<GetCoreParseFn>b__7(String value)
   at ServiceStack.ServiceModel.Serialization.StringMapTypeDeserializer.PopulateFromMap(Object instance, IDictionary`2 keyValuePairs, List`1 ignoredWarningsOnPropertyNames) in c:\code\github\ServiceStack\src\ServiceStack.Common\ServiceModel\Serialization\StringMapTypeDeserializer.cs:line 108
   --- End of inner exception stack trace ---
   at ServiceStack.ServiceModel.Serialization.StringMapTypeDeserializer.PopulateFromMap(Object instance, IDictionary`2 keyValuePairs, List`1 ignoredWarningsOnPropertyNames) in c:\code\github\ServiceStack\src\ServiceStack.Common\ServiceModel\Serialization\StringMapTypeDeserializer.cs:line 132
   at ServiceStack.ServiceHost.RestPath.CreateRequest(String pathInfo, Dictionary`2 queryStringAndFormData, Object fromInstance) in c:\code\github\ServiceStack\src\ServiceStack\ServiceHost\RestPath.cs:line 351
   at ServiceStack.WebHost.Endpoints.RestHandler.GetRequest(IHttpRequest httpReq, IRestPath restPath) in c:\code\github\ServiceStack\src\ServiceStack\WebHost.Endpoints\RestHandler.cs:line 107
   --- End of inner exception stack trace ---
   at ServiceStack.WebHost.Endpoints.RestHandler.GetRequest(IHttpRequest httpReq, IRestPath restPath) in c:\code\github\ServiceStack\src\ServiceStack\WebHost.Endpoints\RestHandler.cs:line 111
   at ServiceStack.WebHost.Endpoints.RestHandler.ProcessRequest(IHttpRequest httpReq, IHttpResponse httpRes, String operationName) in c:\code\github\ServiceStack\src\ServiceStack\WebHost.Endpoints\RestHandler.cs:line 62
```
