### PR TITLE
throw meaningful message when header does not include a space

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
@@ -58,6 +58,11 @@ namespace ServiceStack.ServiceClient.Web
 
 			// get method from first word
 			int pos = authHeader.IndexOf (" ");
+
+			if (pos < 0) {
+				throw new ApplicationException(string.Format("Authentication header not supported, {0}", authHeader));
+			}
+
 			method = authHeader.Substring (0, pos).ToLower ();
 			string remainder = authHeader.Substring (pos + 1);
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AuthTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AuthTests.cs
@@ -1028,6 +1028,13 @@ namespace ServiceStack.WebHost.Endpoints.Tests
                 Is.EqualTo(1)
             );
         }
+
+
+		[TestCase(ExpectedException=typeof(ApplicationException))]
+		public void Meaningful_Exception_for_Unknown_Auth_Header()
+		{
+			AuthenticationInfo authInfo = new AuthenticationInfo("Negotiate,NTLM");
+		}
     }
 
     public class AuthTestsWithinVirtualDirectory : AuthTests


### PR DESCRIPTION
I am not sure if this is the best way to achieve this but I wanted a more meaningful error when the IIS Application is using Windows authentication (thus returning the auth header 'Negotiate,NTLM') and the client has sent a user name and password, rather than a Credentials object.
