### PR TITLE
One possible way to handle Nullables in Swagger models

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -192,12 +192,7 @@ namespace ServiceStack.Api.Swagger
 
         private static string GetSwaggerTypeName(Type type)
         {
-	        Type lookupType = type;
-
-			if (IsNullable(type))
-			{
-				lookupType = type.GetGenericArguments()[0];
-			}
+			var lookupType = Nullable.GetUnderlyingType(type) ?? type;
 
 			return ClrTypesToSwaggerScalarTypes.ContainsKey(lookupType.Name.ToLowerInvariant())
 				? ClrTypesToSwaggerScalarTypes[lookupType.Name.ToLowerInvariant()]

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/SwaggerFeatureTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/SwaggerFeatureTests.cs
@@ -451,8 +451,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		[Test, TestCaseSource("RestClients")]
 		public void Should_retrieve_valid_nullable_fields(IRestClient client)
 		{
-			var resource = client.Get<ResourceResponse>("/resource/swgnull" +
-														"");
+			var resource = client.Get<ResourceResponse>("/resource/swgnull");
 			Assert.That(resource.Models.ContainsKey(typeof(NullableInRequest).Name), Is.True);
 			var requestClassModel = resource.Models[typeof(NullableInRequest).Name];
 


### PR DESCRIPTION
If you define a field of Nullable type in a model, the Response Class section will show that field as complex type with HasValue and Value sub-fields. In case you agree that is not desirable, I want to propose the following soultion: we expose nullable field as field of underlying type, marking it with required = false.

Does this have sense?
