### PR TITLE
Non-String Values are Not URL Encoded in Query String

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/UrlExtensions.cs
@@ -168,7 +168,8 @@ namespace ServiceStack.ServiceClient.Web
         public static Func<object, string> FormatVariable = value =>
         {
             var valueString = value as string;
-            return valueString != null ? Uri.EscapeDataString(valueString) : FormatValue(value ?? "").Trim('"');
+            valueString = valueString ?? FormatValue(value);
+            return Uri.EscapeDataString(valueString);
         };
 
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Using field is just easier.")]
@@ -176,7 +177,8 @@ namespace ServiceStack.ServiceClient.Web
         {
             // Perhaps custom formatting needed for DateTimes, lists, etc.
             var valueString = value as string;
-            return valueString != null ? Uri.EscapeDataString(valueString) : FormatValue(value);
+            valueString = valueString ?? FormatValue(value);
+            return Uri.EscapeDataString(valueString);
         };
 
         private const char PathSeparatorChar = '/';

--- a/tests/ServiceStack.Common.Tests/ServiceClient.Web/UrlExtensionsTests.cs
+++ b/tests/ServiceStack.Common.Tests/ServiceClient.Web/UrlExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using NUnit.Framework;
+using ServiceStack.ServiceClient.Web;
+using ServiceStack.Text;
+
+namespace ServiceStack.Common.Tests.ServiceClient.Web
+{
+    [TestFixture]
+    public class UrlExtensionsTests
+    {
+        [Test]
+        public void FormatVariable_DateTimeOffsetValue_ValueIsUrlEncoded()
+        {
+            var dateTimeOffset = DateTimeOffset.Now;
+            var formattedVariable = RestRoute.FormatVariable(dateTimeOffset);
+            var jsv = dateTimeOffset.ToJsv();
+            Assert.AreEqual(Uri.EscapeDataString(jsv), formattedVariable);
+        }
+
+        [Test]
+        public void FormatQueryParameterValue_DateTimeOffsetValue_ValueIsUrlEncoded()
+        {
+            var dateTimeOffset = DateTimeOffset.Now;
+            var formattedVariable = RestRoute.FormatQueryParameterValue(dateTimeOffset);
+            var jsv = dateTimeOffset.ToJsv();
+            Assert.AreEqual(Uri.EscapeDataString(jsv), formattedVariable);
+        }
+    }
+}

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -190,6 +190,7 @@
     <Compile Include="ServiceClient.Web\HtmlServiceClient.cs" />
     <Compile Include="ServiceClient.Web\ServiceClientBaseTester.cs" />
     <Compile Include="ServiceClient.Web\ServiceClientBaseTests.cs" />
+    <Compile Include="ServiceClient.Web\UrlExtensionsTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
     <Compile Include="StringExtensionTests.cs" />
     <Compile Include="ReflectionUtilTests.cs" />


### PR DESCRIPTION
If a value can not be directly cast to a `string`, it is not URL encoded when used in a query string. For example, if you have a DTO that has a `DateTimeOffset` named `FromDate`, the service stack client passes in on the query string as:

`/mydtoroute?fromdate=2013-05-23T20:47:40.955+00:00`

When this gets to the server, deserialization fails and you get a `400` (Bad Request) error. Both : and + are reserved and need to be URL encoded:

`/mydtoroute?fromdate=2013-05-23T20%3A47%3A40.955%2B00%3A00`

My code change URL encodes all query string values. If they can't be cast to a string, they are URL encoded after formatted.
