### PR TITLE
Add 'overflow' to the 'pre' tag to maintain background consistency.

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
@@ -164,6 +164,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 	        padding: 5px;
 	        margin-right: 15px;
 	        white-space: pre-wrap;
+            overflow:auto;
         }}
         .example .value {{
 	        color: blue;


### PR DESCRIPTION
Without the overflow, the background becomes inconsistent when the content is longer than the window size. 
