### PR TITLE
Always use \r\n as newLine while composing the mime-encoded body of PostFileWithRequest(..) as mandated by rfc1521.

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -1028,7 +1028,7 @@ namespace ServiceStack.ServiceClient.Web
                 var boundary = DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture);
                 webRequest.ContentType = "multipart/form-data; boundary=" + boundary;
                 boundary = "--" + boundary;
-                var newLine = Environment.NewLine;
+                var newLine = "\r\n";
                 using (var outputStream = webRequest.GetRequestStream())
                 {
 #if !MONOTOUCH


### PR DESCRIPTION
This fixes issue: https://github.com/ServiceStack/ServiceStack/issues/747
