### PR TITLE
PopulateWithNonDefaultValues - handle nullables

### DIFF
--- a/src/ServiceStack.Common/Support/AssignmentDefinition.cs
+++ b/src/ServiceStack.Common/Support/AssignmentDefinition.cs
@@ -110,8 +110,8 @@ namespace ServiceStack.Common.Support
 
         public void PopulateWithNonDefaultValues(object to, object from)
         {
-            var nonDefaultPredicate = (Func<object, bool>) (x => 
-                    x != null && !Equals( x, ReflectionUtils.GetDefaultValue(x.GetType()) )
+            var nonDefaultPredicate = (Func<object, Type, bool>) ((x, t) => 
+                    x != null && !Equals( x, ReflectionUtils.GetDefaultValue(t) )
                 );
     
             Populate(to, from, null, nonDefaultPredicate);
@@ -124,7 +124,7 @@ namespace ServiceStack.Common.Support
 
         public void Populate(object to, object from,
             Func<PropertyInfo, bool> propertyInfoPredicate,
-            Func<object, bool> valuePredicate)
+            Func<object, Type, bool> valuePredicate)
         {
             foreach (var assignmentEntry in AssignmentMemberMap)
             {
@@ -143,7 +143,7 @@ namespace ServiceStack.Common.Support
 
                     if (valuePredicate != null)
                     {
-                        if (!valuePredicate(fromValue)) continue;
+                        if (!valuePredicate(fromValue, fromMember.PropertyInfo.PropertyType)) continue;
                     }
 
                     if (fromMember.Type != toMember.Type)

--- a/tests/ServiceStack.Common.Tests/ReflectionUtilTests.cs
+++ b/tests/ServiceStack.Common.Tests/ReflectionUtilTests.cs
@@ -237,6 +237,31 @@ namespace ServiceStack.Common.Tests
 			Assert.That(toObj.DateTime, Is.EqualTo(fromObj.DateTime));
 		}
 
+        [Test]
+        public void Populate_From_Nullable_Properties_With_Non_Default_Values()
+        {
+			var toObj = ModelWithFieldsOfDifferentTypes.Create(1);
+			var fromObj = ModelWithFieldsOfDifferentTypesAsNullables.Create(2);
+            
+			var originalToObj = ModelWithFieldsOfDifferentTypes.Create(1);
+
+			fromObj.Name = null;
+            fromObj.Double = default(double);
+            fromObj.Guid = default(Guid);
+            fromObj.Bool = default(bool);
+
+			ReflectionUtils.PopulateWithNonDefaultValues(toObj, fromObj);
+
+			Assert.That(toObj.Name, Is.EqualTo(originalToObj.Name));
+
+			Assert.That(toObj.Double, Is.EqualTo(fromObj.Double));
+			Assert.That(toObj.Guid, Is.EqualTo(fromObj.Guid));
+            Assert.That(toObj.Bool, Is.EqualTo(fromObj.Bool));
+			Assert.That(toObj.Id, Is.EqualTo(fromObj.Id));
+			Assert.That(toObj.LongId, Is.EqualTo(fromObj.LongId));
+			Assert.That(toObj.DateTime, Is.EqualTo(fromObj.DateTime));
+        }
+
 		[Test]
 		public void Translate_Between_Models_of_differrent_types_and_nullables()
 		{


### PR DESCRIPTION
For nullable properties, treat null as the default value, and any
non-null, including the default value of the underlying value type, as
non-default. Allows using PopulateWithNonDefaultValues to populate both
true and false values if the source property is a nullable boolean, for
example.

Detailed example:

```
class Source { bool? BoolValue { get; set; } }
class Destination { bool BoolValue { get; set; } }
```

This has always worked, because of the `x != null` check in `nonDefaultPredicate`:

```
dest = new Destination { BoolValue = true };
dest.PopulateWithNonDefaultValues(new Source { BoolValue = null });
Assert.That(dest.BoolValue, Is.True);
```

This has always worked, because in `nonDefaultPredicate`, `x` is auto-boxed as
Boolean object with value of true, so `x != null` and `ReflectionUtils.GetDefaultValue`
will return `false`.

```
dest = new Destination { BoolValue = false };
dest.PopulateWithNonDefaultValues(new Source { BoolValue = true });
Assert.That(dest.BoolValue, Is.True);
```

Here is what we want to change: when a nullable bool has a value of false, we were
expecting this to be treated as "non default" since it's not null. The current code however
will treat a nullable boolean with a value of false (or a nullable int with value of zero, etc.)
as a "default" value and refuse to update the destination object.

```
var dest = new Destination { BoolValue = true };
dest.PopulateWithNonDefaultValues(new Source { BoolValue = false });
Assert.That(dest.BoolValue, Is.False); // currently fails
```

We changed this behavior by passing the `PropertyType` info into the `nonDefaultPredicate` 
lambda, and using that type info in `ReflectionUtils.GetDefaultValue` instead of using `x.GetType()`.
Basically, if `x` is a nullable bool, `x.GetType()` will actually give you the `Boolean` type
object instead of `Nullable<bool>`, thus `GetDefaultValue` will return `false` instead of `null`.

See [comments and answers in this post](http://stackoverflow.com/q/374651/795339) for more details on why `GetType()` doesn't work well with nullables.

**Question:** is there any concern about changing the behavior of `PopulateWithNondefaultValues` in this way?
