### PR TITLE
Modify configuration to allow for blank line when deserializing objects

### DIFF
--- a/src/ServiceStack/Configuration/AppSettingsBase.cs
+++ b/src/ServiceStack/Configuration/AppSettingsBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Linq;
 using ServiceStack.Text;
 
 namespace ServiceStack.Configuration
@@ -57,6 +58,12 @@ namespace ServiceStack.Configuration
         public virtual T Get<T>(string name, T defaultValue)
         {
             var stringValue = GetNullableString(name);
+            if (!string.IsNullOrEmpty(stringValue))
+            {
+                var lines = stringValue.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                if (lines.Length > 1)
+                    stringValue = string.Join("", lines.Select(x => x.Trim()));
+            }
 
             T deserializedValue;
             try

--- a/tests/ServiceStack.Common.Tests/Configuration/AppSettingsTests.cs
+++ b/tests/ServiceStack.Common.Tests/Configuration/AppSettingsTests.cs
@@ -19,6 +19,8 @@ namespace ServiceStack.Common.Tests
                     {"BadIntegerKey", "This is not an integer"},
                     {"DictionaryKey", "A:1,B:2,C:3,D:4,E:5"},
                     {"BadDictionaryKey", "A1,B:"},
+                    {"ObjectNoLineFeed", "{SomeSetting:Test,SomeOtherSetting:12,FinalSetting:Final}"},
+                    {"ObjectWithLineFeed", "{SomeSetting:Test,\r\nSomeOtherSetting:12,\r\nFinalSetting:Final}"},
                 });
         }
 
@@ -157,5 +159,35 @@ namespace ServiceStack.Common.Tests
                 Assert.That(ex.Message.Contains("BadDictionaryKey"));
             }
         }
+
+        [Test]
+        public void Get_Returns_ObjectNoLineFeed()
+        {
+            var appSettings = GetAppSettings();
+            var value = appSettings.Get("ObjectNoLineFeed", new SimpleAppSettings());
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value.FinalSetting, Is.EqualTo("Final"));
+            Assert.That(value.SomeOtherSetting, Is.EqualTo(12));
+            Assert.That(value.SomeSetting, Is.EqualTo("Test"));
+        }
+
+        [Test]
+        public void Get_Returns_ObjectWithLineFeed()
+        {
+            var appSettings = GetAppSettings();
+            var value = appSettings.Get("ObjectWithLineFeed", new SimpleAppSettings());
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value.FinalSetting, Is.EqualTo("Final"));
+            Assert.That(value.SomeOtherSetting, Is.EqualTo(12));
+            Assert.That(value.SomeSetting, Is.EqualTo("Test"));
+        }
+
+        public class SimpleAppSettings
+        {
+            public string SomeSetting { get; set; }
+            public int SomeOtherSetting { get; set; }
+            public string FinalSetting { get; set; }
+        }
+
     }
 }


### PR DESCRIPTION
Using configuration system to deserialize slightly complex objects, it makes it difficult to do it all on one line.  Especially if there is an array objects inside the class, etc.   If you have a newline in your string, the deserialize will fail.  This modification allows you to break apart the config on multiple lines for readability and still work.
