### PR TITLE
Fixed SoapHandler.cs to preserve Request.Items entries set at (pre-)request filters until request get executed by service implementation.

### DIFF
--- a/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Global.asax.cs
@@ -38,7 +38,13 @@ namespace ServiceStack.WebHost.IntegrationTests
             {
                 JsConfig.EmitCamelCaseNames = true;
 
+				this.PreRequestFilters.Add((req, res) => {
+					req.Items["_DataSetAtPreRequestFilters"] = true;
+				});
+
                 this.RequestFilters.Add((req, res, dto) => {
+					req.Items["_DataSetAtRequestFilters"] = true;
+
                     var requestFilter = dto as RequestFilter;
                     if (requestFilter != null)
                     {

--- a/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
+++ b/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
@@ -192,6 +192,7 @@
       <DependentUpon>Default.aspx</DependentUpon>
     </Compile>
     <Compile Include="Services\CachedProtoBufEmailService.cs" />
+    <Compile Include="Services\RequestItemsService.cs" />
     <Compile Include="Services\CustomHeadersService.cs" />
     <Compile Include="Services\EndpointAccessService.cs" />
     <Compile Include="Services\HelloImage.cs" />

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/RequestItemsService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/RequestItemsService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.Serialization;
+using System.Web;
+using ServiceStack.CacheAccess;
+using ServiceStack.ServiceHost;
+using ServiceStack.ServiceInterface;
+using ServiceStack.ServiceInterface.ServiceModel;
+using ServiceStack.Text;
+using ServiceStack.WebHost.Endpoints.Extensions;
+
+namespace ServiceStack.WebHost.IntegrationTests.Services
+{
+	[Route("/req-items")]
+	public class RequestItems
+	{
+	}
+
+	public class RequestItemsResponse : IHasResponseStatus
+	{
+		public string Result { get; set; }
+		public ResponseStatus ResponseStatus { get; set; }
+	}
+
+	public class RequestItemsService : ServiceBase<RequestItems>
+	{
+		protected override object Run(RequestItems request)
+		{
+			if (!Request.Items.ContainsKey("_DataSetAtPreRequestFilters"))
+				throw new InvalidOperationException("DataSetAtPreRequestFilters missing.");
+
+			if (!Request.Items.ContainsKey("_DataSetAtRequestFilters"))
+				throw new InvalidOperationException("DataSetAtRequestFilters data missing.");
+
+			return new RequestItemsResponse { Result = "MissionSuccess" };
+		}
+	}
+}

--- a/tests/ServiceStack.WebHost.IntegrationTests/Tests/WebServicesTests.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Tests/WebServicesTests.cs
@@ -77,8 +77,16 @@ namespace ServiceStack.WebHost.IntegrationTests.Tests
 					Is.EqualTo(expectedError));
 			}
 		}
-	}
 
+		[Test]
+		public void Request_items_are_preserved_between_filters()
+		{
+			var client = CreateNewServiceClient();
+			if (client is DirectServiceClient) return;
+			var response = client.Send<RequestItemsResponse>(new RequestItems { });
+			Assert.That(response.Result, Is.EqualTo("MissionSuccess"));
+		}
+	}
 
 	/// <summary>
 	/// Unit tests simulates an in-process ServiceStack host where all services 


### PR DESCRIPTION
When running SOAP-based services hosted by IIS, items set at IHttpRequest.Items by (pre-)request filters, are missing when the request reaches the actual service implementation (i.e. IService.Run(..)).

As said, this was a difficult one to catch, as this behaviour was only found when running SOAP services under IIS.. HttpListener runner works just fine.

After inspecting the code, it looks like this commit (https://github.com/ServiceStack/ServiceStack/commit/b86a7a9bd6745592a64d9d8f64adc19a69f0c0c0) introduced a regresion by re-creating the current IHttpRequest from HttpContext.Current.Request. 

ServiceStack's HttpRequest.Items is a dictionary not backed by the underlaying Sys.Web.HttpRequest object, and as such, a new instance of ServiceStack's HttpRequest will get an empty Items collection.

I've added an integration test demostrating the issue, and which test this behaviour against all transports (JSV, JSON, SOAP, etc.)
