### PR TITLE
ServiceRoutesExtensions.Add<T> with propertyExpressions now returns IServiceRoutes

### DIFF
--- a/src/ServiceStack.ServiceInterface/ServiceRoutesExtensions.cs
+++ b/src/ServiceStack.ServiceInterface/ServiceRoutesExtensions.cs
@@ -177,9 +177,9 @@ namespace ServiceStack.ServiceInterface
             return (lambdaExpression.Body is UnaryExpression ? (MemberExpression)((UnaryExpression)lambdaExpression.Body).Operand : (MemberExpression)lambdaExpression.Body).Member.Name;
         }
 
-        public static void Add<T>(this IServiceRoutes serviceRoutes, string restPath, ApplyTo verbs, params Expression<Func<T, object>>[] propertyExpressions)
+        public static IServiceRoutes Add<T>(this IServiceRoutes serviceRoutes, string restPath, ApplyTo verbs, params Expression<Func<T, object>>[] propertyExpressions)
         {
-            serviceRoutes.Add<T>(FormatRoute(restPath, propertyExpressions), verbs);
+            return serviceRoutes.Add<T>(FormatRoute(restPath, propertyExpressions), verbs);
         }
     }
 }


### PR DESCRIPTION
Just found it a bit annoying that this particular Add method did not return IServiceRoutes, so chaining .Add calls was not possible:

In ServiceRoutesExtensions.cs: 

public static void Add<T>(this IServiceRoutes serviceRoutes, string restPath, ApplyTo verbs, params Expression<Func<T, object>>[] propertyExpressions) 

now returns IServiceRoutes:

public static IServiceRoutes Add<T>(this IServiceRoutes serviceRoutes, string restPath, ApplyTo verbs, params Expression<Func<T, object>>[] propertyExpressions).
