### PR TITLE
Initial interface int -> long conversion

### DIFF
--- a/src/ServiceStack.Interfaces/Redis/Generic/IRedisList.Generic.cs
+++ b/src/ServiceStack.Interfaces/Redis/Generic/IRedisList.Generic.cs
@@ -28,8 +28,8 @@ namespace ServiceStack.Redis.Generic
 		List<T> GetRangeFromSortedList(int startingFrom, int endingAt);
 		void RemoveAll();
 		void Trim(int keepStartingFrom, int keepEndingAt);
-		int RemoveValue(T value);
-		int RemoveValue(T value, int noOfMatches);
+		long RemoveValue(T value);
+		long RemoveValue(T value, int noOfMatches);
 
 		void AddRange(IEnumerable<T> values);
 		void Append(T value);

--- a/src/ServiceStack.Interfaces/Redis/Generic/IRedisSortedSet.Generic.cs
+++ b/src/ServiceStack.Interfaces/Redis/Generic/IRedisSortedSet.Generic.cs
@@ -21,7 +21,7 @@ namespace ServiceStack.Redis.Generic
 		T PopItemWithLowestScore();
 		double IncrementItem(T item, double incrementBy);
 		int IndexOf(T item);
-		int IndexOfDescending(T item);
+		long IndexOfDescending(T item);
 		List<T> GetAll();
 		List<T> GetAllDescending();
 		List<T> GetRange(int fromRank, int toRank);
@@ -29,10 +29,10 @@ namespace ServiceStack.Redis.Generic
 		List<T> GetRangeByLowestScore(double fromScore, double toScore, int? skip, int? take);
 		List<T> GetRangeByHighestScore(double fromScore, double toScore);
 		List<T> GetRangeByHighestScore(double fromScore, double toScore, int? skip, int? take);
-		int RemoveRange(int minRank, int maxRank);
-		int RemoveRangeByScore(double fromScore, double toScore);
+		long RemoveRange(int minRank, int maxRank);
+		long RemoveRangeByScore(double fromScore, double toScore);
 		double GetItemScore(T item);
-		int PopulateWithIntersectOf(params IRedisSortedSet<T>[] setIds);
-		int PopulateWithUnionOf(params IRedisSortedSet<T>[] setIds);
+		long PopulateWithIntersectOf(params IRedisSortedSet<T>[] setIds);
+		long PopulateWithUnionOf(params IRedisSortedSet<T>[] setIds);
 	}
 }

--- a/src/ServiceStack.Interfaces/Redis/Generic/IRedisTypedClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/Generic/IRedisTypedClient.cs
@@ -36,7 +36,7 @@ namespace ServiceStack.Redis.Generic
 		IDisposable AcquireLock();
 		IDisposable AcquireLock(TimeSpan timeOut);
 
-		int Db { get; set; }
+		long Db { get; set; }
 		List<string> GetAllKeys();
 		IRedisSet TypeIdsSet { get; }
 
@@ -86,7 +86,7 @@ namespace ServiceStack.Redis.Generic
 		void RemoveItemFromSet(IRedisSet<T> fromSet, T item);
 		T PopItemFromSet(IRedisSet<T> fromSet);
 		void MoveBetweenSets(IRedisSet<T> fromSet, IRedisSet<T> toSet, T item);
-		int GetSetCount(IRedisSet<T> set);
+		long GetSetCount(IRedisSet<T> set);
 		bool SetContainsItem(IRedisSet<T> set, T item);
 		HashSet<T> GetIntersectFromSets(params IRedisSet<T>[] sets);
 		void StoreIntersectFromSets(IRedisSet<T> intoSet, params IRedisSet<T>[] sets);
@@ -107,9 +107,9 @@ namespace ServiceStack.Redis.Generic
 		T RemoveEndFromList(IRedisList<T> fromList);
 		void RemoveAllFromList(IRedisList<T> fromList);
 		void TrimList(IRedisList<T> fromList, int keepStartingFrom, int keepEndingAt);
