### PR TITLE
fix - set the correct ContentType for optimized response

### DIFF
--- a/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
+++ b/src/ServiceStack/ServiceHost/RequestContextExtensions.cs
@@ -24,7 +24,7 @@ namespace ServiceStack.ServiceHost
 				return (object)serializedDto;
 
 			byte[] compressedBytes = StreamExtensions.Compress(serializedDto, requestContext.CompressionType);
-			return new CompressedResult(compressedBytes, requestContext.CompressionType, requestContext.ContentType);
+            return new CompressedResult(compressedBytes, requestContext.CompressionType, requestContext.ResponseContentType);
 		}
 
 		/// <summary>


### PR DESCRIPTION
In RequestContextExtensions.ToOptimizedResult the ContentType is incorrectly set to requestContext.ContentType instead of requestContext.ResponseContentType.

If there is no incoming request content then request ContentType is empty, and thus the response ContentType is also incorrectly left empty.

Also report on Google Groups: https://groups.google.com/forum/?fromgroups#!topic/servicestack/ABLWbjyW4RY
