### PR TITLE
Facebook will respect Auth.Continue after authentication

### DIFF
--- a/src/ServiceStack.ServiceInterface/Auth/FacebookAuthProvider.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/FacebookAuthProvider.cs
@@ -34,8 +34,15 @@ namespace ServiceStack.ServiceInterface.Auth
 
             var code = authService.RequestContext.Get<IHttpRequest>().QueryString["code"];
             var isPreAuthCallback = !code.IsNullOrEmpty();
+
             if (!isPreAuthCallback)
             {
+                if (!request.Continue.IsNullOrEmpty())
+                {
+                    // store the continue url in the session for the return trip
+                    session.ReferrerUrl = request.Continue;
+                }
+
                 var preAuthUrl = PreAuthUrl + "?client_id={0}&redirect_uri={1}&scope={2}"
                     .Fmt(AppId, this.CallbackUrl.UrlEncode(), string.Join(",", Permissions));
 


### PR DESCRIPTION
After authenticating using the Facebook OAuth provider the user is now properly redirected to the Continue url (if it was supplied pre auth). The Continue url is stored in the session before making the authentication call to Facebook.
