### PR TITLE
NamespacePrefix for IRedisClient/IRedisClientFacade

### DIFF
--- a/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
@@ -39,6 +39,7 @@ namespace ServiceStack.Redis
 		int SendTimeout { get; set; }
 		string Password { get; set; }
 		bool HadExceptions { get; }
+        string NamespacePrefix { get; }
 
 		void Save();
 		void SaveAsync();

--- a/src/ServiceStack.ServiceInterface/Auth/IRedisClientFacade.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/IRedisClientFacade.cs
@@ -26,6 +26,7 @@ namespace ServiceStack.ServiceInterface.Auth
         void RemoveEntryFromHash(string hashId, string key);
         void AddItemToSet(string setId, string item);
         ITypedRedisClientFacade<T> As<T>();
+        string NamespacePrefix { get; }
     }
 
     public interface ITypedRedisClientFacade<T>
@@ -127,6 +128,11 @@ namespace ServiceStack.ServiceInterface.Auth
             public void Dispose()
             {
                 this.redisClient.Dispose();
+            }
+
+            public string NamespacePrefix
+            {
+                get { return this.redisClient.NamespacePrefix; }
             }
         }
     }

--- a/src/ServiceStack.ServiceInterface/Auth/InMemoryAuthRepository.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/InMemoryAuthRepository.cs
@@ -203,6 +203,11 @@ namespace ServiceStack.ServiceInterface.Auth
             public void Dispose()
             {
             }
+
+            public string NamespacePrefix
+            {
+                get { return null; }
+            }
         }
 
     }


### PR DESCRIPTION
Nam

Expose NamespacePrefix in IRedisClient and IRedisClientFacade so it
could be used in RedisAuthRepository. When the prefix is set in the
manager the local/private keys in RedisAuthRepository has no prefix but
the "clientTyped keys" has.
