### PR TITLE
Fix #754: Ensure GetSession(true) will remove existing session from Request.Items before adding the newly generated one.

### DIFF
--- a/src/ServiceStack.ServiceInterface/ServiceExtensions.cs
+++ b/src/ServiceStack.ServiceInterface/ServiceExtensions.cs
@@ -206,6 +206,10 @@ namespace ServiceStack.ServiceInterface
                     session.CreatedAt = session.LastModified = DateTime.UtcNow;
                     session.OnCreated(httpReq);
                 }
+
+                if (httpReq.Items.ContainsKey(RequestItemsSessionKey))
+                    httpReq.Items.Remove(RequestItemsSessionKey);
+
                 httpReq.Items.Add(RequestItemsSessionKey, session);
                 return session;
             }


### PR DESCRIPTION
This fixess issue https://github.com/ServiceStack/ServiceStack/issues/754.
