### PR TITLE
Remove debugger call from FileSystemWatcherLiveReload.cs

### DIFF
--- a/src/ServiceStack.Razor/Managers/FileSystemWatcherLiveReload.cs
+++ b/src/ServiceStack.Razor/Managers/FileSystemWatcherLiveReload.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.Razor.Managers
 
                 if (!views.Pages.Remove(oldPagePath))
                 {
-                    Debugger.Break();
+                    //Debugger.Break();
                 }
 
                 views.AddPage(e.FullPath);


### PR DESCRIPTION
We have a problem with launching the Debugger as our javascript project files are synced to the ServiceStack server's bin folder regularly as they are being worked on.
