### PR TITLE
Added the missing '--' to the closing boundary in a multipart/form-data ...

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestExtensions.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestExtensions.cs
@@ -111,7 +111,7 @@ namespace ServiceStack.ServiceClient.Web
 
             httpReq.ContentType = "multipart/form-data; boundary=" + boundary;
 
-            var boundarybytes = System.Text.Encoding.ASCII.GetBytes("\r\n--" + boundary + "\r\n");
+            var boundarybytes = System.Text.Encoding.ASCII.GetBytes("\r\n--" + boundary + "--\r\n");
 
             var headerTemplate = "\r\n--" + boundary +
                                  "\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{0}\"\r\nContent-Type: {1}\r\n\r\n";


### PR DESCRIPTION
I found that when I was using the PostFile method with the REST client, I was getting server-side problems because the request was badly formed.

The Fiddler program allowed me to snoop the data being transferred and I noticed that there was a missing '--' in the closing boundary line.

The same problem does not appear to exist with the PostFileWithRequest method.
