### PR TITLE
Abstract out the Html templates for Metadata without impacting on performance.

### DIFF
--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -303,6 +303,7 @@
     <Compile Include="WebHost.Endpoints\Extensions\HttpListenerRequestWrapper.cs" />
     <Compile Include="WebHost.Endpoints\AppDelegates.cs" />
     <Compile Include="WebHost.Endpoints\ActionHandler.cs" />
+    <Compile Include="WebHost.Endpoints\Support\Templates\HtmlTemplates.cs" />
     <Compile Include="WebHost.Endpoints\RequestBindingException.cs" />
     <Compile Include="WebHost.Endpoints\Support\Markdown\Evaluator.cs" />
     <Compile Include="WebHost.Endpoints\Support\Markdown\ITemplateWriter.cs" />
@@ -411,6 +412,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Funq\License.txt" />
+    <EmbeddedResource Include="WebHost.Endpoints\Support\Templates\Html\OperationControl.html" />
+    <EmbeddedResource Include="WebHost.Endpoints\Support\Templates\Html\OperationsControl.html" />
+    <EmbeddedResource Include="WebHost.Endpoints\Support\Templates\Html\IndexOperations.html" />
     <EmbeddedResource Include="WebHost.Endpoints\Formats\HtmlFormat.html" />
     <None Include="MiniProfiler\UI\jquery.tmpl.beta1.js.orig" />
     <None Include="MiniProfiler\UI\jquery.1.6.2.js.orig" />

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/IndexOperationsControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/IndexOperationsControl.cs
@@ -87,7 +87,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
             }
 
 			var renderedTemplate = string.Format(
-				PageTemplate, 
+				HtmlTemplates.IndexOperationsTemplate, 
                 this.Title, 
                 this.MetadataPageBodyHtml, 
                 this.XsdServiceTypesIndex,
@@ -98,109 +98,6 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 
 			output.Write(renderedTemplate);
 		}
-
-		#region Page Template
-		private const string PageTemplate = @"
-<!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.0 Transitional//EN"" ""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"">
-
-<html xmlns=""http://www.w3.org/1999/xhtml"" >
-<head>
-    <title>{0}</title>
-    <style type=""text/css"">
-        BODY  {{
-            background-color:white;
-            color:#000000;
-            font-family: Verdana, Helvetica, Arial, ""Lucida Grande"", sans-serif; 
-            margin: 0;
-            font-size: 12px;
-        }}
-        a#logo {{
-            position: absolute;
-            top: 8px;
-            right: 5px;
-            width: 46px;
-            height: 30px;
-            background-repeat: no-repeat;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
-        }}
-        H1 {{
-            background-color: #036;
-            color: #FFF;
-            font-family: Tahoma;
-            font-size: 26px;
-            font-weight: normal;
-            margin: 0;
-            padding: 10px 0 3px 15px;
-        }}
-        FORM {{
-            margin-left: 20px;
-            padding-bottom: 2em;
-        }}
-        UL {{
-            margin: 10px 0 0 10px;
-			padding: 0px 0px 0px 10px;
-        }}
-        LI {{
-			clear: left;
-            margin-top: 10px;
-        }}
-        A {{
-            color: #369;
-            font-weight: bold;
-            text-decoration: none;
-        }}
-        A:hover {{
-            color: #C30;
-            text-decoration: underline;
-        }}
-		.operations TABLE {{
-			margin-left: 1.5em;
-            border-collapse: collapse;
-		}}
-		TABLE, TR, TH, TD {{
-            border: none;
-		}}
-		.operations TH {{
-            text-align: left;
-            font-weight: normal;
-            line-height: 18px;
-			min-width: 27em;
-            white-space: nowrap;
-		}}
-		.operations TD {{
-            font-size: 11px;
-            line-height: 18px;
-            font-weight: bold;
-            color: #CCC;
-			padding-left: 1.5em;
-		}}
-        </style>
-</head>
-<body>
-    <a id=""logo"" href=""http://www.servicestack.net"" title=""servicestack""></a>
-    <h1>{0}</h1>
-    
-    <form id=""form1"">
-        <p>
-            The following operations are supported. For a formal definition, please review the Service <a href=""?xsd={2}"">XSD</a>.
-        </p>
-
-	    <div class=""operations"">
-	      {3}
-	    </div>
-
-        {1}    
-    
-        {4}
-
-	    {5}
- 
-	    {6}
-    </form>
-
-</body>
-</html>";
-		#endregion
-
+        
 	}
 }

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
@@ -2,6 +2,7 @@ using System.Web;
 using System.Web.UI;
 using ServiceStack.Common;
 using ServiceStack.ServiceHost;
