### PR TITLE
Facebook Provider - Handle an error callback

### DIFF
--- a/src/ServiceStack.ServiceInterface/Auth/FacebookAuthProvider.cs
+++ b/src/ServiceStack.ServiceInterface/Auth/FacebookAuthProvider.cs
@@ -35,6 +35,14 @@ namespace ServiceStack.ServiceInterface.Auth
         {
             var tokens = Init(authService, ref session, request);
 
+            var error = authService.RequestContext.Get<IHttpRequest>().QueryString["error"];
+            var hasError = !error.IsNullOrEmpty();
+            if (hasError)
+            {
+                Log.Error("Facebook error callback. {0}".Fmt(authService.RequestContext.Get<IHttpRequest>().QueryString));
+                return authService.Redirect(session.ReferrerUrl);
+            }
+
             var code = authService.RequestContext.Get<IHttpRequest>().QueryString["code"];
             var isPreAuthCallback = !code.IsNullOrEmpty();
             if (!isPreAuthCallback)


### PR DESCRIPTION
For example, the user decides to log in with facebook, but once at the
facebook permissions confirmation page chooses cancel.
Previously, facebook would callback and servicestack would return the user
to the facebook permissions confirmation page.
Now, the user is redirected back to the referrer url after choosing cancel.
