### PR TITLE
Make sure htmlRedirect is relative before resolving its absolute url.

### DIFF
--- a/src/ServiceStack.ServiceInterface/AuthenticateAttribute.cs
+++ b/src/ServiceStack.ServiceInterface/AuthenticateAttribute.cs
@@ -80,7 +80,7 @@ namespace ServiceStack.ServiceInterface
                 var htmlRedirect = HtmlRedirect ?? AuthService.HtmlRedirect;
                 if (htmlRedirect != null && req.ResponseContentType.MatchesContentType(ContentType.Html))
                 {
-                    var url = req.ResolveAbsoluteUrl(htmlRedirect);
+                    var url = htmlRedirect.IsRelativePath() ? req.ResolveAbsoluteUrl(htmlRedirect) : htmlRedirect;
                     url = url.AddQueryParam("redirect", req.AbsoluteUri);
                     res.RedirectToUrl(url);
                     return;


### PR DESCRIPTION
Related to changes in #699.
I configure `HtmlRedirect` with an absolute url because it is hosted on a separate sub-domain. Sending an absolute url through `ResolveAbsoluteUrl` throws an exception.
