### PR TITLE
Fix metadata break when any of the paratemers to the Format function are null.

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -165,9 +165,11 @@ namespace ServiceStack.WebHost.Endpoints
             if (string.IsNullOrEmpty(pathInfo) || pathInfo == "/")
             {
                 //Exception calling context.Request.Url on Apache+mod_mono
-                var absoluteUrl = Env.IsMono ? url.ToParentPath() : context.Request.GetApplicationUrl();
                 if (ApplicationBaseUrl == null)
+                {
+                    var absoluteUrl = Env.IsMono ? url.ToParentPath() : context.Request.GetApplicationUrl();
                     SetApplicationBaseUrl(absoluteUrl);
+                }
 
                 //e.g. CatchAllHandler to Process Markdown files
                 var catchAllHandler = GetCatchAllHandlerIfAny(httpReq.HttpMethod, pathInfo, httpReq.GetPhysicalPath());

--- a/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Templates/HtmlTemplates.cs
@@ -88,7 +88,8 @@ namespace ServiceStack.WebHost.Endpoints.Support.Templates
         {
             for (int i = 0; i < args.Length; i++)
             {
-                template = template.Replace(@"{" + i + "}", args[i].ToString());
+                var currentValue = args[i] ?? String.Empty;
+                template = template.Replace(@"{" + i + "}", currentValue.ToString());
             }
             return template;
         }


### PR DESCRIPTION
Here's the proper fix. Example of failure can be seen in the in-built Swagger ResourceRequest which will generate an error.