-		int RemoveItemFromList(IRedisList<T> fromList, T value);
-		int RemoveItemFromList(IRedisList<T> fromList, T value, int noOfMatches);
-		int GetListCount(IRedisList<T> fromList);
+		long RemoveItemFromList(IRedisList<T> fromList, T value);
+		long RemoveItemFromList(IRedisList<T> fromList, T value, int noOfMatches);
+		long GetListCount(IRedisList<T> fromList);
 		T GetItemFromList(IRedisList<T> fromList, int listIndex);
 		void SetItemInList(IRedisList<T> toList, int listIndex, T value);
         void InsertBeforeItemInList(IRedisList<T> toList, T pivot, T value);
@@ -135,8 +135,8 @@ namespace ServiceStack.Redis.Generic
 		T PopItemWithHighestScoreFromSortedSet(IRedisSortedSet<T> fromSet);
 		bool SortedSetContainsItem(IRedisSortedSet<T> set, T value);
 		double IncrementItemInSortedSet(IRedisSortedSet<T> set, T value, double incrementBy);
-		int GetItemIndexInSortedSet(IRedisSortedSet<T> set, T value);
-		int GetItemIndexInSortedSetDesc(IRedisSortedSet<T> set, T value);
+		long GetItemIndexInSortedSet(IRedisSortedSet<T> set, T value);
+		long GetItemIndexInSortedSetDesc(IRedisSortedSet<T> set, T value);
 		List<T> GetAllItemsFromSortedSet(IRedisSortedSet<T> set);
 		List<T> GetAllItemsFromSortedSetDesc(IRedisSortedSet<T> set);
 		List<T> GetRangeFromSortedSet(IRedisSortedSet<T> set, int fromRank, int toRank);
@@ -160,12 +160,12 @@ namespace ServiceStack.Redis.Generic
 		IDictionary<T, double> GetRangeWithScoresFromSortedSetByHighestScore(IRedisSortedSet<T> set, string fromStringScore, string toStringScore, int? skip, int? take);
 		IDictionary<T, double> GetRangeWithScoresFromSortedSetByHighestScore(IRedisSortedSet<T> set, double fromScore, double toScore);
 		IDictionary<T, double> GetRangeWithScoresFromSortedSetByHighestScore(IRedisSortedSet<T> set, double fromScore, double toScore, int? skip, int? take);
-		int RemoveRangeFromSortedSet(IRedisSortedSet<T> set, int minRank, int maxRank);
-		int RemoveRangeFromSortedSetByScore(IRedisSortedSet<T> set, double fromScore, double toScore);
-		int GetSortedSetCount(IRedisSortedSet<T> set);
+		long RemoveRangeFromSortedSet(IRedisSortedSet<T> set, int minRank, int maxRank);
+		long RemoveRangeFromSortedSetByScore(IRedisSortedSet<T> set, double fromScore, double toScore);
+		long GetSortedSetCount(IRedisSortedSet<T> set);
 		double GetItemScoreInSortedSet(IRedisSortedSet<T> set, T value);
-		int StoreIntersectFromSortedSets(IRedisSortedSet<T> intoSetId, params IRedisSortedSet<T>[] setIds);
-		int StoreUnionFromSortedSets(IRedisSortedSet<T> intoSetId, params IRedisSortedSet<T>[] setIds);
+		long StoreIntersectFromSortedSets(IRedisSortedSet<T> intoSetId, params IRedisSortedSet<T>[] setIds);
+		long StoreUnionFromSortedSets(IRedisSortedSet<T> intoSetId, params IRedisSortedSet<T>[] setIds);
 		
 		//Hash operations
 		bool HashContainsEntry<TKey>(IRedisHash<TKey, T> hash, TKey key);
@@ -174,7 +174,7 @@ namespace ServiceStack.Redis.Generic
 		void SetRangeInHash<TKey>(IRedisHash<TKey, T> hash, IEnumerable<KeyValuePair<TKey, T>> keyValuePairs);
 		T GetValueFromHash<TKey>(IRedisHash<TKey, T> hash, TKey key);
 		bool RemoveEntryFromHash<TKey>(IRedisHash<TKey, T> hash, TKey key);
