### PR TITLE
Fix for app relative auth redirects when absolute host uri inferring fails

### DIFF
--- a/src/ServiceStack.ServiceInterface/AuthenticateAttribute.cs
+++ b/src/ServiceStack.ServiceInterface/AuthenticateAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Web;
 using ServiceStack.Common;
 using ServiceStack.Common.Web;
 using ServiceStack.ServiceHost;
@@ -87,6 +88,10 @@ namespace ServiceStack.ServiceInterface
                         if (url.SafeSubstring(0, 2) == "~/")
                         {
                             url = req.GetBaseUrl().CombineWith(url.Substring(2));
+                            // req.GetBaseUrl() returns a root relative url (i.e. '/') if absolute url inferring fails.
+                            // Must handle this case and re-include the virtual application path segment.
+                            if (url.SafeSubstring(0, 1) == "/")
+                                url = VirtualPathUtility.ToAbsolute( url.Insert( 0, "~" ) );
                         }
                         url = url.AddQueryParam("redirect", req.AbsoluteUri);
                         res.RedirectToUrl(url);


### PR DESCRIPTION
The issue occurs when using an AuthService HtmlRedirect of e.g. "~/login.html". That redirect only works when the absolute uri can be resolved via settings like `EndpointHost.Config.WebHostUrl`.

Not sure if my fix is suitable though... e.g. how does using `VirtualPathUtility.ToAbsolute` affects self hosted services? Or if the modification I made should be pushed lower down and made part of the `IHttpRequest.GetBaseUrl()` implementation?
