### PR TITLE
Fix in Auto-Mapping methods for protected/private properties

### DIFF
--- a/src/ServiceStack.Common/Utils/ReflectionUtils.cs
+++ b/src/ServiceStack.Common/Utils/ReflectionUtils.cs
@@ -144,7 +144,7 @@ namespace ServiceStack.Common.Utils
                     }
                     else
                     {
-                        if (propertyInfo.CanWrite)
+                        if (propertyInfo.CanWrite && propertyInfo.GetSetMethod() != null)
                         {
                             map[info.Name] = new AssignmentMember(propertyInfo.PropertyType, propertyInfo);
                             continue;

--- a/tests/ServiceStack.Common.Tests/ReflectionExtensionsTests.cs
+++ b/tests/ServiceStack.Common.Tests/ReflectionExtensionsTests.cs
@@ -28,6 +28,11 @@ namespace ServiceStack.Common.Tests
 		public ArrayOfString FromUserFileTypes { get; set; }
 	}
 
+    public class TestClassC
+    {
+        public IList<string> FromStringList { get; protected set; }
+    }
+
 	[TestFixture]
 	public class ReflectionExtensionsTests
 	{
@@ -58,6 +63,20 @@ namespace ServiceStack.Common.Tests
 			var fromTestB = testB.TranslateTo<TestClassA>();
 			AssertAreEqual(fromTestB, testB);
 		}
+
+        [Test]
+        public void Can_translate_generic_list_does_ignore_protected_setters()
+        {
+            var values = new[] { "A", "B", "C" };
+            var testA = new TestClassA
+            {
+                ToStringList = new List<string>(values),
+            };
+
+            var fromTestA = testA.TranslateTo<TestClassC>();
+            Assert.NotNull(fromTestA);
+            Assert.IsNull(fromTestA.FromStringList);
+        }
 
 		private static void AssertAreEqual(TestClassA testA, TestClassB testB)
 		{


### PR DESCRIPTION
For a problem description see: https://groups.google.com/d/msg/servicestack/DYI1LlBG4zo/IB-njmxuFAAJ

As Demis suggested in the answer to my post to the list, I ensured that the Set-Method of the property is accessible. This prevents an ArgumentNullException in PropertyInvoker.

I also included a test case ReflectionExtensionsTests::Can_translate_generic_list_does_ignore_protected_setters that failed without the change. The other existing tests still pass.
