### PR TITLE
Fixed build by adding missing using statements

### DIFF
--- a/src/ServiceStack.Plugins.ProtoBuf/ProtoBufServiceClient.cs
+++ b/src/ServiceStack.Plugins.ProtoBuf/ProtoBufServiceClient.cs
@@ -1,5 +1,7 @@
-using ProtoBuf;
+using System;
 using System.IO;
+using System.Runtime.Serialization;
+using ProtoBuf;
 using ServiceStack.ServiceClient.Web;
 using ServiceStack.ServiceHost;
 


### PR DESCRIPTION
Build failed due to missing references to `System` and `System.Runtime.Serialization`.  Added in these `using` statements to fix the build.
