### PR TITLE
Fix SessionFeature.AddSessionIdToRequestFilter so it wont add session cookies to response twice when called multiple times.

### DIFF
--- a/src/ServiceStack.ServiceInterface/SessionFeature.cs
+++ b/src/ServiceStack.ServiceInterface/SessionFeature.cs
@@ -16,6 +16,7 @@ namespace ServiceStack.ServiceInterface
         public const string SessionId = "ss-id";
         public const string PermanentSessionId = "ss-pid";
         public const string SessionOptionsKey = "ss-opt";
+		public const string SessionAlreadyAdded = "__SessionAlreadyAdded";
         public const string XUserAuthId = HttpHeaders.XUserAuthId;
 
         private static bool alreadyConfigured;
@@ -31,6 +32,9 @@ namespace ServiceStack.ServiceInterface
 
         public static void AddSessionIdToRequestFilter(IHttpRequest req, IHttpResponse res, object requestDto)
         {
+			// Avoid adding session cookies to response twice.
+			if (req.Items.ContainsKey(SessionAlreadyAdded)) return;
+
             if (req.GetCookieValue(SessionId) == null)
             {
                 res.CreateTemporarySessionId(req);
@@ -39,6 +43,8 @@ namespace ServiceStack.ServiceInterface
             {
                 res.CreatePermanentSessionId(req);
             }
+
+			req.Items[SessionAlreadyAdded] = true;
         }
 
         public static string GetSessionId(IHttpRequest httpReq = null)


### PR DESCRIPTION
Calling "SessionFeature.AddSessionIdToRequestFilter(..)" twice for the same request (i.e. when more than one AuthProvider calls it internally) provokes SS to append more than one ss-pid/ss-id cookies to response.

As our "ICookies" abstraction does not provide a way of traversing the currently added cookies to a response, the best fix I've found is to simply add an item to request signalling wether session cookies were already added.

Greets
Pablo
