### PR TITLE
OrmLite interfaces added to iOS project

### DIFF
--- a/src/ServiceStack.Interfaces/DataAccess/IHasDbConnection.cs
+++ b/src/ServiceStack.Interfaces/DataAccess/IHasDbConnection.cs
@@ -1,4 +1,4 @@
-﻿#if !SILVERLIGHT && !MONOTOUCH && !XBOX
+﻿#if !SILVERLIGHT && !XBOX
 using System.Data;
 
 namespace ServiceStack.DataAccess

--- a/src/ServiceStack.MonoTouch/ServiceStack.Interfaces.MonoTouch/ServiceStack.Interfaces.MonoTouch.csproj
+++ b/src/ServiceStack.MonoTouch/ServiceStack.Interfaces.MonoTouch/ServiceStack.Interfaces.MonoTouch.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="monotouch" />
@@ -329,6 +330,12 @@
     </Compile>
     <Compile Include="..\..\ServiceStack.Interfaces\Messaging\UnRetryableMessagingException.cs">
       <Link>Messaging\UnRetryableMessagingException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\ServiceStack.Interfaces\OrmLite\DbConnectionFactory.cs">
+      <Link>OrmLite\DbConnectionFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\..\ServiceStack.Interfaces\OrmLite\IDbConnectionFactory.cs">
+      <Link>OrmLite\IDbConnectionFactory.cs</Link>
     </Compile>
     <Compile Include="..\..\ServiceStack.Interfaces\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>


### PR DESCRIPTION
Since System.Data & System.ComponentModel.DataAnnotations are now
available in Xamarin.iOS we can enable these interfaces.

OrmLite now has iOS solution and the base project. I will see if I can
add SQLite and SQLCipher as database providers for iOS (and Android).
