### PR TITLE
Failing razor test shows page is executed even though redirect was returned

### DIFF
--- a/tests/ServiceStack.Razor.Tests/HelloRequest.cs
+++ b/tests/ServiceStack.Razor.Tests/HelloRequest.cs
@@ -1,4 +1,5 @@
-﻿using ServiceStack.ServiceHost;
+﻿using ServiceStack.Common.Web;
+using ServiceStack.ServiceHost;
 using ServiceStack.ServiceInterface;
 
 namespace ServiceStack.Razor.Tests
@@ -65,6 +66,10 @@ namespace ServiceStack.Razor.Tests
         [DefaultView("DefaultViewFoo")]
         public object Get(DefaultViewFooRequest request)
         {
+            if (request.WhatToSay == "redirect")
+            {
+                return HttpResult.Redirect("/");
+            }
             return new DefaultViewFooResponse { FooSaid = string.Format("GET: {0}", request.WhatToSay) };
         }
     }

--- a/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
+++ b/tests/ServiceStack.Razor.Tests/ServiceStack.Razor.Tests.csproj
@@ -106,6 +106,10 @@
     <Folder Include="Shared\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\ServiceStack.Common\ServiceStack.Common.csproj">
+      <Project>{982416db-c143-4028-a0c3-cf41892d18d3}</Project>
+      <Name>ServiceStack.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj">
       <Project>{42e1c8c0-a163-44cc-92b1-8f416f2c0b01}</Project>
       <Name>ServiceStack.Interfaces</Name>

--- a/tests/ServiceStack.Razor.Tests/Views/Foobar/DefaultViewFoo.cshtml
+++ b/tests/ServiceStack.Razor.Tests/Views/Foobar/DefaultViewFoo.cshtml
@@ -5,7 +5,7 @@
 @using ServiceStack.WebHost.Endpoints
 
 <div>
-    <h4>/Views/Foo</h4>
+    <h4>/Views/DefaultViewFoo</h4>
     The time is: @DateTime.Now
     <h4>Foo Was Here!</h4>
     <h4>He said: @Model.FooSaid</h4>
@@ -17,4 +17,7 @@
 
     obob
     <button>Button out of form</button>
+    
+    <h2>DefaultViewFoo is executed on redirect</h2>
+    <h3>@Model.FooSaid.ToUpper()</h3>
 </div>


### PR DESCRIPTION
When using `DefaultView` and returning `HttpResult.Redirect()` the original view is executed even though it will never been shown.