-		int GetHashCount<TKey>(IRedisHash<TKey, T> hash);
+		long GetHashCount<TKey>(IRedisHash<TKey, T> hash);
 		List<TKey> GetHashKeys<TKey>(IRedisHash<TKey, T> hash);
 		List<T> GetHashValues<TKey>(IRedisHash<TKey, T> hash);
 		Dictionary<TKey, T> GetAllEntriesFromHash<TKey>(IRedisHash<TKey, T> hash);
@@ -185,7 +185,7 @@ namespace ServiceStack.Redis.Generic
 		void DeleteRelatedEntities<TChild>(object parentId);
 		void DeleteRelatedEntity<TChild>(object parentId, object childId);
 		List<TChild> GetRelatedEntities<TChild>(object parentId);
-		int GetRelatedEntitiesCount<TChild>(object parentId);
+		long GetRelatedEntitiesCount<TChild>(object parentId);
 		void AddToRecentsList(T value);
 		List<T> GetLatestFromRecentsList(int skip, int take);
 		List<T> GetEarliestFromRecentsList(int skip, int take);

--- a/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
@@ -27,8 +27,8 @@ namespace ServiceStack.Redis
 		: IBasicPersistenceProvider, ICacheClient
 	{
 		//Basic Redis Connection operations
-		int Db { get; set; }
-		int DbSize { get; }
+		long Db { get; set; }
+		long DbSize { get; }
 		Dictionary<string, string> Info { get; }
 		DateTime LastSave { get; }
 		string Host { get; }
@@ -61,7 +61,7 @@ namespace ServiceStack.Redis
 		List<T> GetValues<T>(List<string> keys);
 		Dictionary<string, string> GetValuesMap(List<string> keys);
 		Dictionary<string, T> GetValuesMap<T>(List<string> keys);
-		int AppendToValue(string key, string value);
+		long AppendToValue(string key, string value);
 		void RenameKey(string fromName, string toName);
 		string GetSubstring(string key, int fromIndex, int toIndex);
 
@@ -118,7 +118,7 @@ namespace ServiceStack.Redis
 		void Watch(params string[] keys);
 		void UnWatch();
 		IRedisSubscription CreateSubscription();
-		int PublishMessage(string toChannel, string message);
+		long PublishMessage(string toChannel, string message);
 
 		#endregion
 
@@ -131,7 +131,7 @@ namespace ServiceStack.Redis
 		void RemoveItemFromSet(string setId, string item);
 		string PopItemFromSet(string setId);
 		void MoveBetweenSets(string fromSetId, string toSetId, string item);
-		int GetSetCount(string setId);
+		long GetSetCount(string setId);
 		bool SetContainsItem(string setId, string item);
 		HashSet<string> GetIntersectFromSets(params string[] setIds);
 		void StoreIntersectFromSets(string intoSetId, params string[] setIds);
@@ -161,9 +161,9 @@ namespace ServiceStack.Redis
         ItemRef BlockingRemoveStartFromLists(string []listIds, TimeSpan? timeOut);
 		string RemoveEndFromList(string listId);
 		void TrimList(string listId, int keepStartingFrom, int keepEndingAt);
-		int RemoveItemFromList(string listId, string value);
-		int RemoveItemFromList(string listId, string value, int noOfMatches);
-		int GetListCount(string listId);
+		long RemoveItemFromList(string listId, string value);
+		long RemoveItemFromList(string listId, string value, int noOfMatches);
+		long GetListCount(string listId);
 		string GetItemFromList(string listId, int listIndex);
 		void SetItemInList(string listId, int listIndex, string value);
 
@@ -196,8 +196,8 @@ namespace ServiceStack.Redis
 		bool SortedSetContainsItem(string setId, string value);
 		double IncrementItemInSortedSet(string setId, string value, double incrementBy);
 		double IncrementItemInSortedSet(string setId, string value, long incrementBy);
-		int GetItemIndexInSortedSet(string setId, string value);
-		int GetItemIndexInSortedSetDesc(string setId, string value);
+		long GetItemIndexInSortedSet(string setId, string value);
+		long GetItemIndexInSortedSetDesc(string setId, string value);
 		List<string> GetAllItemsFromSortedSet(string setId);
 		List<string> GetAllItemsFromSortedSetDesc(string setId);
 		List<string> GetRangeFromSortedSet(string setId, int fromRank, int toRank);
@@ -229,16 +229,16 @@ namespace ServiceStack.Redis
 		IDictionary<string, double> GetRangeWithScoresFromSortedSetByHighestScore(string setId, long fromScore, long toScore);
 		IDictionary<string, double> GetRangeWithScoresFromSortedSetByHighestScore(string setId, double fromScore, double toScore, int? skip, int? take);
 		IDictionary<string, double> GetRangeWithScoresFromSortedSetByHighestScore(string setId, long fromScore, long toScore, int? skip, int? take);
-		int RemoveRangeFromSortedSet(string setId, int minRank, int maxRank);
-		int RemoveRangeFromSortedSetByScore(string setId, double fromScore, double toScore);
-		int RemoveRangeFromSortedSetByScore(string setId, long fromScore, long toScore);
-        int GetSortedSetCount(string setId);
-        int GetSortedSetCount(string setId, string fromStringScore, string toStringScore);
-        int GetSortedSetCount(string setId, long fromScore, long toScore);
-        int GetSortedSetCount(string setId, double fromScore, double toScore);
+		long RemoveRangeFromSortedSet(string setId, int minRank, int maxRank);
+		long RemoveRangeFromSortedSetByScore(string setId, double fromScore, double toScore);
+		long RemoveRangeFromSortedSetByScore(string setId, long fromScore, long toScore);
+		long GetSortedSetCount(string setId);
+		long GetSortedSetCount(string setId, string fromStringScore, string toStringScore);
+		long GetSortedSetCount(string setId, long fromScore, long toScore);
+		long GetSortedSetCount(string setId, double fromScore, double toScore);
 		double GetItemScoreInSortedSet(string setId, string value);
-		int StoreIntersectFromSortedSets(string intoSetId, params string[] setIds);
-		int StoreUnionFromSortedSets(string intoSetId, params string[] setIds);
+		long StoreIntersectFromSortedSets(string intoSetId, params string[] setIds);
+		long StoreUnionFromSortedSets(string intoSetId, params string[] setIds);
 
 		#endregion
 
@@ -249,11 +249,11 @@ namespace ServiceStack.Redis
 		bool SetEntryInHash(string hashId, string key, string value);
 		bool SetEntryInHashIfNotExists(string hashId, string key, string value);
 		void SetRangeInHash(string hashId, IEnumerable<KeyValuePair<string, string>> keyValuePairs);
-		int IncrementValueInHash(string hashId, string key, int incrementBy);
+		long IncrementValueInHash(string hashId, string key, int incrementBy);
 		string GetValueFromHash(string hashId, string key);
 		List<string> GetValuesFromHash(string hashId, params string[] keys);
 		bool RemoveEntryFromHash(string hashId, string key);
-		int GetHashCount(string hashId);
+		long GetHashCount(string hashId);
 		List<string> GetHashKeys(string hashId);
 		List<string> GetHashValues(string hashId);
 		Dictionary<string, string> GetAllEntriesFromHash(string hashId);
@@ -267,11 +267,11 @@ namespace ServiceStack.Redis
         string ExecLuaAsString(string luaBody, string[] keys, string[] args);
         string ExecLuaShaAsString(string sha1, params string[] args);
         string ExecLuaShaAsString(string sha1, string[] keys, string[] args);
-        
-        int ExecLuaAsInt(string luaBody, params string[] args);
-        int ExecLuaAsInt(string luaBody, string[] keys, string[] args);
-        int ExecLuaShaAsInt(string sha1, params string[] args);
-        int ExecLuaShaAsInt(string sha1, string[] keys, string[] args);
+
+		long ExecLuaAsInt(string luaBody, params string[] args);
+		long ExecLuaAsInt(string luaBody, string[] keys, string[] args);
+		long ExecLuaShaAsInt(string sha1, params string[] args);
+		long ExecLuaShaAsInt(string sha1, string[] keys, string[] args);
 
         List<string> ExecLuaAsList(string luaBody, params string[] args);
         List<string> ExecLuaAsList(string luaBody, string[] keys, string[] args);

--- a/src/ServiceStack.Interfaces/Redis/IRedisHash.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisHash.cs
@@ -8,6 +8,6 @@ namespace ServiceStack.Redis
 	{
 		bool AddIfNotExists(KeyValuePair<string, string> item);
 		void AddRange(IEnumerable<KeyValuePair<string, string>> items);
-		int IncrementValue(string key, int incrementBy);
+		long IncrementValue(string key, int incrementBy);
 	}
 }

