### PR TITLE
Fix superfluous requests in response to http 401.

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/AsyncServiceClient.cs
@@ -474,7 +474,7 @@ namespace ServiceStack.ServiceClient.Web
             catch (Exception ex)
             {
                 var firstCall = Interlocked.Increment(ref requestState.RequestCount) == 1;
-                if (firstCall && WebRequestUtils.ShouldAuthenticate(ex, this.UserName, this.Password))
+                if (firstCall && WebRequestUtils.ShouldAuthenticate(ex, this.UserName, this.Password, requestState.WebRequest))
                 {
                     try
                     {

--- a/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/WebRequestUtils.cs
@@ -129,14 +129,15 @@ namespace ServiceStack.ServiceClient.Web
             return null;
         }
 
-        internal static bool ShouldAuthenticate(Exception ex, string userName, string password)
+        internal static bool ShouldAuthenticate(Exception ex, string userName, string password, WebRequest request)
         {
             var webEx = ex as WebException;
             return (webEx != null
                     && webEx.Response != null
                     && ((HttpWebResponse) webEx.Response).StatusCode == HttpStatusCode.Unauthorized
                     && !String.IsNullOrEmpty(userName)
-                    && !String.IsNullOrEmpty(password));
+                    && !String.IsNullOrEmpty(password)
+                    && (request == null || request.Headers.Get("Authorization") == null));
         }
 
         internal static void AddBasicAuth(this WebRequest client, string userName, string password)


### PR DESCRIPTION
Currently when sending requests using ServiceClientBase derived client using Get&lt;TResponse>(...) and GetAsync&lt;TResponse>(...) that already contain auth header (forced with AlwaysSendBasicAuthHeader) is slightly buggy.
When remote server responds with 401, ServiceStack decides to resend the request without realizing that authorization was already sent with the last request.
Here is simple repro:
https://gist.github.com/vosen/7456584
Run it alongside Fiddler or any other network inspector to see additional request.
