### PR TITLE
Only check for IsWatchedFile if a file was found.

### DIFF
--- a/src/ServiceStack.Razor/Managers/FileSystemWatcherLiveReload.cs
+++ b/src/ServiceStack.Razor/Managers/FileSystemWatcherLiveReload.cs
@@ -76,7 +76,7 @@ namespace ServiceStack.Razor.Managers
             try
             {
                 var file = views.GetVirutalFile(e.FullPath);
-                if (!views.IsWatchedFile(file)) return;
+                if (file == null || !views.IsWatchedFile(file)) return;
 
                 var pathPage = views.GetDictionaryPagePath(file);
 
@@ -105,7 +105,7 @@ namespace ServiceStack.Razor.Managers
             try
             {
                 var file = views.GetVirutalFile(e.FullPath);
-                if (!views.IsWatchedFile(file)) return;
+                if (file == null || !views.IsWatchedFile(file)) return;
 
                 var pagePath = views.GetDictionaryPagePath(file);
 


### PR DESCRIPTION
There are some situations where the e.FullPath filename isn't found by
the virtual file system provider (it doesn't exist, etc.) so we need to
account for that before calling views.IsWatchedFile.
