### PR TITLE
#668 use extension method to create object instance

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Metadata/XmlMetadataHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Metadata/XmlMetadataHandler.cs
@@ -4,6 +4,7 @@ using ServiceStack.Common.Utils;
 using ServiceStack.ServiceHost;
 using ServiceStack.ServiceModel.Serialization;
 using ServiceStack.WebHost.Endpoints.Support.Metadata.Controls;
+using ServiceStack.Text;
 
 namespace ServiceStack.WebHost.Endpoints.Metadata
 {
@@ -13,7 +14,7 @@ namespace ServiceStack.WebHost.Endpoints.Metadata
 
 		protected override string CreateMessage(Type dtoType)
 		{
-			var requestObj = ReflectionUtils.PopulateObject(Activator.CreateInstance(dtoType));
+			var requestObj = ReflectionUtils.PopulateObject(dtoType.CreateInstance());
 			return DataContractSerializer.Instance.Parse(requestObj, true);
 		}
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Support\Operations\GetCustomer.cs" />
     <Compile Include="Support\Types\Customer.cs" />
+    <Compile Include="XmlMetaDataHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ServiceStack.Api.Swagger\ServiceStack.Api.Swagger.csproj">

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/XmlMetaDataHandlerTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/XmlMetaDataHandlerTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using ServiceStack.WebHost.Endpoints.Metadata;
+using System.Runtime.Serialization;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    [TestFixture]
+    public class XmlMetaDataHandlerTests
+    {
+        [Test]
+        public void when_creating_a_response_for_a_dto_with_no_default_constructor_the_response_is_not_empty()
+        {
+            var handler = new XmlMetadataHandler();
+            var response = handler.CreateResponse(typeof(NoDefaultConstructor));
+            Assert.That(response, Is.Not.Empty);
+        }
+
+    }
+
+    [DataContract(Namespace = "http://schemas.servicestack.net/types")]
+    public class NoDefaultConstructor
+    {
+        public NoDefaultConstructor(string test)
+        { }
+
+        [DataMember]
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
This is a fix for #668, where if you use a DTO without a parameterless constructor it silently errors and returns an empty response. 

I've made the functionality in XmlMetaDataHandler the same as that in JsonMetadataHandler. Instead of trying to create an object instance using Activator.CreateInstance, which is what causes the original error, we create one use the CreateInstance extension method. Which already handles parameterless constructors. 
