### PR TITLE
Fix for async exceptions during deserialization: added proper serialization/deserialization exception propagation

### DIFF
--- a/src/ServiceStack.Plugins.ProtoBuf/ProtoBufServiceClient.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/ProtoBufServiceClient.cs
@@ -28,7 +28,7 @@ namespace ServiceStack.Plugins.ProtoBuf
 			}
 			catch (Exception ex)
 			{
-				throw new SerializationException("ProtoBufServiceClient: Error converting to type: " + ex.Message, ex);
+				throw new SerializationException("ProtoBufServiceClient: Error serializing: " + ex.Message, ex);
 			}
 		}
 
@@ -40,7 +40,7 @@ namespace ServiceStack.Plugins.ProtoBuf
 			}
 			catch (Exception ex)
 			{
-				throw new SerializationException("ProtoBufServiceClient: Error converting to type: " + ex.Message, ex);
+				throw new SerializationException("ProtoBufServiceClient: Error deserializing: " + ex.Message, ex);
 			}
 		}
 
@@ -62,7 +62,7 @@ namespace ServiceStack.Plugins.ProtoBuf
 			}
 			catch (Exception ex)
 			{
-				throw new SerializationException("ProtoBufServiceClient: Error converting to type: " + ex.Message, ex);
+				throw new SerializationException("ProtoBufServiceClient: Error deserializing: " + ex.Message, ex);
 			}
 		}
 	}


### PR DESCRIPTION
The current implementation causes incorrect handling by ServiceStack of web responses (ex.: 401 Authorization Required) when performing async calls (ex.: GetAsync()). ServiceStack expects a SerializationException - not a ProtoBuf.ProtoException. This causes the host application to crash instead of calling the OnError handler specified at the GetAsync call site.

Wrapping the exception in a SerializationException fixes this incorrect behavior, where ServiceStack analyses the response, generates the proper WebServiceException and calls the OnError handler, as expected.
