### PR TITLE
Swagger

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -355,6 +355,10 @@ namespace ServiceStack.Api.Swagger
 
         private static string GetModelPropertyName(PropertyInfo prop)
         {
+            var dataMemberAttr = prop.FirstAttribute<DataMemberAttribute>();
+            if (dataMemberAttr != null && !dataMemberAttr.Name.IsNullOrEmpty()) 
+                return dataMemberAttr.Name;
+            
             return UseCamelCaseModelPropertyNames
                 ? (UseLowercaseUnderscoreModelPropertyNames ? prop.Name.ToLowercaseUnderscore() : prop.Name.ToCamelCase())
                 : prop.Name;

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/SwaggerFeatureTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/SwaggerFeatureTests.cs
@@ -259,13 +259,15 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [DataMember(Order = 1)]
         public string Parrot { get; set; }
         [DataMember]
+        public string Cat { get; set; }
+        [DataMember]
         public string Dog { get; set; }
         [DataMember(Order = 3)]
         public string Antelope { get; set; }
-        [DataMember]
-        public string Cat { get; set; }
         [DataMember(Order = 1)]
         public string Albatross { get; set; }
+        [DataMember(Order = 0, Name = "Baldeagle")]
+        public string Eagle { get; set; }
     }
 
     public class DataMemberAttributeOrderService : Service
@@ -657,10 +659,11 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.That(responseClassModel.Properties.ElementAt(1).Key, Is.EqualTo("Falcon"));
             Assert.That(responseClassModel.Properties.ElementAt(2).Key, Is.EqualTo("Cat"));
             Assert.That(responseClassModel.Properties.ElementAt(3).Key, Is.EqualTo("Dog"));
-            Assert.That(responseClassModel.Properties.ElementAt(4).Key, Is.EqualTo("Bird"));
-            Assert.That(responseClassModel.Properties.ElementAt(5).Key, Is.EqualTo("Albatross"));
-            Assert.That(responseClassModel.Properties.ElementAt(6).Key, Is.EqualTo("Parrot"));
-            Assert.That(responseClassModel.Properties.ElementAt(7).Key, Is.EqualTo("Antelope"));
+            Assert.That(responseClassModel.Properties.ElementAt(4).Key, Is.EqualTo("Baldeagle"));
+            Assert.That(responseClassModel.Properties.ElementAt(5).Key, Is.EqualTo("Bird"));
+            Assert.That(responseClassModel.Properties.ElementAt(6).Key, Is.EqualTo("Albatross"));
+            Assert.That(responseClassModel.Properties.ElementAt(7).Key, Is.EqualTo("Parrot"));
+            Assert.That(responseClassModel.Properties.ElementAt(8).Key, Is.EqualTo("Antelope"));
         }
     }
 }


### PR DESCRIPTION
Hi,

I realised that there was an issue with my ordering when the hierarchy was deeper than 2 levels.  I've expanded the test to ensure it's fully correct.

`GetModelPropetyName()` now also uses `[DataMember].Name` when it exists, otherwise continues on as normal.

(I initially thought the `[DataMember].Name` was set [here](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Api.Swagger/SwaggerApiService.cs#L479) but upon closer inspection, it seems the change was necessary?)