+using ServiceStack.WebHost.Endpoints.Support.Templates;
 
 namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 {
@@ -43,7 +44,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 
 		public void Render(HtmlTextWriter output)
 		{
-			var renderedTemplate = string.Format(PageTemplate, 
+			var renderedTemplate = string.Format(HtmlTemplates.OperationControlTemplate, 
 				Title, 
 				HttpRequest.GetParentAbsolutePath().ToParentPath() + MetadataConfig.DefaultMetadataUri,
 				ContentFormat.ToUpper(), 
@@ -54,154 +55,6 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 
 			output.Write(renderedTemplate);
 		}
-
-		protected const string PageTemplate =
-@"<!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.0 Transitional//EN"" ""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"">
-<html xmlns=""http://www.w3.org/1999/xhtml"" >
-<head>
-    <title>{0}</title>
-    <style type=""text/css"">
-        BODY  {{
-            background-color:white;
-            color:#000000;
-            font-family:Verdana;
-            margin: 0;
-        }}
-        table {{
-            border-collapse: collapse;
-            border-spacing: 0;
-            margin: 0 0 20px 0;
-            font-size: 12px;
-        }}
-        caption {{
-            text-align: left;
-            font-size: 14px;
-            padding: 10px 0;
-            white-space: nowrap;
-        }}
-        tbody th {{
-            text-align: left;
-        }}
-        thead th {{
-            background-color: #E5E5CC;
-            text-align: left;
-        }}
-        th, td {{
-            padding: 5px 15px;
-        }}
-        .call-info {{
-            margin: 0 0 20px 0;
-        }}
-        a#logo {{
-            position: absolute;
-            top: 8px;
-            right: 5px;
-            width: 46px;
-            height: 30px;
-            background-repeat: no-repeat;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
-        }}
-		#desc{{
-			margin: 0;
-			padding: 0 0 15px 15px;
-			font-size: 16px;
-		}}
-		#desc P {{
-			margin: 5px 0;
-			padding: 0;
-			line-height: 20px;
-			color: #444;
-		}}
-        H1 {{
-            background-color: #036;
-            color: #FFF;
-            font-family: Tahoma;
-            font-size: 26px;
-            font-weight: normal;
-            margin: 0;
-            padding: 10px 0 3px 15px;
-        }}
-        FORM {{
-            font-size: 0.7em;
-            margin-left: 20px;
-            padding-bottom: 2em;
-        }}
-        UL {{
-            margin: 10px 0 0 20px;
-        }}
-        LI {{
-            margin-top: 10px;
-        }}
-        LI A {{
-            color: #369;
-            font-weight: bold;
-            text-decoration: underline;
-        }}
-        LI A:hover {{
-            color: #C30;
-        }}
-
-        H2 {{
-	        border-top: 1px solid #003366;
-	        color: #036;
-	        font-size: 1.5em;
-	        font-weight: bold;
-	        margin: 25px 0 20px 0;
-        }}
-        .example {{
-	        padding-left: 15px;
-        }}
-        .example h3 {{ 
-	        color:#000000;
-	        font-size:1.1em;
-	        margin: 10px 0 0 -15px;
-        }}
-        .example pre {{
-	        background-color: #E5E5CC;
-	        border: 1px solid #F0F0E0;
-	        font-family: Courier New;
-	        font-size: small;
-	        padding: 5px;
-	        margin-right: 15px;
-	        white-space: pre-wrap;
-            overflow:auto;
-        }}
-        .example .value {{
-	        color: blue;
-        }}    
-        </style>
-</head>
-<body>
-    <a id=""logo"" href=""http://www.servicestack.net"" title=""servicestack""></a>
-    <h1>{0}</h1>
-    
-    <form>
-    <div>
-        <p><a href=""{1}"">&lt;back to all web services</a></p>
-        <h2>{3}</h2>
-
-		{6}
-
-		<div class=""example"">
-<!-- REST Examples -->
-
-            <h3>HTTP + {2}</h3>
-            <p> The following are sample HTTP requests and responses. 
-                The placeholders shown need to be replaced with actual values.</p>
-
-<div class=""request"">
-<pre>
-{4}
-</pre>
-</div>
-
-{5}
-
-        </div>
-    </div>
-    </form>
-</body>
-</html>";
 
 		public virtual string HttpRequestTemplate
 		{

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationsControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationsControl.cs
@@ -17,81 +17,10 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
                 ListItems = this.OperationNames,
                 ListItemTemplate = @"<li><a href=""?op={0}"">{0}</a></li>"
             }.ToString();
