### PR TITLE
Add new client project for "Indie License" Xamarin.Android

### DIFF
--- a/src/ServiceStack.AndroidIndie.sln
+++ b/src/ServiceStack.AndroidIndie.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Common.Android", "ServiceStack.Common.AndroidIndie\ServiceStack.Common.Android.csproj", "{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Interfaces.Android", "ServiceStack.Interfaces.AndroidIndie\ServiceStack.Interfaces.Android.csproj", "{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Text.Android", "..\..\ServiceStack.Text\src\ServiceStack.Text.Android\ServiceStack.Text.Android\ServiceStack.Text.Android.csproj", "{56838CD4-8EBC-4860-A3E1-1697875BBC61}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56838CD4-8EBC-4860-A3E1-1697875BBC61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56838CD4-8EBC-4860-A3E1-1697875BBC61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56838CD4-8EBC-4860-A3E1-1697875BBC61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56838CD4-8EBC-4860-A3E1-1697875BBC61}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ServiceStack.Common.AndroidIndie/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Common.AndroidIndie/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack.Common.SL4")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceStack.Common.SL4")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0ab3f9c6-cfc9-44c8-b678-6526f3ad7e73")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Common.AndroidIndie/ServiceStack.Common.Android.csproj
+++ b/src/ServiceStack.Common.AndroidIndie/ServiceStack.Common.Android.csproj
@@ -1,0 +1,443 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BEA92E9F-00B1-4923-BD81-7F3A9CA24408}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceStack.Common</RootNamespace>
+    <AssemblyName>ServiceStack.Common</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;ANDROIDINDIE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>True</Optimize>
+    <OutputPath>..\..\release\latest\MonoDroidIndie\</OutputPath>
+    <DefineConstants>TRACE;ANDROIDINDIE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ServiceStack.Common\ActionExecExtensions.cs">
+      <Link>ActionExecExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\AssertExtensions.cs">
+      <Link>AssertExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ByteArrayExtensions.cs">
+      <Link>ByteArrayExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\DictionaryExtensions.cs">
+      <Link>DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\DirectoryInfoExtensions.cs">
+      <Link>DirectoryInfoExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\DisposableExtensions.cs">
+      <Link>DisposableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\EnumerableExtensions.cs">
+      <Link>EnumerableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\EnumExtensions.cs">
+      <Link>EnumExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ExecExtensions.cs">
+      <Link>ExecExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Expressions\DelegateFactory.cs">
+      <Link>Expressions\DelegateFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\ActionExecExtensions.cs">
+      <Link>Extensions\ActionExecExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\AssertExtensions.cs">
+      <Link>Extensions\AssertExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\ByteArrayExtensions.cs">
+      <Link>Extensions\ByteArrayExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\CollectionExtensions.cs">
+      <Link>Extensions\CollectionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\DictionaryExtensions.cs">
+      <Link>Extensions\DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\EnumerableExtensions.cs">
+      <Link>Extensions\EnumerableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\IntExtensions.cs">
+      <Link>Extensions\IntExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\ITranslatorExtensions.cs">
+      <Link>Extensions\ITranslatorExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Extensions\StringExtensions.cs">
+      <Link>Extensions\StringExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\IntExtensions.cs">
+      <Link>IntExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\IPAddressExtensions.cs">
+      <Link>IPAddressExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\ClientFactory.cs">
+      <Link>Messaging\ClientFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\IMessageHandler.cs">
+      <Link>Messaging\IMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\IMessageHandlerDisposer.cs">
+      <Link>Messaging\IMessageHandlerDisposer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\IMessageHandlerFactory.cs">
+      <Link>Messaging\IMessageHandlerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\InMemoryMessageQueueClient.cs">
+      <Link>Messaging\InMemoryMessageQueueClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\InMemoryTransientMessageFactory.cs">
+      <Link>Messaging\InMemoryTransientMessageFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\InMemoryTransientMessageService.cs">
+      <Link>Messaging\InMemoryTransientMessageService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\MessageExtensions.cs">
+      <Link>Messaging\MessageExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\MessageHandler.cs">
+      <Link>Messaging\MessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\MessageHandlerFactory.cs">
+      <Link>Messaging\MessageHandlerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\MessageQueueClientFactory.cs">
+      <Link>Messaging\MessageQueueClientFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\Rcon\Client.cs">
+      <Link>Messaging\Rcon\Client.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\Rcon\Packet.cs">
+      <Link>Messaging\Rcon\Packet.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\Rcon\PacketCodec.cs">
+      <Link>Messaging\Rcon\PacketCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\Rcon\PacketProcessingClient.cs">
+      <Link>Messaging\Rcon\PacketProcessingClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\Rcon\Server.cs">
+      <Link>Messaging\Rcon\Server.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Messaging\TransientMessageServiceBase.cs">
+      <Link>Messaging\TransientMessageServiceBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Model.cs">
+      <Link>Model.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ModelConfig.cs">
+      <Link>ModelConfig.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Net30\ConcurrentDictionary.cs">
+      <Link>Net30\ConcurrentDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Net30\ObjectPool.cs">
+      <Link>Net30\ObjectPool.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Net30\SplitOrderedList.cs">
+      <Link>Net30\SplitOrderedList.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Net30\Tuple.cs">
+      <Link>Net30\Tuple.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ReflectionExtensions.cs">
+      <Link>ReflectionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Reflection\PropertyAccessor.cs">
+      <Link>Reflection\PropertyAccessor.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Reflection\StaticAccessors.cs">
+      <Link>Reflection\StaticAccessors.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\AsyncServiceClient.cs">
+      <Link>ServiceClient.Web\AsyncServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\AuthDtos.cs">
+      <Link>ServiceClient.Web\AuthDtos.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\DictionaryExtensions.cs">
+      <Link>ServiceClient.Web\DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\GenericProxy.cs">
+      <Link>ServiceClient.Web\GenericProxy.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\HttpMethod.cs">
+      <Link>ServiceClient.Web\HttpMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\IDuplex.cs">
+      <Link>ServiceClient.Web\IDuplex.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\IDuplexCallback.cs">
+      <Link>ServiceClient.Web\IDuplexCallback.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\IOneWay.cs">
+      <Link>ServiceClient.Web\IOneWay.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\ISyncReply.cs">
+      <Link>ServiceClient.Web\ISyncReply.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\IWcfServiceClient.cs">
+      <Link>ServiceClient.Web\IWcfServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\JsonRestClientAsync.cs">
+      <Link>ServiceClient.Web\JsonRestClientAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\JsonServiceClient.cs">
+      <Link>ServiceClient.Web\JsonServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\JsvRestClientAsync.cs">
+      <Link>ServiceClient.Web\JsvRestClientAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\JsvServiceClient.cs">
+      <Link>ServiceClient.Web\JsvServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\RouteMember.cs">
+      <Link>ServiceClient.Web\RouteMember.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\ServiceClientBase.cs">
+      <Link>ServiceClient.Web\ServiceClientBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\Soap11ServiceClient.cs">
+      <Link>ServiceClient.Web\Soap11ServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\WcfServiceClient.cs">
+      <Link>ServiceClient.Web\WcfServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\WebRequestExtensions.cs">
+      <Link>ServiceClient.Web\WebRequestExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\WebRequestUtils.cs">
+      <Link>ServiceClient.Web\WebRequestUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\WebServiceException.cs">
+      <Link>ServiceClient.Web\WebServiceException.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\XLinqExtensions.cs">
+      <Link>ServiceClient.Web\XLinqExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\XmlRestClientAsync.cs">
+      <Link>ServiceClient.Web\XmlRestClientAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\XmlServiceClient.cs">
+      <Link>ServiceClient.Web\XmlServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\DictionaryExtensions.cs">
+      <Link>ServiceModel\DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\DataContractDeserializer.cs">
+      <Link>ServiceModel\Serialization\DataContractDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\DataContractSerializer.cs">
+      <Link>ServiceModel\Serialization\DataContractSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\JsonDataContractDeserializer.cs">
+      <Link>ServiceModel\Serialization\JsonDataContractDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\JsonDataContractSerializer.cs">
+      <Link>ServiceModel\Serialization\JsonDataContractSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\KeyValueDataContractDeserializer.cs">
+      <Link>ServiceModel\Serialization\KeyValueDataContractDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\StringMapTypeDeserializer.cs">
+      <Link>ServiceModel\Serialization\StringMapTypeDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\XmlSerializableDeserializer.cs">
+      <Link>ServiceModel\Serialization\XmlSerializableDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Serialization\XmlSerializableSerializer.cs">
+      <Link>ServiceModel\Serialization\XmlSerializableSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Support\XmlSerializableWrapper.cs">
+      <Link>ServiceModel\Support\XmlSerializableWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Validation\ValidationError.cs">
+      <Link>ServiceModel\Validation\ValidationError.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Validation\ValidationErrorField.cs">
+      <Link>ServiceModel\Validation\ValidationErrorField.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\Validation\ValidationErrorResult.cs">
+      <Link>ServiceModel\Validation\ValidationErrorResult.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceModel\XLinqExtensions.cs">
+      <Link>ServiceModel\XLinqExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\StreamExtensions.cs">
+      <Link>StreamExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\StringExtensions.cs">
+      <Link>StringExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\ActionExecHandler.cs">
+      <Link>Support\ActionExecHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\AdapterBase.cs">
+      <Link>Support\AdapterBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\AssignmentDefinition.cs">
+      <Link>Support\AssignmentDefinition.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\CommandExecsHandler.cs">
+      <Link>Support\CommandExecsHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\CommandResultsHandler.cs">
+      <Link>Support\CommandResultsHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\InMemoryLogFactory.cs">
+      <Link>Support\InMemoryLogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\LogicFacadeBase.cs">
+      <Link>Support\LogicFacadeBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\NetDeflateProvider.cs">
+      <Link>Support\NetDeflateProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\NetGZipProvider.cs">
+      <Link>Support\NetGZipProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Support\PropertyInvoker.cs">
+      <Link>Support\PropertyInvoker.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\TypeExtensions.cs">
+      <Link>TypeExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\UrnId.cs">
+      <Link>UrnId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\AssertUtils.cs">
+      <Link>Utils\AssertUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\CommandsUtils.cs">
+      <Link>Utils\CommandsUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\FuncUtils.cs">
+      <Link>Utils\FuncUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\IdUtils.cs">
+      <Link>Utils\IdUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\PathUtils.cs">
+      <Link>Utils\PathUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\PerfUtils.cs">
+      <Link>Utils\PerfUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\ReflectionUtils.cs">
+      <Link>Utils\ReflectionUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\CompressedFileResult.cs">
+      <Link>Web\CompressedFileResult.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\CompressedResult.cs">
+      <Link>Web\CompressedResult.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\CompressionTypes.cs">
+      <Link>Web\CompressionTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\ContentType.cs">
+      <Link>Web\ContentType.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\EndPoint.cs">
+      <Link>Web\EndPoint.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpError.cs">
+      <Link>Web\HttpError.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpHeaders.cs">
+      <Link>Web\HttpHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpMethods.cs">
+      <Link>Web\HttpMethods.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResponseFilter.cs">
+      <Link>Web\HttpResponseFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResponseStreamWrapper.cs">
+      <Link>Web\HttpResponseStreamWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResult.cs">
+      <Link>Web\HttpResult.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\HttpResultExtensions.cs">
+      <Link>Web\HttpResultExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\MimeTypes.cs">
+      <Link>Web\MimeTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Web\SerializationContext.cs">
+      <Link>Web\SerializationContext.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\ServiceStack.Common\RequestContextExtensions.cs">
+      <Link>RequestContextExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\ServiceClient.Web\UrlExtensions.cs">
+      <Link>ServiceClient.Web\UrlExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\IResponseStatusConvertible.cs">
+      <Link>IResponseStatusConvertible.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Common\Utils\ResponseStatusUtils.cs">
+      <Link>ResponseStatusUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ServiceStack.Common\README.md">
+      <Link>README.md</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\ServiceStack.Text\src\ServiceStack.Text.Android\ServiceStack.Text.Android\ServiceStack.Text.Android.csproj">
+      <Project>{56838CD4-8EBC-4860-A3E1-1697875BBC61}</Project>
+      <Name>ServiceStack.Text.Android</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceStack.Interfaces.Android\ServiceStack.Interfaces.Android.csproj">
+      <Project>{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}</Project>
+      <Name>ServiceStack.Interfaces.Android</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceStack.Common/ServiceClient.Web/GenericProxy.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/GenericProxy.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System.ServiceModel;
 using System.ServiceModel.Description;
 

