### PR TITLE
NotAcceptable exception

### DIFF
--- a/src/ServiceStack/NotAcceptableException.cs
+++ b/src/ServiceStack/NotAcceptableException.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Web;
+
+namespace ServiceStack
+{
+	public class NotAcceptableException : HttpException
+	{
+		public IEnumerable<string> Allowed { get; private set; }
+
+		public NotAcceptableException() : this(new List<string>())
+		{
+		}
+
+		public NotAcceptableException(IEnumerable<string> allowed)
+		{
+			Allowed = allowed;
+		}
+	}
+}

--- a/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
+++ b/src/ServiceStack/ServiceHost/HttpRequestExtensions.cs
@@ -250,6 +250,7 @@ namespace ServiceStack.ServiceHost
 
             if (ex is HttpError) return ((HttpError)ex).Status;
             if (ex is NotImplementedException || ex is NotSupportedException) return (int)HttpStatusCode.MethodNotAllowed;
+			if (ex is NotAcceptableException) return (int)HttpStatusCode.NotAcceptable;
             if (ex is ArgumentException || ex is SerializationException) return (int)HttpStatusCode.BadRequest;
             if (ex is UnauthorizedAccessException) return (int) HttpStatusCode.Forbidden;
             return (int)HttpStatusCode.InternalServerError;

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Html\ViewContext.cs" />
     <Compile Include="HttpExtensions.cs" />
     <Compile Include="MetadataTypesHandler.cs" />
+    <Compile Include="NotAcceptableException.cs" />
     <Compile Include="PredefinedRoutesFeature.cs" />
     <Compile Include="Funq\Action.cs" />
     <Compile Include="Funq\Container.cs" />

--- a/tests/ServiceStack.Common.Tests/HttpRequestExtensionTests.cs
+++ b/tests/ServiceStack.Common.Tests/HttpRequestExtensionTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.Serialization;
+using NUnit.Framework;
+using ServiceStack.ServiceHost;
+
+namespace ServiceStack.Common.Tests
+{
+	[TestFixture]
+	public class HttpRequestExtensionTests
+	{
+		[Test]
+		public void ToStatusCode_returns_correct_http_status_codes()
+		{
+			Assert.That(new ArgumentException().ToStatusCode(), Is.EqualTo(400));
+			Assert.That(new SerializationException().ToStatusCode(), Is.EqualTo(400));
+			Assert.That(new UnauthorizedAccessException().ToStatusCode(), Is.EqualTo(403));
+			Assert.That(new NotImplementedException().ToStatusCode(), Is.EqualTo(405));
+			Assert.That(new NotSupportedException().ToStatusCode(), Is.EqualTo(405));
+			Assert.That(new NotAcceptableException().ToStatusCode(), Is.EqualTo(406));
+			Assert.That(new Exception().ToStatusCode(), Is.EqualTo(500));
+		}
+	}
+}

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="EndpointHandlerBaseTests.cs" />
     <Compile Include="FluentValidation\ErrorCodeTests.cs" />
     <Compile Include="FunqTests.cs" />
+    <Compile Include="HttpRequestExtensionTests.cs" />
     <Compile Include="MappingTests.cs" />
     <Compile Include="MessagingTests.cs" />
     <Compile Include="Messaging\RedisMqServerTests.cs" />


### PR DESCRIPTION
Hi,

I've made an NotAcceptableException (wasn't sure where best to put it, so placed it in the ServiceStack project).

We'd like a way, when making a Request Filter, to throw a new NotAcceptableException(*allowed types in here)

Then catch it during exception handling, and use the ToStatusCode extension method to provide the 406 value.

See if it makes sense, or if you know of a better way of doing so.

(Sorry for the line endings, I committed from Linux and had my git configured differently)
