### PR TITLE
Integrate Restrict attribute to Swagger Api

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -161,10 +161,10 @@ namespace ServiceStack.Api.Swagger
             {
                 basePath = basePath.Substring(0, basePath.LastIndexOf(SwaggerResourcesService.RESOURCE_PATH, StringComparison.OrdinalIgnoreCase));
             }
-
+            var meta = EndpointHost.Metadata;
             foreach (var key in map.Keys)
             {
-                paths.AddRange(map[key].Where(x => x.Path == path || x.Path.StartsWith(path + "/")));
+                paths.AddRange(map[key].Where(x => (x.Path == path || x.Path.StartsWith(path + "/") && meta.IsVisible(Request, Format.Json, x.RequestType.Name))));
             }
 
             var models = new Dictionary<string, SwaggerModel>();

--- a/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
@@ -74,6 +74,7 @@ namespace ServiceStack.Api.Swagger
                 if (operationType == null) continue;
                 if (operationType == typeof(Resources) || operationType == typeof(ResourceRequest))
                     continue;
+                if (!operations.IsVisible(Request, Format.Json, operationName)) continue;
 
                 CreateRestPaths(result.Apis, operationType, operationName);
             }


### PR DESCRIPTION
Restrict currently operates on the ServiceStack metadata page. This will extend the behavior to also properly hide the route information on the Swagger page.

It uses the same code that the metadata page uses to determine if it should show the route. Additionally, it will hide the entire base route section if none of its routes are visible.