--- a/src/ServiceStack.Common/ServiceClient.Web/IDuplex.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/IDuplex.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 

--- a/src/ServiceStack.Common/ServiceClient.Web/IDuplexCallback.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/IDuplexCallback.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 

--- a/src/ServiceStack.Common/ServiceClient.Web/IOneWay.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/IOneWay.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using ServiceStack.ServiceHost;

--- a/src/ServiceStack.Common/ServiceClient.Web/ISyncReply.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ISyncReply.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using ServiceStack.ServiceHost;

--- a/src/ServiceStack.Common/ServiceClient.Web/IWcfServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/IWcfServiceClient.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System;
 using System.ServiceModel.Channels;
 using ServiceStack.Service;

--- a/src/ServiceStack.Common/ServiceClient.Web/Soap11ServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/Soap11ServiceClient.cs
@@ -6,7 +6,7 @@ using ServiceStack.ServiceHost;
 namespace ServiceStack.ServiceClient.Web
 {
 
-#if SILVERLIGHT || MONOTOUCH || XBOX
+#if SILVERLIGHT || MONOTOUCH || XBOX || ANDROIDINDIE
 
     public class Soap11ServiceClient : IServiceClient
     {

--- a/src/ServiceStack.Common/ServiceClient.Web/WcfServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WcfServiceClient.cs
@@ -1,4 +1,4 @@
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
 using System;
 using System.IO;
 using System.Net;

--- a/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractDeserializer.cs
+++ b/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractDeserializer.cs
@@ -20,7 +20,7 @@ namespace ServiceStack.ServiceModel.Serialization
             if (TextSerializer != null)
                 return TextSerializer.DeserializeFromString(json, returnType);
 
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
             if (!UseBcl)
                 return JsonSerializer.DeserializeFromString(json, returnType);
 
@@ -60,7 +60,7 @@ namespace ServiceStack.ServiceModel.Serialization
             if (TextSerializer != null)
                 return TextSerializer.DeserializeFromStream<T>(stream);
 
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
             if (UseBcl)
             {
                 var serializer = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(T));
@@ -75,7 +75,7 @@ namespace ServiceStack.ServiceModel.Serialization
             if (TextSerializer != null)
                 return TextSerializer.DeserializeFromStream(type, stream);
 
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
             if (UseBcl)
             {
                 var serializer = new System.Runtime.Serialization.Json.DataContractJsonSerializer(type);

--- a/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
+++ b/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
@@ -25,7 +25,7 @@ namespace ServiceStack.ServiceModel.Serialization
             if (TextSerializer != null)
                 return TextSerializer.SerializeToString(obj);
 
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
             if (!UseBcl)
                 return JsonSerializer.SerializeToString(obj);
 
@@ -59,7 +59,7 @@ namespace ServiceStack.ServiceModel.Serialization
             {
                 TextSerializer.SerializeToStream(obj, stream);
             }
-#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+#if !SILVERLIGHT && !MONOTOUCH && !XBOX && !ANDROIDINDIE
             else if (UseBcl)
             {
                 var serializer = new System.Runtime.Serialization.Json.DataContractJsonSerializer(obj.GetType());

--- a/src/ServiceStack.Interfaces.AndroidIndie/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Interfaces.AndroidIndie/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack.Interfaces.Android")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceStack.Interfaces.Android")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0ab3f9c6-cfc9-44c8-b678-6526f3ad7e73")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.Interfaces.AndroidIndie/ServiceStack.Interfaces.Android.csproj
+++ b/src/ServiceStack.Interfaces.AndroidIndie/ServiceStack.Interfaces.Android.csproj
@@ -1,0 +1,609 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{05A5DDBF-A1A2-4B28-9FF0-C07060A8AEFC}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceStack.Interfaces</RootNamespace>
+    <AssemblyName>ServiceStack.Interfaces</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;ANDROIDINDIE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;ANDROIDINDIE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheClearable.cs">
+      <Link>CacheAccess\ICacheClearable.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheClient.cs">
+      <Link>CacheAccess\ICacheClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheHasContentType.cs">
+      <Link>CacheAccess\ICacheHasContentType.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheManager.cs">
+      <Link>CacheAccess\ICacheManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheTextManager.cs">
+      <Link>CacheAccess\ICacheTextManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICacheTextManagerFactory.cs">
+      <Link>CacheAccess\ICacheTextManagerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICompressableCacheTextManager.cs">
+      <Link>CacheAccess\ICompressableCacheTextManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ICompressableCacheTextManagerFactory.cs">
+      <Link>CacheAccess\ICompressableCacheTextManagerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IDeflateProvider.cs">
+      <Link>CacheAccess\IDeflateProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IGZipProvider.cs">
+      <Link>CacheAccess\IGZipProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IHasCacheClient.cs">
+      <Link>CacheAccess\IHasCacheClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IMemcachedClient.cs">
+      <Link>CacheAccess\IMemcachedClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IPersistenceProviderCache.cs">
+      <Link>CacheAccess\IPersistenceProviderCache.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\IPersistenceProviderCacheFactory.cs">
+      <Link>CacheAccess\IPersistenceProviderCacheFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ISession.cs">
+      <Link>CacheAccess\ISession.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\CacheAccess\ISessionFactory.cs">
+      <Link>CacheAccess\ISessionFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Configuration\IContainerAdapter.cs">
+      <Link>Configuration\IContainerAdapter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Configuration\IFactoryProvider.cs">
+      <Link>Configuration\IFactoryProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Configuration\IResourceManager.cs">
+      <Link>Configuration\IResourceManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Configuration\ITypeFactory.cs">
+      <Link>Configuration\ITypeFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\Criteria\ICriteria.cs">
+      <Link>DataAccess\Criteria\ICriteria.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\Criteria\IOrderAscendingCriteria.cs">
+      <Link>DataAccess\Criteria\IOrderAscendingCriteria.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\Criteria\IOrderDescendingCriteria.cs">
+      <Link>DataAccess\Criteria\IOrderDescendingCriteria.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\Criteria\IPagingCriteria.cs">
+      <Link>DataAccess\Criteria\IPagingCriteria.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\Criteria\PagingCriteria.cs">
+      <Link>DataAccess\Criteria\PagingCriteria.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\DataAccessException.cs">
+      <Link>DataAccess\DataAccessException.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IAggregatable.cs">
+      <Link>DataAccess\IAggregatable.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IBasicPersistenceProvider.cs">
+      <Link>DataAccess\IBasicPersistenceProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IBasicPersistenceProvider.Generic.cs">
+      <Link>DataAccess\IBasicPersistenceProvider.Generic.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IHasDbConnection.cs">
+      <Link>DataAccess\IHasDbConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IPersistenceProvider.cs">
+      <Link>DataAccess\IPersistenceProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IPersistenceProviderManager.cs">
+      <Link>DataAccess\IPersistenceProviderManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IPersistenceProviderManagerFactory.cs">
+      <Link>DataAccess\IPersistenceProviderManagerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IQueryable.cs">
+      <Link>DataAccess\IQueryable.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IQueryableByComparer.cs">
+      <Link>DataAccess\IQueryableByComparer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IQueryableByExample.cs">
+      <Link>DataAccess\IQueryableByExample.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IQueryableByPredicate.cs">
+      <Link>DataAccess\IQueryableByPredicate.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IQueryablePersistenceProvider.cs">
+      <Link>DataAccess\IQueryablePersistenceProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\IResultSet.cs">
+      <Link>DataAccess\IResultSet.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAccess\ITransactionContext.cs">
+      <Link>DataAccess\ITransactionContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\AliasAttribute.cs">
+      <Link>DataAnnotations\AliasAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\AutoIncrementAttribute.cs">
+      <Link>DataAnnotations\AutoIncrementAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\CompositeIndexAttribute.cs">
+      <Link>DataAnnotations\CompositeIndexAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\DefaultAttribute.cs">
+      <Link>DataAnnotations\DefaultAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\IndexAttribute.cs">
+      <Link>DataAnnotations\IndexAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DataAnnotations\ReferencesAttribute.cs">
+      <Link>DataAnnotations\ReferencesAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommand.cs">
+      <Link>DesignPatterns\Command\ICommand.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommandExec.cs">
+      <Link>DesignPatterns\Command\ICommandExec.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommandIEnumerable.cs">
+      <Link>DesignPatterns\Command\ICommandIEnumerable.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommandIList.cs">
+      <Link>DesignPatterns\Command\ICommandIList.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommandList.cs">
+      <Link>DesignPatterns\Command\ICommandList.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Command\ICommandVoid.cs">
+      <Link>DesignPatterns\Command\ICommandVoid.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasGuidId.cs">
+      <Link>DesignPatterns\Model\IHasGuidId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasId.cs">
+      <Link>DesignPatterns\Model\IHasId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasIntId.cs">
+      <Link>DesignPatterns\Model\IHasIntId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasLongId.cs">
+      <Link>DesignPatterns\Model\IHasLongId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasNamed.cs">
+      <Link>DesignPatterns\Model\IHasNamed.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasNamedCollection.cs">
+      <Link>DesignPatterns\Model\IHasNamedCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasNamedList.cs">
+      <Link>DesignPatterns\Model\IHasNamedList.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasStringId.cs">
+      <Link>DesignPatterns\Model\IHasStringId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasUserId.cs">
+      <Link>DesignPatterns\Model\IHasUserId.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Model\IHasUserSession.cs">
+      <Link>DesignPatterns\Model\IHasUserSession.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Serialization\IStringDeserializer.cs">
+      <Link>DesignPatterns\Serialization\IStringDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Serialization\IStringSerializer.cs">
+      <Link>DesignPatterns\Serialization\IStringSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Serialization\ITextSerializer.cs">
+      <Link>DesignPatterns\Serialization\ITextSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\DesignPatterns\Translator\ITranslator.cs">
+      <Link>DesignPatterns\Translator\ITranslator.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\ILog.cs">
+      <Link>Logging\ILog.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\ILogFactory.cs">
+      <Link>Logging\ILogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\LogManager.cs">
+      <Link>Logging\LogManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\ConsoleLogFactory.cs">
+      <Link>Logging\Support\Logging\ConsoleLogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\ConsoleLogger.cs">
+      <Link>Logging\Support\Logging\ConsoleLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\DebugLogFactory.cs">
+      <Link>Logging\Support\Logging\DebugLogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\DebugLogger.cs">
+      <Link>Logging\Support\Logging\DebugLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\NullDebugLogger.cs">
+      <Link>Logging\Support\Logging\NullDebugLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\NullLogFactory.cs">
+      <Link>Logging\Support\Logging\NullLogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\TestLogFactory.cs">
+      <Link>Logging\Support\Logging\TestLogFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Logging\Support\Logging\TestLogger.cs">
+      <Link>Logging\Support\Logging\TestLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\IApplicationContext.cs">
+      <Link>LogicFacade\IApplicationContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\IInitContext.cs">
+      <Link>LogicFacade\IInitContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\ILogicFacade.cs">
+      <Link>LogicFacade\ILogicFacade.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\InitOptions.cs">
+      <Link>LogicFacade\InitOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\IOperationContext.cs">
+      <Link>LogicFacade\IOperationContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\IServiceModelFinder.cs">
+      <Link>LogicFacade\IServiceModelFinder.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\LogicFacade\IXmlRequest.cs">
+      <Link>LogicFacade\IXmlRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessage.cs">
+      <Link>Messaging\IMessage.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessageFactory.cs">
+      <Link>Messaging\IMessageFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessageProducer.cs">
+      <Link>Messaging\IMessageProducer.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessageQueueClient.cs">
+      <Link>Messaging\IMessageQueueClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessageQueueClientFactory.cs">
+      <Link>Messaging\IMessageQueueClientFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\IMessageService.cs">
+      <Link>Messaging\IMessageService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\MessageError.cs">
+      <Link>Messaging\MessageError.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\MessageFactory.cs">
+      <Link>Messaging\MessageFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\MessageHandlerStats.cs">
+      <Link>Messaging\MessageHandlerStats.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\MessageOption.cs">
+      <Link>Messaging\MessageOption.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\MessagingException.cs">
+      <Link>Messaging\MessagingException.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\QueueNames.cs">
+      <Link>Messaging\QueueNames.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Messaging\UnRetryableMessagingException.cs">
+      <Link>Messaging\UnRetryableMessagingException.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisHash.Generic.cs">
+      <Link>Redis\Generic\IRedisHash.Generic.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisList.Generic.cs">
+      <Link>Redis\Generic\IRedisList.Generic.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisSet.Generic.cs">
+      <Link>Redis\Generic\IRedisSet.Generic.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisSortedSet.Generic.cs">
+      <Link>Redis\Generic\IRedisSortedSet.Generic.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisTransaction.cs">
+      <Link>Redis\Generic\IRedisTransaction.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisTypedClient.cs">
+      <Link>Redis\Generic\IRedisTypedClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisTypedPipeline.cs">
+      <Link>Redis\Generic\IRedisTypedPipeline.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Generic\IRedisTypedQueueableOperation.cs">
+      <Link>Redis\Generic\IRedisTypedQueueableOperation.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisClient.cs">
+      <Link>Redis\IRedisClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisClientCacheManager.cs">
+      <Link>Redis\IRedisClientCacheManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisClientsManager.cs">
+      <Link>Redis\IRedisClientsManager.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisHash.cs">
+      <Link>Redis\IRedisHash.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisList.cs">
+      <Link>Redis\IRedisList.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisNativeClient.cs">
+      <Link>Redis\IRedisNativeClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisSet.cs">
+      <Link>Redis\IRedisSet.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\ItemRef.cs">
+      <Link>Redis\ItemRef.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisSortedSet.cs">
+      <Link>Redis\IRedisSortedSet.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisSubscription.cs">
+      <Link>Redis\IRedisSubscription.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisTransaction.cs">
+      <Link>Redis\IRedisTransaction.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\IRedisTransactionBase.cs">
+      <Link>Redis\IRedisTransactionBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Pipeline\IRedisPipeline.cs">
+      <Link>Redis\Pipeline\IRedisPipeline.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Pipeline\IRedisPipelineShared.cs">
+      <Link>Redis\Pipeline\IRedisPipelineShared.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Pipeline\IRedisQueueableOperation.cs">
+      <Link>Redis\Pipeline\IRedisQueueableOperation.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\Pipeline\IRedisQueueCompletableOperation.cs">
+      <Link>Redis\Pipeline\IRedisQueueCompletableOperation.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\RedisKeyType.cs">
+      <Link>Redis\RedisKeyType.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Redis\SortOptions.cs">
+      <Link>Redis\SortOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\SearchIndex\FullTextIndexAttribute.cs">
+      <Link>SearchIndex\FullTextIndexAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\SearchIndex\FullTextIndexDocumentAttribute.cs">
+      <Link>SearchIndex\FullTextIndexDocumentAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\SearchIndex\FullTextIndexFieldAttribute.cs">
+      <Link>SearchIndex\FullTextIndexFieldAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\EndpointAttributes.cs">
+      <Link>ServiceHost\EndpointAttributes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\Feature.cs">
+      <Link>ServiceHost\Feature.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IAsyncService.cs">
+      <Link>ServiceHost\IAsyncService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IContentTypeFilter.cs">
+      <Link>ServiceHost\IContentTypeFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IContentTypeReader.cs">
+      <Link>ServiceHost\IContentTypeReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IContentTypeWriter.cs">
+      <Link>ServiceHost\IContentTypeWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\ICookies.cs">
+      <Link>ServiceHost\ICookies.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IExpirable.cs">
+      <Link>ServiceHost\IExpirable.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IFile.cs">
+      <Link>ServiceHost\IFile.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHasOptions.cs">
+      <Link>ServiceHost\IHasOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHasRequestFilter.cs">
+      <Link>ServiceHost\IHasRequestFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHasResponseFilter.cs">
+      <Link>ServiceHost\IHasResponseFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHttpError.cs">
+      <Link>ServiceHost\IHttpError.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHttpRequest.cs">
+      <Link>ServiceHost\IHttpRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHttpResponse.cs">
+      <Link>ServiceHost\IHttpResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IHttpResult.cs">
+      <Link>ServiceHost\IHttpResult.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRequestAttributes.cs">
+      <Link>ServiceHost\IRequestAttributes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRequestContext.cs">
+      <Link>ServiceHost\IRequestContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRequestLogger.cs">
+      <Link>ServiceHost\IRequestLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRequiresRequestContext.cs">
+      <Link>ServiceHost\IRequiresRequestContext.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestDeleteService.cs">
+      <Link>ServiceHost\IRestDeleteService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestGetService.cs">
+      <Link>ServiceHost\IRestGetService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestPatchService.cs">
+      <Link>ServiceHost\IRestPatchService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestPath.cs">
+      <Link>ServiceHost\IRestPath.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestPostService.cs">
+      <Link>ServiceHost\IRestPostService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestPutService.cs">
+      <Link>ServiceHost\IRestPutService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IRestService.cs">
+      <Link>ServiceHost\IRestService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IService.cs">
+      <Link>ServiceHost\IService.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IServiceController.cs">
+      <Link>ServiceHost\IServiceController.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IServiceRoutes.cs">
+      <Link>ServiceHost\IServiceRoutes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\RestServiceAttribute.cs">
+      <Link>ServiceHost\RestServiceAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\CollectionTypes.cs">
+      <Link>ServiceInterface.ServiceModel\CollectionTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ICacheByDateModified.cs">
+      <Link>ServiceInterface.ServiceModel\ICacheByDateModified.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ICacheByEtag.cs">
+      <Link>ServiceInterface.ServiceModel\ICacheByEtag.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\IHasAction.cs">
+      <Link>ServiceInterface.ServiceModel\IHasAction.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\IHasResponseStatus.cs">
+      <Link>ServiceInterface.ServiceModel\IHasResponseStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\Property.cs">
+      <Link>ServiceInterface.ServiceModel\Property.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\RequestLogEntry.cs">
+      <Link>ServiceInterface.ServiceModel\RequestLogEntry.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ResponseError.cs">
+      <Link>ServiceInterface.ServiceModel\ResponseError.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ResponseStatus.cs">
+      <Link>ServiceInterface.ServiceModel\ResponseStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IOneWayClient.cs">
+      <Link>Service\IOneWayClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IReplyClient.cs">
+      <Link>Service\IReplyClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IResponseBase.cs">
+      <Link>Service\IResponseBase.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IResponseStatus.cs">
+      <Link>Service\IResponseStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IRestClient.cs">
+      <Link>Service\IRestClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IRestClientAsync.cs">
+      <Link>Service\IRestClientAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IServiceClient.cs">
+      <Link>Service\IServiceClient.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IServiceClientAsync.cs">
+      <Link>Service\IServiceClientAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IStreamWriter.cs">
+      <Link>Service\IStreamWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Translators\TranslateAttribute.cs">
+      <Link>Translators\TranslateAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Translators\TranslateExtensionAttribute.cs">
+      <Link>Translators\TranslateExtensionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Translators\TranslateMemberAttribute.cs">
+      <Link>Translators\TranslateMemberAttribute.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\IResolver.cs">
+      <Link>ServiceHost\IResolver.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceHost\RouteAttribute.cs">
+      <Link>ServiceHost\RouteAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\ServiceInterface.ServiceModel\ErrorResponse.cs">
+      <Link>ServiceInterface.ServiceModel\ErrorResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.Interfaces\Service\IPartialWriter.cs">
+      <Link>Service\IPartialWriter.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" />
+    <None Include="..\Redis\Redis.cd" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\Redis\Redis-annotated.png" />
+    <Content Include="..\Redis\Redis.png" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceStack.Interfaces/Service/IServiceClient.cs
+++ b/src/ServiceStack.Interfaces/Service/IServiceClient.cs
@@ -3,7 +3,7 @@ using System;
 namespace ServiceStack.Service
 {
 	public interface IServiceClient : IServiceClientAsync, IOneWayClient
-#if !(SILVERLIGHT || MONOTOUCH)
+#if !(SILVERLIGHT || MONOTOUCH || ANDROIDINDIE)
 		, IReplyClient
 #endif
 	{


### PR DESCRIPTION
New client build project for Xamarin.Android "Indie License" because we cannot use WCF under Indie License
- Create new project and solution for Indie License not link WCF
- Add new preprocess symbol ANDROIDINDIE
