### PR TITLE
Custom HttpHandler configurations overwrite response status code.

### DIFF
--- a/tests/ServiceStack.WebHost.Endpoints.Tests/CustomHttpHandlerTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/CustomHttpHandlerTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Funq;
+using NUnit.Framework;
+using ServiceStack.ServiceHost;
+using ServiceStack.ServiceInterface;
+using ServiceStack.Text;
+using ServiceStack.WebHost.Endpoints.Support;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    public class CustomHttpHandlerAppHost : AppHostHttpListenerBase
+    {
+        public CustomHttpHandlerAppHost() : base("Custom Handlers", typeof (CustomHttpHandlerAppHost).Assembly)
+        {
+        }
+
+        public override void Configure(Container container)
+        {
+            SetConfig(new EndpointHostConfig
+            {
+                CustomHttpHandlers = new Dictionary<HttpStatusCode, IServiceStackHttpHandler>
+                {
+                    {HttpStatusCode.NotFound, new SomeStandardHandler("/404")}
+                }
+            });
+        }
+    }
+
+    // The idea here is that this handler is not specific to 404s, it is a general purpose handler
+    // that can be used in many contexts, just like the RazorHandler. Therefor this handler
+    // can never write specific HTTP status codes to the response stream.
+    public class SomeStandardHandler : IServiceStackHttpHandler
+    {
+        private readonly string responseFilePath;
+
+        public SomeStandardHandler(string responseFilePath)
+        {
+            this.responseFilePath = responseFilePath;
+        }
+
+        public void ProcessRequest(IHttpRequest httpReq, IHttpResponse httpRes, string operationName)
+        {
+            httpRes.Write(responseFilePath);
+            httpRes.EndHttpHandlerRequest();
+        }
+    }
+
+    public class CustomHttpHandlerTests
+    {
+        private const string ListeningOn = "http://localhost:82/";
+        private CustomHttpHandlerAppHost appHost;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            appHost = new CustomHttpHandlerAppHost();
+            appHost.Init();
+            appHost.Start(ListeningOn);
+        }
+
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            appHost.Dispose();
+            appHost = null;
+        }
+
+        [Test]
+        public void Custom_404_handler_returns_404_status_code()
+        {
+            var statusCode = (ListeningOn + "/non-existent-path").GetResponseStatus();
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceStack.WebHost.Endpoints.Tests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="BufferedRequestTests.cs" />
     <Compile Include="CachedServiceTests.cs" />
     <Compile Include="CompressionTests.cs" />
+    <Compile Include="CustomHttpHandlerTests.cs" />
     <Compile Include="RouteTests.cs" />
     <Compile Include="CustomValidationErrorTests.cs" />
     <Compile Include="EncodingTests.cs" />


### PR DESCRIPTION
If using custom http handlers to return custom pages for e.g. 404, 500 errors, the response status code gets overwritten to whatever the inner handler sets it to, usually a 200.

e.g:

```
SetConfig(new EndpointHostConfig {
    CustomHttpHandlers = {
        { HttpStatusCode.NotFound, new RazorHandler("/notfound") }
    }
});
```

http://razor.servicestack.net/#smart-views

You can see the live rockstars example here, while it looks like a 404 page, actually returns a 200 OK.
http://razor.servicestack.net/stars/alive/coldplay

This pull request is only a repro test so far. Not sure where to fix this one, it cant be done before passing to the inner handler as the inner handler will just overwrite it, and it can't be done after as the inner handlers can close the response stream.
