### PR TITLE
Avoid NullReferenceException when request times out

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
@@ -590,63 +590,71 @@ namespace ServiceStack.ServiceClient.Web
 
         private void HandleResponseError<TResponse>(Exception exception, RequestState<TResponse> requestState)
         {
-            var webEx = exception as WebException;
-            if (webEx != null
+            while (true) //only for flow control
+            {
+                var webEx = exception as WebException;
+                if (webEx != null
 #if !SILVERLIGHT
  && webEx.Status == WebExceptionStatus.ProtocolError
 #endif
 )
-            {
-                var errorResponse = ((HttpWebResponse)webEx.Response);
-                Log.Error(webEx);
-                Log.DebugFormat("Status Code : {0}", errorResponse.StatusCode);
-                Log.DebugFormat("Status Description : {0}", errorResponse.StatusDescription);
-
-                var serviceEx = new WebServiceException(errorResponse.StatusDescription)
                 {
-                    StatusCode = (int)errorResponse.StatusCode,
-                };
+                    var errorResponse = ((HttpWebResponse)webEx.Response);
+                    if (errorResponse == null) //response is null in case of time out
+                        break;
 
-                try
-                {
-                    using (var stream = errorResponse.GetResponseStream())
-                    {
-                        //Uncomment to Debug exceptions:
-                        //var strResponse = new StreamReader(stream).ReadToEnd();
-                        //Console.WriteLine("Response: " + strResponse);
-                        //stream.Position = 0;
-                        serviceEx.ResponseBody = errorResponse.GetResponseStream().ReadFully().FromUtf8Bytes();
-#if !MONOTOUCH
-                        // MonoTouch throws NotSupportedException when setting System.Net.WebConnectionStream.Position
-                        // Not sure if the stream is used later though, so may have to copy to MemoryStream and
-                        // pass that around instead after this point?
-                        stream.Position = 0;
-#endif
+                    Log.Error(webEx);
+                    Log.DebugFormat("Status Code : {0}", errorResponse.StatusCode);
+                    Log.DebugFormat("Status Description : {0}", errorResponse.StatusDescription);
 
-                        serviceEx.ResponseDto = this.StreamDeserializer(typeof(TResponse), stream);
-                        requestState.HandleError((TResponse)serviceEx.ResponseDto, serviceEx);
-                    }
-                }
-                catch (Exception innerEx)
-                {
-                    // Oh, well, we tried
-                    Log.Debug(string.Format("WebException Reading Response Error: {0}", innerEx.Message), innerEx);
-                    requestState.HandleError(default(TResponse), new WebServiceException(errorResponse.StatusDescription, innerEx)
+                    var serviceEx = new WebServiceException(errorResponse.StatusDescription)
                     {
                         StatusCode = (int)errorResponse.StatusCode,
-                    });
+                    };
+
+                    try
+                    {
+                        using (var stream = errorResponse.GetResponseStream())
+                        {
+                            //Uncomment to Debug exceptions:
+                            //var strResponse = new StreamReader(stream).ReadToEnd();
+                            //Console.WriteLine("Response: " + strResponse);
+                            //stream.Position = 0;
+                            serviceEx.ResponseBody = errorResponse.GetResponseStream().ReadFully().FromUtf8Bytes();
+#if !MONOTOUCH
+                            // MonoTouch throws NotSupportedException when setting System.Net.WebConnectionStream.Position
+                            // Not sure if the stream is used later though, so may have to copy to MemoryStream and
+                            // pass that around instead after this point?
+                            stream.Position = 0;
+#endif
+
+                            serviceEx.ResponseDto = this.StreamDeserializer(typeof(TResponse), stream);
+                            requestState.HandleError((TResponse)serviceEx.ResponseDto, serviceEx);
+                        }
+                    }
+                    catch (Exception innerEx)
+                    {
+                        // Oh, well, we tried
+                        Log.Debug(string.Format("WebException Reading Response Error: {0}", innerEx.Message), innerEx);
+                        requestState.HandleError(default(TResponse), new WebServiceException(errorResponse.StatusDescription, innerEx)
+                        {
+                            StatusCode = (int)errorResponse.StatusCode,
+                        });
+                    }
+                    return;
                 }
-                return;
-            }
 
-            var authEx = exception as AuthenticationException;
-            if (authEx != null)
-            {
-                var customEx = WebRequestUtils.CreateCustomException(requestState.Url, authEx);
+                var authEx = exception as AuthenticationException;
+                if (authEx != null)
+                {
+                    var customEx = WebRequestUtils.CreateCustomException(requestState.Url, authEx);
 
-                Log.Debug(string.Format("AuthenticationException: {0}", customEx.Message), customEx);
-                requestState.HandleError(default(TResponse), authEx);
-            }
+                    Log.Debug(string.Format("AuthenticationException: {0}", customEx.Message), customEx);
+                    requestState.HandleError(default(TResponse), authEx);
+                }
+
+                break; //exit while
+            };
 
             Log.Debug(string.Format("Exception Reading Response Error: {0}", exception.Message), exception);
             requestState.HandleError(default(TResponse), exception);


### PR DESCRIPTION
The diff looks bigger but the actual change is in 
- wrapping the tests on exception type to flow-controlling loop and
- testing the response on null (with possible break to continuation code)

I also have suspicion that there is missing 'return' when exception is AuthenticationException but did'nt fix as not sure about the purpose.
