### PR TITLE
Fix metadata break when any of the parameters return null due to the extra Format function.

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -165,9 +165,11 @@ namespace ServiceStack.WebHost.Endpoints
             if (string.IsNullOrEmpty(pathInfo) || pathInfo == "/")
             {
                 //Exception calling context.Request.Url on Apache+mod_mono
-                var absoluteUrl = Env.IsMono ? url.ToParentPath() : context.Request.GetApplicationUrl();
                 if (ApplicationBaseUrl == null)
+                {
+                    var absoluteUrl = Env.IsMono ? url.ToParentPath() : context.Request.GetApplicationUrl();
                     SetApplicationBaseUrl(absoluteUrl);
+                }
 
                 //e.g. CatchAllHandler to Process Markdown files
                 var catchAllHandler = GetCatchAllHandlerIfAny(httpReq.HttpMethod, pathInfo, httpReq.GetPhysicalPath());

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/IndexOperationsControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/IndexOperationsControl.cs
@@ -86,7 +86,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
                 debugOnlyInfo.AppendLine("</ul>");
             }
 
-            var renderedTemplate = HtmlTemplates.Format(
+            var renderedTemplate = string.Format(
 				HtmlTemplates.IndexOperationsTemplate, 
                 this.Title, 
                 this.MetadataPageBodyHtml, 

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationControl.cs
@@ -44,7 +44,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
 
 		public void Render(HtmlTextWriter output)
 		{
-            var renderedTemplate = HtmlTemplates.Format(HtmlTemplates.OperationControlTemplate, 
+            var renderedTemplate = string.Format(HtmlTemplates.OperationControlTemplate, 
 				Title, 
 				HttpRequest.GetParentAbsolutePath().ToParentPath() + MetadataConfig.DefaultMetadataUri,
 				ContentFormat.ToUpper(), 

--- a/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationsControl.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Metadata/Controls/OperationsControl.cs
@@ -17,7 +17,7 @@ namespace ServiceStack.WebHost.Endpoints.Support.Metadata.Controls
                 ListItems = this.OperationNames,
                 ListItemTemplate = @"<li><a href=""?op={0}"">{0}</a></li>"
             }.ToString();
-            var renderedTemplate = HtmlTemplates.Format(HtmlTemplates.OperationsControlTemplate, 
+            var renderedTemplate = string.Format(HtmlTemplates.OperationsControlTemplate, 
                 this.Title, this.MetadataOperationPageBodyHtml, operationsPart);
             output.Write(renderedTemplate);
         }

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
@@ -55,8 +55,8 @@ namespace ServiceStack.WebHost.Endpoints.Support.Templates
             try
             {
                 var staticFilePath = PathUtils.CombinePaths(
-                    EndpointHost.AppHost.VirtualPathProvider.RootDirectory.RealPath, 
-                    EndpointHost.Config.MetadataCustomPath, 
+                    EndpointHost.AppHost.VirtualPathProvider.RootDirectory.RealPath,
+                    EndpointHost.Config.MetadataCustomPath,
                     templateName);
 
                 template = File.ReadAllText(staticFilePath);
@@ -83,15 +83,5 @@ namespace ServiceStack.WebHost.Endpoints.Support.Templates
                 return streamReader.ReadToEnd();
             }
         }
-
-        public static string Format(string template, params object[] args)
-        {
-            for (int i = 0; i < args.Length; i++)
-            {
-                template = template.Replace(@"{" + i + "}", args[i].ToString());
-            }
-            return template;
-        }
-
     }
 }


### PR DESCRIPTION
Remove the unnecessary Format function that breaks the metadata template when any of the parameters are null. As ToString() is invoked on a null object.