-            var renderedTemplate = string.Format(PageTemplate, 
+            var renderedTemplate = string.Format(HtmlTemplates.OperationsControlTemplate, 
                 this.Title, this.MetadataOperationPageBodyHtml, operationsPart);
             output.Write(renderedTemplate);
         }
-
-        #region Page Template
-        private const string PageTemplate = 
-@"<!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.0 Transitional//EN"" ""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"">
-
-<html xmlns=""http://www.w3.org/1999/xhtml"" >
-<head>
-    <title>{0}</title>
-    <style type=""text/css"">
-        BODY  {{
-            background-color:white;
-            color:#000000;
-            font-family:Verdana;
-            margin: 0;
-        }}
-        a#logo {{
-            position: absolute;
-            top: 8px;
-            right: 5px;
-            width: 46px;
-            height: 30px;
-            background-repeat: no-repeat;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
-        }}
-        H1 {{
-            background-color: #036;
-            color: #FFF;
-            font-family: Tahoma;
-            font-size: 26px;
-            font-weight: normal;
-            margin: 0;
-            padding: 10px 0 3px 15px;
-        }}
-        FORM {{
-            font-size: 0.7em;
-            margin-left: 20px;
-            padding-bottom: 2em;
-        }}
-        UL {{
-            margin: 10px 0 0 20px;
-        }}
-        LI {{
-            margin-top: 10px;
-        }}
-        LI A {{
-            color: #369;
-            font-weight: bold;
-            text-decoration: underline;
-        }}
-        LI A:hover {{
-            color: #C30;
-        }}
-        </style>
-</head>
-<body>
-    <a id=""logo"" href=""http://www.servicestack.net"" title=""servicestack""></a>
-    <h1>{0}</h1>
-    
-    <form>
-    <p> The following operations are supported.
-        For a more information please view the <a href=""../../Metadata"">Service Documentation</a>.
-    </p>
-
-    {2}
-
-    {1}    
-    
-    </form>
-</body>
-</html>";
-        #endregion
 
     }
 }

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/IndexOperations.html
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/IndexOperations.html
@@ -1,0 +1,99 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<head>
+    <title>{0}</title>
+    <style type="text/css">
+        BODY  {{
+            background-color:white;
+            color:#000000;
+            font-family: Verdana, Helvetica, Arial, "Lucida Grande", sans-serif; 
+            margin: 0;
+            font-size: 12px;
+        }}
+        a#logo {{
+            position: absolute;
+            top: 8px;
+            right: 5px;
+            width: 46px;
+            height: 30px;
+            background-repeat: no-repeat;
+            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
+        }}
+        H1 {{
+            background-color: #036;
+            color: #FFF;
+            font-family: Tahoma;
+            font-size: 26px;
+            font-weight: normal;
+            margin: 0;
+            padding: 10px 0 3px 15px;
+        }}
+        FORM {{
+            margin-left: 20px;
+            padding-bottom: 2em;
+        }}
+        UL {{
+            margin: 10px 0 0 10px;
+			padding: 0px 0px 0px 10px;
+        }}
+        LI {{
+			clear: left;
+            margin-top: 10px;
+        }}
+        A {{
+            color: #369;
+            font-weight: bold;
+            text-decoration: none;
+        }}
+        A:hover {{
+            color: #C30;
+            text-decoration: underline;
+        }}
+		.operations TABLE {{
+			margin-left: 1.5em;
+            border-collapse: collapse;
+		}}
+		TABLE, TR, TH, TD {{
+            border: none;
+		}}
+		.operations TH {{
+            text-align: left;
+            font-weight: normal;
+            line-height: 18px;
+			min-width: 27em;
+            white-space: nowrap;
+		}}
+		.operations TD {{
+            font-size: 11px;
+            line-height: 18px;
+            font-weight: bold;
+            color: #CCC;
+			padding-left: 1.5em;
+		}}
+        </style>
+</head>
+<body>
+    <a id="logo" href="http://www.servicestack.net" title="servicestack"></a>
+    <h1>{0}</h1>
+    
+    <form id="form1">
+        <p>
+            The following operations are supported. For a formal definition, please review the Service <a href="?xsd={2}">XSD</a>.
+        </p>
+
+	    <div class="operations">
+	      {3}
+	    </div>
+
+        {1}    
+    
+        {4}
+
+	    {5}
+ 
+	    {6}
+    </form>
+
+</body>
+</html>

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/OperationControl.html
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/OperationControl.html
@@ -1,0 +1,146 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<head>
+    <title>{0}</title>
+    <style type="text/css">
+        BODY  {{
+            background-color:white;
+            color:#000000;
+            font-family:Verdana;
+            margin: 0;
+        }}
+        table {{
+            border-collapse: collapse;
+            border-spacing: 0;
+            margin: 0 0 20px 0;
+            font-size: 12px;
+        }}
+        caption {{
+            text-align: left;
+            font-size: 14px;
+            padding: 10px 0;
+            white-space: nowrap;
+        }}
+        tbody th {{
+            text-align: left;
+        }}
+        thead th {{
+            background-color: #E5E5CC;
+            text-align: left;
+        }}
+        th, td {{
+            padding: 5px 15px;
+        }}
+        .call-info {{
+            margin: 0 0 20px 0;
+        }}
+        a#logo {{
+            position: absolute;
+            top: 8px;
+            right: 5px;
+            width: 46px;
+            height: 30px;
+            background-repeat: no-repeat;
+            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
+        }}
+		#desc{{
+			margin: 0;
+			padding: 0 0 15px 15px;
+			font-size: 16px;
+		}}
+		#desc P {{
+			margin: 5px 0;
+			padding: 0;
+			line-height: 20px;
+			color: #444;
+		}}
+        H1 {{
+            background-color: #036;
+            color: #FFF;
+            font-family: Tahoma;
+            font-size: 26px;
+            font-weight: normal;
+            margin: 0;
+            padding: 10px 0 3px 15px;
+        }}
+        FORM {{
+            font-size: 0.7em;
+            margin-left: 20px;
+            padding-bottom: 2em;
+        }}
+        UL {{
+            margin: 10px 0 0 20px;
+        }}
+        LI {{
+            margin-top: 10px;
+        }}
+        LI A {{
+            color: #369;
+            font-weight: bold;
+            text-decoration: underline;
+        }}
+        LI A:hover {{
+            color: #C30;
+        }}
+
+        H2 {{
+	        border-top: 1px solid #003366;
+	        color: #036;
+	        font-size: 1.5em;
+	        font-weight: bold;
+	        margin: 25px 0 20px 0;
+        }}
+        .example {{
+	        padding-left: 15px;
+        }}
+        .example h3 {{ 
+	        color:#000000;
+	        font-size:1.1em;
+	        margin: 10px 0 0 -15px;
+        }}
+        .example pre {{
+	        background-color: #E5E5CC;
+	        border: 1px solid #F0F0E0;
+	        font-family: Courier New;
+	        font-size: small;
+	        padding: 5px;
+	        margin-right: 15px;
+	        white-space: pre-wrap;
+            overflow:auto;
+        }}
+        .example .value {{
+	        color: blue;
+        }}    
+        </style>
+</head>
+<body>
+    <a id="logo" href="http://www.servicestack.net" title="servicestack"></a>
+    <h1>{0}</h1>
+    
+    <form>
+    <div>
+        <p><a href="{1}">&lt;back to all web services</a></p>
+        <h2>{3}</h2>
+
+		{6}
+
+		<div class="example">
+<!-- REST Examples -->
+
+            <h3>HTTP + {2}</h3>
+            <p> The following are sample HTTP requests and responses. 
+                The placeholders shown need to be replaced with actual values.</p>
+
+<div class="request">
+<pre>
+{4}
+</pre>
+</div>
+
+{5}
+
+        </div>
+    </div>
+    </form>
+</body>
+</html>

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/OperationsControl.html
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/Html/OperationsControl.html
@@ -1,0 +1,67 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<head>
+    <title>{0}</title>
+    <style type="text/css">
+        BODY  {{
+            background-color:white;
+            color:#000000;
+            font-family:Verdana;
+            margin: 0;
+        }}
+        a#logo {{
+            position: absolute;
+            top: 8px;
+            right: 5px;
+            width: 46px;
+            height: 30px;
+            background-repeat: no-repeat;
+            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC4AAAAeCAYAAABTwyyaAAADCklEQVRYw+3YXUhTYRgH8FUXQR8gEV10G5RXdqMIkQV9YWEXEmaQ9jHCXAMrFcNN7YSWkm1Nps2p2Uxzdcyshh9LdLRkqDG3Y3PuM5DuBMkSIlJ5et61E8uW2077UOriD4fDBr/znv97nrPxAIC3GsP5i263O9Fms+1adXCTyRSH+CmMyeVyFWC2rQo4idPpPI5wIEH4N8wTPN674uHeyuhZvE9G8SLSeTzemhUL9111PzE7HI60mMP5JcojFEWt9T1H0/Q6XN3pZfCkRjrcyAkxg2eL7gm3HLiykJZ3151ZVNtWKnucRM4jrGU5uDcLGCnDMBtjUpVzpQ2Spo5XMGxkoKqxCzIK5TNnxEq7zmCEIPAk77E++2LS8UO51S7rpP0nhhzXPuqGsyVKEMnUMMZMBMIv4l0qJzWLKrxUpk5G4KI/FEFfr6MhW1wPHT16CND9AbvdvjWqT5XDudVTgWrR+mIQsooVIG/rBtef8W7Ex0cNfrpYoTK8NQfV6x7dsOcOkDoh1N9nZrD3yVGBX5O2nySbNMgN6YlmwACniuqgs++Nv5WfC2XqcoZT8qeJlY3PQoKzUah7IVtUD+Z31qX4z1ibpIjCxTXqPVLVS05wkolJGwgqmqGB1i7FT+M03hExeF6VStiu0XGGs3n4fAAuUE1gdzh98VactJsjAsfp2T8+MfnXcJKRsXEyyICx/FIdOiLw9Ks1M+FAs3E4nZAlUoDRbPE9fz6scEHFg/zmzn4IJ5xN3P7LoH09wlbmE1Zme1jglFKz4ahQ8jESaDYp/FtgZCwsXh0W+MGLty0hvFBxChlSmfi8t1htP2rkZziFhE4VSIY6evURRbMhG5/gvRfSxwlO1dGbUviVjmBHfLjSpR0CWYvGc4yDaXdIcGF5swA7PTs0aooqmk3OjfueyuCqKwPCM/A9+dJNVUGq8M4H8mYXCzAbsknzq1vJ8SxO1PW/wXMoZXyWuL7wmFA6uDNdPJeQSX3FHwZf+GUN8/yyxoVY5kShfB6f82bfTcr75/6C+w/nmO/AJ8aemGSrCwAAAABJRU5ErkJggg==);
+        }}
+        H1 {{
+            background-color: #036;
+            color: #FFF;
+            font-family: Tahoma;
+            font-size: 26px;
+            font-weight: normal;
+            margin: 0;
+            padding: 10px 0 3px 15px;
+        }}
+        FORM {{
+            font-size: 0.7em;
+            margin-left: 20px;
+            padding-bottom: 2em;
+        }}
+        UL {{
+            margin: 10px 0 0 20px;
+        }}
+        LI {{
+            margin-top: 10px;
+        }}
+        LI A {{
+            color: #369;
+            font-weight: bold;
+            text-decoration: underline;
+        }}
+        LI A:hover {{
+            color: #C30;
+        }}
+        </style>
+</head>
+<body>
+    <a id="logo" href="http://www.servicestack.net" title="servicestack"></a>
+    <h1>{0}</h1>
+    
+    <form>
+    <p> The following operations are supported.
+        For a more information please view the <a href="../../Metadata">Service Documentation</a>.
+    </p>
+
+    {2}
+
+    {1}    
+    
+    </form>
+</body>
+</html>

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using System.IO;
+
+namespace ServiceStack.WebHost.Endpoints.Support.Templates
+{
+    public static class HtmlTemplates
+    {
+        public static string IndexOperationsTemplate;
+        public static string OperationControlTemplate;
+        public static string OperationsControlTemplate;
+
+        static HtmlTemplates()
+        {
+            IndexOperationsTemplate = LoadHtmlTemplate("IndexOperations.html");
+            OperationControlTemplate = LoadHtmlTemplate("OperationControl.html");
+            OperationsControlTemplate = LoadHtmlTemplate("OperationsControl.html");
+        }
+
+        private static string LoadHtmlTemplate(string templateName)
+        {
+            string _resourceNamespace = typeof(HtmlTemplates).Namespace + ".Html.";
+            var stream = typeof(HtmlTemplates).Assembly.GetManifestResourceStream(_resourceNamespace + templateName);
+			if (stream == null)
+			{
+				throw new FileNotFoundException(
+                    "Could not load HTML template embedded resource " + templateName,
+                    templateName);
+			}
+			using (var streamReader = new StreamReader(stream))
+			{
+				return streamReader.ReadToEnd();
+			}
+        }
+
+    }
+}


### PR DESCRIPTION
HtmlTemplates are now outside in a separate folder as '.html' files as embedded resources which are loaded once during initialization into a string. Much easier to edit them now without impacting on the performance.
