### PR TITLE
Built interface for ApiResponseAttribute

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -326,8 +326,8 @@ namespace ServiceStack.Api.Swagger
         private static List<ErrorResponseStatus> GetMethodResponseCodes(Type requestType)
         {
             return requestType
-                .GetCustomAttributes(typeof(ApiResponseAttribute), true)
-                .OfType<ApiResponseAttribute>()
+                .GetCustomAttributes(typeof(IApiResponseDescription), true)
+                .OfType<IApiResponseDescription>()
                 .Select(x => new ErrorResponseStatus
                 {
                     StatusCode = (int)x.StatusCode,

--- a/src/ServiceStack.Interfaces/ServiceHost/ApiResponse.cs
+++ b/src/ServiceStack.Interfaces/ServiceHost/ApiResponse.cs
@@ -3,17 +3,24 @@ using System.Net;
 
 namespace ServiceStack.ServiceHost
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-    public class ApiResponseAttribute : Attribute
+    public interface IApiResponseDescription
     {
         /// <summary>
         /// The status code of a response
         /// </summary>
-        public int StatusCode { get; set; }
+        int StatusCode { get; }
 
         /// <summary>
         /// The description of a response status code
         /// </summary>
+        string Description { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class ApiResponseAttribute : Attribute, IApiResponseDescription
+    {
+        public int StatusCode { get; set; }
+
         public string Description { get; set; }
 
         public ApiResponseAttribute(HttpStatusCode statusCode, string description)


### PR DESCRIPTION
This allows you to document status codes from a custom class. For example, if you are using a permission attribute, you can use this class to combine the role checking and documentation into a single attribute.
