### PR TITLE
Fixed issue with greyed out operations on metadata page for Turkish user...

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceMetadata.cs
+++ b/src/ServiceStack/ServiceHost/ServiceMetadata.cs
@@ -207,7 +207,7 @@ namespace ServiceStack.ServiceHost
                 return true;
 
             Operation operation;
-            OperationNamesMap.TryGetValue(operationName.ToLower(), out operation);
+            OperationNamesMap.TryGetValue(operationName.ToLowerInvariant(), out operation);
             if (operation == null) return false;
 
             var canCall = HasImplementation(operation, format);

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/OperationTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/OperationTests.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Globalization;
 using System.IO;
+using System.Runtime.Serialization;
+using System.Threading;
 using System.Web.UI;
 using Funq;
 using NUnit.Framework;
@@ -76,5 +80,38 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.IsTrue(html.Contains("<a href=\"/metadata\">&lt;back to all web services</a>"));
         }
 
+        [Test]
+        public void When_culture_is_turkish_operations_containing_capital_I_are_still_visible()
+        {
+            Metadata.Add(GetType(), typeof(HelloImage), null);
+
+            using (new CultureSwitch("tr-TR"))
+            {
+                Assert.IsTrue(Metadata.IsVisible(_operationControl.HttpRequest, Format.Json, "HelloImage"));
+            }
+        }
 	}
+
+    [DataContract]
+    public class HelloImage
+    {
+    }
+
+    public class CultureSwitch : IDisposable
+    {
+        private readonly CultureInfo _currentCulture;
+
+        public CultureSwitch(string culture)
+        {
+            var currentThread = Thread.CurrentThread;
+            _currentCulture = currentThread.CurrentCulture;
+            var switchCulture = CultureInfo.GetCultureInfo(culture);
+            currentThread.CurrentCulture = switchCulture;
+        }
+
+        public void Dispose()
+        {
+            Thread.CurrentThread.CurrentCulture = _currentCulture;
+        }
+    }
 }


### PR DESCRIPTION
...s

When the client culture is set to tr-TR (Turkish) and the ASP.NET client
based culture settings are configured as follows in web.config:

<system.web>
    ...
    <globalization uiCulture="auto" culture="auto"
                   enableClientBasedCulture="true" />
    ...
</system.web>

Operations under the metadata page which contain a capital 'I' will be
grayed out. This due to the Turkish I problem. Using ToLowerInvariant
rather than ToLower fixes the issue in this case.

The problem is described in detail here:
http://haacked.com/archive/2012/07/05/turkish-i-problem-and-why-you-should-care.aspx

and here:
http://www.codinghorror.com/blog/2008/03/whats-wrong-with-turkey.html
