### PR TITLE
Added Name property to CompositeIndex

### DIFF
--- a/src/ServiceStack.Interfaces/DataAnnotations/CompositeIndexAttribute.cs
+++ b/src/ServiceStack.Interfaces/DataAnnotations/CompositeIndexAttribute.cs
@@ -25,5 +25,7 @@ namespace ServiceStack.DataAnnotations
 		public List<string> FieldNames { get; set; }
 
 		public bool Unique { get; set; }
+
+	    public string Name { get; set; }
 	}
 }

--- a/tests/ServiceStack.Common.Tests/Models/ModelWithNamedCompositeIndex.cs
+++ b/tests/ServiceStack.Common.Tests/Models/ModelWithNamedCompositeIndex.cs
@@ -1,0 +1,22 @@
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.Common.Tests.Models
+{
+	[CompositeIndex(true, "Composite1", "Composite2", Name = "custom_index_name")]
+	public class ModelWithNamedCompositeIndex
+	{
+		public string Id { get; set; }
+
+		[Index]
+		public string Name { get; set; }
+
+		public string AlbumId { get; set; }
+
+		[Index(true)]
+		public string UniqueName { get; set; }
+
+		public string Composite1 { get; set; }
+
+		public string Composite2 { get; set; }
+	}
+}

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="MappingTests.cs" />
     <Compile Include="MessagingTests.cs" />
     <Compile Include="Messaging\RedisMqServerTests.cs" />
+    <Compile Include="Models\ModelWithNamedCompositeIndex.cs" />
     <Compile Include="Models\DdnContentIngest.cs" />
     <Compile Include="EnumerableExtensionsTests.cs" />
     <Compile Include="IdUtilsTests.cs" />


### PR DESCRIPTION
so that users can specify a custom name for the index other than default
auto-generated name.
Stand by for OrmLite companion pull req.
