### PR TITLE
Order routes for Swagger Api alphabetically

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
@@ -68,6 +68,8 @@ namespace ServiceStack.Api.Swagger
 
                 CreateRestPaths(result.Apis, operationType, operationName);
             }
+
+            result.Apis = result.Apis.OrderBy(a => a.Path).ToList();
             return result;
         }
 


### PR DESCRIPTION
Currently there is no ordering being supplied to the routes being retrieved for Swagger documentation. They maintain the same order from when they were [added to the ServiceMetaData class](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs#L58). This can lead to the routes getting jumbled around as more are added.

Instead, they should be sorted alphabetically. There is already an alphabetical sorting being performed on the [individual base routes](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Api.Swagger/SwaggerApiService.cs#L173), just none yet being done here at the base level.
