### PR TITLE
Add support for using HttpContextBase, HttpRequestBase, HttpResponseBase...

### DIFF
--- a/src/ServiceStack/HttpExtensions.cs
+++ b/src/ServiceStack/HttpExtensions.cs
@@ -11,6 +11,13 @@ namespace ServiceStack
 {
     public static class HttpExtensions
     {
+        public static HttpRequestContext ToRequestContext(this HttpContextBase httpContext, object requestDto = null)
+        {
+            return new HttpRequestContext(
+                httpContext.Request.ToRequest(),
+                httpContext.Response.ToResponse(),
+                requestDto);
+        }
         public static HttpRequestContext ToRequestContext(this HttpContext httpContext, object requestDto = null)
         {
             return new HttpRequestContext(

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestExtensions.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestExtensions.cs
@@ -109,6 +109,21 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 			}
 		}
 
+        public static string GetUrlHostName(this HttpRequestBase request)
+        {
+            //TODO: Fix bug in mono fastcgi, when trying to get 'Request.Url.Host'
+            try
+            {
+                return request.Url.Host;
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("Error trying to get 'Request.Url.Host'", ex);
+
+                return request.UserHostName;
+            }
+        }
+
 		// http://localhost/ServiceStack.Examples.Host.Web/Public/Public/Soap12/Wsdl => 
 		// http://localhost/ServiceStack.Examples.Host.Web/Public/Soap12/
 		public static string GetParentBaseUrl(this HttpRequest request)
@@ -152,6 +167,20 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 		{
 			return GetLastPathInfoFromRawUrl(request.RawUrl);
 		}
+
+        public static string GetPathInfo(this HttpRequestBase request)
+        {
+            if (!String.IsNullOrEmpty(request.PathInfo)) return request.PathInfo.TrimEnd('/');
+
+            var mode = EndpointHost.Config.ServiceStackHandlerFactoryPath;
+            var appPath = String.IsNullOrEmpty(request.ApplicationPath)
+                          ? WebHostDirectoryName
+                          : request.ApplicationPath.TrimStart('/');
+
+            //mod_mono: /CustomPath35/api//default.htm
+            var path = Env.IsMono ? request.Path.Replace("//", "/") : request.Path;
+            return GetPathInfo(path, mode, appPath);
+        }
 
 		public static string GetPathInfo(this HttpRequest request)
 		{
@@ -525,6 +554,15 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 
 	        return false;
 	    }
+
+        public static IHttpRequest ToRequest(this HttpRequestBase aspnetHttpReq, string operationName = null)
+        {
+            return new HttpRequestWrapper(aspnetHttpReq)
+            {
+                OperationName = operationName,
+                Container = AppHostBase.Instance != null ? AppHostBase.Instance.Container : null
+            };
+        }
         
 	    public static IHttpRequest ToRequest(this HttpRequest aspnetHttpReq, string operationName=null)
 	    {
@@ -541,6 +579,11 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
                 Container = AppHostBase.Instance != null ? AppHostBase.Instance.Container : null
             };
 	    }
+
+        public static IHttpResponse ToResponse(this HttpResponseBase aspnetHttpRes)
+        {
+            return new HttpResponseWrapper(aspnetHttpRes);
+        }
 
 	    public static IHttpResponse ToResponse(this HttpResponse aspnetHttpRes)
 	    {

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestWrapper.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpRequestWrapper.cs
@@ -17,14 +17,14 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
     {
         private static readonly string physicalFilePath;
         public Container Container { get; set; }
-        private readonly HttpRequest request;
+        private readonly HttpRequestBase request;
 
         static HttpRequestWrapper()
         {
             physicalFilePath = "~".MapHostAbsolutePath();
         }
 
-        public HttpRequest Request
+        public HttpRequestBase Request
         {
             get { return request; }
         }
@@ -32,6 +32,18 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
         public object OriginalRequest
         {
             get { return request; }
+        }
+
+        public HttpRequestWrapper(HttpRequestBase request)
+            : this(null, request)
+        {
+        }
+
+        public HttpRequestWrapper(string operationName, HttpRequestBase request)
+        {
+            this.OperationName = operationName;
+            this.request = request;
+            this.Container = Container;
         }
 
         public HttpRequestWrapper(HttpRequest request)
@@ -42,7 +54,7 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
         public HttpRequestWrapper(string operationName, HttpRequest request)
         {
             this.OperationName = operationName;
-            this.request = request;
+            this.request = new System.Web.HttpRequestWrapper(request);
             this.Container = Container;
         }
 

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpResponseStreamExtensions.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpResponseStreamExtensions.cs
@@ -27,6 +27,24 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
 			//IsIis = !Env.IsMono;
 			IsHttpListener = HttpContext.Current == null;
 		}
+
+        public static void CloseOutputStream(this HttpResponseBase response)
+        {
+            try
+            {
+                //Don't close for MonoFastCGI as it outputs random 4-letters at the start
+                if (!IsMonoFastCgi)
+                {
+                    response.OutputStream.Flush();
+                    response.OutputStream.Close();
+                    //response.Close(); //This kills .NET Development Web Server
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Exception closing HttpResponse: " + ex.Message, ex);
+            }
+        }
         
 		public static void CloseOutputStream(this HttpResponse response)
 		{

--- a/src/ServiceStack/WebHost.Endpoints/Extensions/HttpResponseWrapper.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Extensions/HttpResponseWrapper.cs
@@ -10,16 +10,23 @@ namespace ServiceStack.WebHost.Endpoints.Extensions
     {
         //private static readonly ILog Log = LogManager.GetLogger(typeof(HttpResponseWrapper));
 
-        private readonly HttpResponse response;
+        private readonly HttpResponseBase response;
 
         public HttpResponseWrapper(HttpResponse response)
+        {
+            this.response = new System.Web.HttpResponseWrapper(response);
+            this.response.TrySkipIisCustomErrors = true;
+            this.Cookies = new Cookies(this);
+        }
+
+        public HttpResponseWrapper(HttpResponseBase response)
         {
             this.response = response;
             this.response.TrySkipIisCustomErrors = true;
             this.Cookies = new Cookies(this);
         }
 
-        public HttpResponse Response
+        public HttpResponseBase Response
         {
             get { return response; }
         }


### PR DESCRIPTION
As discussed in forums, here is the modification to support the enhancement.
....

These are equivalent classes to the non 'base' versions, but can be customized and used outside the asp.net pipeline.
This helps with unit testing and not using global HttpContext.Current.
Potentially the servicestack HttpResponseWrapper and HttpRequestWrapper classes could be just inherited from existing asp.net wrapper classes?