--- a/src/ServiceStack.Interfaces/Redis/IRedisList.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisList.cs
@@ -24,8 +24,8 @@ namespace ServiceStack.Redis
 		List<string> GetRangeFromSortedList(int startingFrom, int endingAt);
 		void RemoveAll();
 		void Trim(int keepStartingFrom, int keepEndingAt);
-		int RemoveValue(string value);
-		int RemoveValue(string value, int noOfMatches);
+		long RemoveValue(string value);
+		long RemoveValue(string value, int noOfMatches);
 
 		void Prepend(string value);
 		void Append(string value);

--- a/src/ServiceStack.Interfaces/Redis/IRedisNativeClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisNativeClient.cs
@@ -20,8 +20,8 @@ namespace ServiceStack.Redis
 	{
 		//Redis utility operations
 		Dictionary<string, string> Info { get; }
-		int Db { get; set; }
-		int DbSize { get; }
+		long Db { get; set; }
+		long DbSize { get; }
 		DateTime LastSave { get; }
 		void Save();
 		void BgSave();
@@ -43,17 +43,17 @@ namespace ServiceStack.Redis
 		byte[] Restore(string key, long expireMs, byte[] dumpValue);
 		void Migrate(string host, int port, int destinationDb, long timeoutMs);
 		bool Move(string key, int db);
-		int ObjectIdleTime(string key);
+		long ObjectIdleTime(string key);
 
 		//Common key-value Redis operations
 		byte[][] Keys(string pattern);
-		int Exists(string key);
-		int StrLen(string key);
+		long Exists(string key);
+		long StrLen(string key);
 		void Set(string key, byte[] value);
 		void SetEx(string key, int expireInSeconds, byte[] value);
 		bool Persist(string key);
 		void PSetEx(string key, long expireInMs, byte[] value);
-		int SetNX(string key, byte[] value);
+		long SetNX(string key, byte[] value);
 		void MSet(byte[][] keys, byte[][] values);
 		void MSet(string[] keys, byte[][] values);
 		bool MSetNx(byte[][] keys, byte[][] values);
@@ -62,20 +62,20 @@ namespace ServiceStack.Redis
 		byte[] GetSet(string key, byte[] value);
 		byte[][] MGet(params byte[][] keysAndArgs);
 		byte[][] MGet(params string[] keys);
-		int Del(string key);
-		int Del(params string[] keys);
+		long Del(string key);
+		long Del(params string[] keys);
 		long Incr(string key);
 		long IncrBy(string key, int incrBy);
 		double IncrByFloat(string key, double incrBy);
 		long Decr(string key);
 		long DecrBy(string key, int decrBy);
-		int Append(string key, byte[] value);
+		long Append(string key, byte[] value);
 		[Obsolete("Was renamed to GetRange in 2.4")]
 		byte[] Substr(string key, int fromIndex, int toIndex);
 		byte[] GetRange(string key, int fromIndex, int toIndex);
-		int SetRange(string key, int offset, byte[] value);
-		int GetBit(string key, int offset);
-		int SetBit(string key, int offset, int value);
+		long SetRange(string key, int offset, byte[] value);
+		long GetBit(string key, int offset);
+		long SetBit(string key, int offset, int value);
 		
 		string RandomKey();
 		void Rename(string oldKeyname, string newKeyname);
@@ -84,7 +84,7 @@ namespace ServiceStack.Redis
 		bool PExpire(string key, long ttlMs);
 		bool ExpireAt(string key, long unixTime);
 		bool PExpireAt(string key, long unixTimeMs);
-		int Ttl(string key);
+		long Ttl(string key);
 		long PTtl(string key);
 
 		//Redis Sort operation (works on lists, sets or hashes)
@@ -92,13 +92,13 @@ namespace ServiceStack.Redis
 
 		//Redis List operations
 		byte[][] LRange(string listId, int startingFrom, int endingAt);
-		int RPush(string listId, byte[] value);
-		int RPushX(string listId, byte[] value);
-		int LPush(string listId, byte[] value);
-		int LPushX(string listId, byte[] value);
+		long RPush(string listId, byte[] value);
+		long RPushX(string listId, byte[] value);
+		long LPush(string listId, byte[] value);
+		long LPushX(string listId, byte[] value);
 		void LTrim(string listId, int keepStartingFrom, int keepEndingAt);
-		int LRem(string listId, int removeNoOfMatches, byte[] value);
-		int LLen(string listId);
+		long LRem(string listId, int removeNoOfMatches, byte[] value);
+		long LLen(string listId);
 		byte[] LIndex(string listId, int listIndex);
         void LInsert(string listId, bool insertBefore, byte[] pivot, byte[] value);
 		void LSet(string listId, int listIndex, byte[] value);
@@ -116,12 +116,12 @@ namespace ServiceStack.Redis
 
 		//Redis Set operations
 		byte[][] SMembers(string setId);
-		int SAdd(string setId, byte[] value);
-		int SRem(string setId, byte[] value);
+		long SAdd(string setId, byte[] value);
+		long SRem(string setId, byte[] value);
 		byte[] SPop(string setId);
 		void SMove(string fromSetId, string toSetId, byte[] value);
-		int SCard(string setId);
-		int SIsMember(string setId, byte[] value);
+		long SCard(string setId);
+		long SIsMember(string setId, byte[] value);
 		byte[][] SInter(params string[] setIds);
 		void SInterStore(string intoSetId, params string[] setIds);
 		byte[][] SUnion(params string[] setIds);
@@ -132,13 +132,13 @@ namespace ServiceStack.Redis
 
 
 		//Redis Sorted Set operations
-		int ZAdd(string setId, double score, byte[] value);
-		int ZAdd(string setId, long score, byte[] value);
-		int ZRem(string setId, byte[] value);
+		long ZAdd(string setId, double score, byte[] value);
+		long ZAdd(string setId, long score, byte[] value);
+		long ZRem(string setId, byte[] value);
 		double ZIncrBy(string setId, double incrBy, byte[] value);
 		double ZIncrBy(string setId, long incrBy, byte[] value);
-		int ZRank(string setId, byte[] value);
-		int ZRevRank(string setId, byte[] value);
+		long ZRank(string setId, byte[] value);
+		long ZRevRank(string setId, byte[] value);
 		byte[][] ZRange(string setId, int min, int max);
 		byte[][] ZRangeWithScores(string setId, int min, int max);
 		byte[][] ZRevRange(string setId, int min, int max);
@@ -151,25 +151,25 @@ namespace ServiceStack.Redis
 		byte[][] ZRevRangeByScore(string setId, long min, long max, int? skip, int? take);
 		byte[][] ZRevRangeByScoreWithScores(string setId, double min, double max, int? skip, int? take);
 		byte[][] ZRevRangeByScoreWithScores(string setId, long min, long max, int? skip, int? take);
-		int ZRemRangeByRank(string setId, int min, int max);
-		int ZRemRangeByScore(string setId, double fromScore, double toScore);
-		int ZRemRangeByScore(string setId, long fromScore, long toScore);
-		int ZCard(string setId);
+		long ZRemRangeByRank(string setId, int min, int max);
+		long ZRemRangeByScore(string setId, double fromScore, double toScore);
+		long ZRemRangeByScore(string setId, long fromScore, long toScore);
+		long ZCard(string setId);
 		double ZScore(string setId, byte[] value);
-		int ZUnionStore(string intoSetId, params string[] setIds);
-		int ZInterStore(string intoSetId, params string[] setIds);
+		long ZUnionStore(string intoSetId, params string[] setIds);
+		long ZInterStore(string intoSetId, params string[] setIds);
 
 		//Redis Hash operations
-		int HSet(string hashId, byte[] key, byte[] value);
+		long HSet(string hashId, byte[] key, byte[] value);
 		void HMSet(string hashId, byte[][] keys, byte[][] values);
-		int HSetNX(string hashId, byte[] key, byte[] value);
-		int HIncrby(string hashId, byte[] key, int incrementBy);
+		long HSetNX(string hashId, byte[] key, byte[] value);
+		long HIncrby(string hashId, byte[] key, int incrementBy);
 		double HIncrbyFloat(string hashId, byte[] key, double incrementBy);
 		byte[] HGet(string hashId, byte[] key);
 		byte[][] HMGet(string hashId, params byte[][] keysAndArgs);
-		int HDel(string hashId, byte[] key);
-		int HExists(string hashId, byte[] key);
-		int HLen(string hashId);
+		long HDel(string hashId, byte[] key);
+		long HExists(string hashId, byte[] key);
+		long HLen(string hashId);
 		byte[][] HKeys(string hashId);
 		byte[][] HVals(string hashId);
 		byte[][] HGetAll(string hashId);
@@ -177,7 +177,7 @@ namespace ServiceStack.Redis
 		//Redis Pub/Sub operations
 		void Watch(params string[] keys);
 		void UnWatch();
-		int Publish(string toChannel, byte[] message);
+		long Publish(string toChannel, byte[] message);
 		byte[][] Subscribe(params string[] toChannels);
 		byte[][] UnSubscribe(params string[] toChannels);
 		byte[][] PSubscribe(params string[] toChannelsMatchingPatterns);
@@ -185,8 +185,8 @@ namespace ServiceStack.Redis
 		byte[][] ReceiveMessages();
 
         //Redis LUA support
-        int EvalInt(string luaBody, int numberOfKeys, params byte[][] keysAndArgs);
-        int EvalShaInt(string sha1, int numberOfKeys, params byte[][] keysAndArgs);
+		long EvalInt(string luaBody, int numberOfKeys, params byte[][] keysAndArgs);
+		long EvalShaInt(string sha1, int numberOfKeys, params byte[][] keysAndArgs);
         string EvalStr(string luaBody, int numberOfKeys, params byte[][] keysAndArgs);
         string EvalShaStr(string sha1, int numberOfKeys, params byte[][] keysAndArgs);
         byte[][] Eval(string luaBody, int numberOfKeys, params byte[][] keysAndArgs);

--- a/src/ServiceStack.Interfaces/Redis/IRedisSortedSet.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisSortedSet.cs
@@ -28,7 +28,7 @@ namespace ServiceStack.Redis
 		void RemoveRangeByScore(double fromScore, double toScore);
 		void StoreFromIntersect(params IRedisSortedSet[] ofSets);
 		void StoreFromUnion(params IRedisSortedSet[] ofSets);
-		int GetItemIndex(string value);
+		long GetItemIndex(string value);
 		double GetItemScore(string value);
 		void IncrementItemScore(string value, double incrementByScore);
 		string PopItemWithHighestScore();

--- a/src/ServiceStack.Interfaces/Redis/IRedisSubscription.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisSubscription.cs
@@ -8,7 +8,7 @@ namespace ServiceStack.Redis
 		/// <summary>
 		/// The number of active subscriptions this client has
 		/// </summary>
-		int SubscriptionCount { get; }
+		long SubscriptionCount { get; }
 		
 		/// <summary>
 		/// Registered handler called after client *Subscribes* to each new channel


### PR DESCRIPTION
This change is part of the proposed changes to address(https://github.com/ServiceStack/ServiceStack.Redis/issues/147).  The issue is that Redis can potentially return longs for any integer value, and our code should try to handle that.

Note that this will be a breaking change for anyone that is actually using the int responses.

Dan
