### PR TITLE
Stop initializing ApplicationBaseUrl automatically

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -164,13 +164,6 @@ namespace ServiceStack.WebHost.Endpoints
             //Default Request /
             if (string.IsNullOrEmpty(pathInfo) || pathInfo == "/")
             {
-                //Exception calling context.Request.Url on Apache+mod_mono
-                if (ApplicationBaseUrl == null)
-                {
-                    var absoluteUrl = Env.IsMono ? url.ToParentPath() : context.Request.GetApplicationUrl();
-                    SetApplicationBaseUrl(absoluteUrl);
-                }
-
                 //e.g. CatchAllHandler to Process Markdown files
                 var catchAllHandler = GetCatchAllHandlerIfAny(httpReq.HttpMethod, pathInfo, httpReq.GetPhysicalPath());
                 if (catchAllHandler != null) return catchAllHandler;
@@ -203,7 +196,7 @@ namespace ServiceStack.WebHost.Endpoints
 
         private static void SetApplicationBaseUrl(string absoluteUrl)
         {
-            if (absoluteUrl == null) return;
+            if (string.IsNullOrEmpty(absoluteUrl)) return;
 
             ApplicationBaseUrl = absoluteUrl;
 
@@ -237,9 +230,6 @@ namespace ServiceStack.WebHost.Endpoints
             //Default Request /
             if (string.IsNullOrEmpty(pathInfo) || pathInfo == "/")
             {
-                if (ApplicationBaseUrl == null)
-                    SetApplicationBaseUrl(httpReq.GetPathUrl());
-
                 //e.g. CatchAllHandler to Process Markdown files
                 var catchAllHandler = GetCatchAllHandlerIfAny(httpReq.HttpMethod, pathInfo, httpReq.GetPhysicalPath());
                 if (catchAllHandler != null) return catchAllHandler;


### PR DESCRIPTION
### Initializing the ApplicationBaseUrl automatically has an unintended side affect.

If you happen to hit the server locally at http://localhost and then later from http://somehostname -- the default redirect will send the user to http://localhost/somepath instead of http://somehostname/somepath
### Notes

This commit fixed my issue locally. I'm not certain why this base application url was being set by default. Since I'm not sure why it was being set I can't evaluate the side affects to what I did here. Please be **sure** that there aren't bad side affects before merging. If there are side affects, is there a better way to fix?

I do not want to set the config.WebHostUrl to anything specific, I'd rather just let the server correctly handle redirects using relative url. 

One other note -- I updated my fork w/ all of the changes from the base -- but now that commit is showing up in this pull request even tho it corretly is only showing the one file changed. I'm not sure how to exclude commit f77ff33 in GitHub pull request.
