### PR TITLE
Fix Support for nested Classes / Name resolution

### DIFF
--- a/src/ServiceStack.Client/UrlExtensions.cs
+++ b/src/ServiceStack.Client/UrlExtensions.cs
@@ -57,6 +57,11 @@ namespace ServiceStack
             return requestDto.ToUrl(HttpMethods.Delete);
         }
 
+		public static string GetComplexTypeName(this Type t)
+		{
+			return t.FullName.Replace(t.Namespace + ".", "").Replace("+", ".");
+		}
+
         public static string ToUrl(this object requestDto, string httpMethod = "GET", string formatFallbackToPredefinedRoute = null)
         {
             httpMethod = httpMethod.ToUpper();
@@ -70,7 +75,7 @@ namespace ServiceStack
                         + "(Note: The automatic route selection only works with [Route] attributes on the request DTO and "
                         + "not with routes registered in the IAppHost!)");
 
-                var predefinedRoute = "/{0}/reply/{1}".Fmt(formatFallbackToPredefinedRoute, requestType.Name);
+                var predefinedRoute = "/{0}/reply/{1}".Fmt(formatFallbackToPredefinedRoute, requestType.GetComplexTypeName());
                 if (httpMethod == "GET" || httpMethod == "DELETE" || httpMethod == "OPTIONS" || httpMethod == "HEAD")
                 {
                     var queryProperties = RestRoute.GetQueryProperties(requestDto.GetType());
@@ -86,7 +91,7 @@ namespace ServiceStack
             {
                 var errors = string.Join(String.Empty, routesApplied.Select(x => "\r\n\t{0}:\t{1}".Fmt(x.Route.Path, x.FailReason)).ToArray());
                 var errMsg = "None of the given rest routes matches '{0}' request:{1}"
-                    .Fmt(requestType.Name, errors);
+                    .Fmt(requestType.GetComplexTypeName(), errors);
 
                 throw new InvalidOperationException(errMsg);
             }

--- a/src/ServiceStack/AppHostExtensions.cs
+++ b/src/ServiceStack/AppHostExtensions.cs
@@ -44,7 +44,7 @@ namespace ServiceStack
 					}
 					catch (Exception ex)
 					{
-						log.Error("Error adding new Plugin " + pluginType.Name, ex);
+						log.Error("Error adding new Plugin " + pluginType.GetComplexTypeName(), ex);
 					}
 				}
 			}

--- a/src/ServiceStack/AppHostHttpListenerBase.cs
+++ b/src/ServiceStack/AppHostHttpListenerBase.cs
@@ -46,7 +46,7 @@ namespace ServiceStack
                 var restHandler = serviceStackHandler as RestHandler;
                 if (restHandler != null)
                 {
-                    httpReq.OperationName = operationName = restHandler.RestPath.RequestType.Name;
+                    httpReq.OperationName = operationName = restHandler.RestPath.RequestType.GetComplexTypeName();
                 }
 
                 var task = serviceStackHandler.ProcessRequestAsync(httpReq, httpRes, operationName);                

--- a/src/ServiceStack/Auth/UserAuth.cs
+++ b/src/ServiceStack/Auth/UserAuth.cs
@@ -302,7 +302,7 @@ namespace ServiceStack.Auth
                 return default(T);
 
             string str;
-            instance.Meta.TryGetValue(typeof(T).Name, out str);
+            instance.Meta.TryGetValue(typeof(T).GetComplexTypeName(), out str);
             return str == null ? default(T) : TypeSerializer.DeserializeFromString<T>(str);
         }
 
@@ -313,7 +313,7 @@ namespace ServiceStack.Auth
                 throw new ArgumentNullException("instance");
 
             string str;
-            if (!instance.Meta.TryGetValue(typeof(T).Name, out str))
+            if (!instance.Meta.TryGetValue(typeof(T).GetComplexTypeName(), out str))
                 return false;
 
             value = TypeSerializer.DeserializeFromString<T>(str);
@@ -328,7 +328,7 @@ namespace ServiceStack.Auth
             if (instance.Meta == null)
                 instance.Meta = new Dictionary<string, string>();
 
-            instance.Meta[typeof(T).Name] = TypeSerializer.SerializeToString(value);
+            instance.Meta[typeof(T).GetComplexTypeName()] = TypeSerializer.SerializeToString(value);
             return value;
         }
     }

--- a/src/ServiceStack/Configuration/ConfigUtils.cs
+++ b/src/ServiceStack/Configuration/ConfigUtils.cs
@@ -176,7 +176,7 @@ namespace ServiceStack.Configuration
 				var ci = GetConstructorInfo(typeof(T));
 				if (ci == null)
 				{
-					throw new TypeLoadException(string.Format(ErrorCreatingType, typeof(T).Name, textValue));
+					throw new TypeLoadException(string.Format(ErrorCreatingType, typeof(T).GetComplexTypeName(), textValue));
 				}
 				var newT = ci.Invoke(null, new object[] { textValue });
 				return (T)newT;

--- a/src/ServiceStack/DtoUtils.cs
+++ b/src/ServiceStack/DtoUtils.cs
@@ -185,7 +185,7 @@ namespace ServiceStack
                 //Serializing request successfully is not critical and only provides added error info
             }
 
-            return string.Format("[{0}: {1}]:\n[REQUEST: {2}]", (request?? new object()).GetType().Name, DateTime.UtcNow, requestString);
+            return string.Format("[{0}: {1}]:\n[REQUEST: {2}]", (request?? new object()).GetType().GetComplexTypeName(), DateTime.UtcNow, requestString);
         }
     }
 }

--- a/src/ServiceStack/Extensions/Type.cs
+++ b/src/ServiceStack/Extensions/Type.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack
+{
+	public static class Extensions
+	{
+		public static string GetComplexTypeName(this Type t)
+		{
+			return t.FullName.Replace(t.Namespace + ".", "").Replace("+", ".");
+		}
+	}
+}

--- a/src/ServiceStack/FluentValidation/AbstractValidator.cs
+++ b/src/ServiceStack/FluentValidation/AbstractValidator.cs
@@ -47,7 +47,7 @@ namespace ServiceStack.FluentValidation
         ValidationResult IValidator.Validate(object instance) {
             instance.Guard("Cannot pass null to Validate.");
             if(! ((IValidator)this).CanValidateInstancesOfType(instance.GetType())) {
-                throw new InvalidOperationException(string.Format("Cannot validate instances of type '{0}'. This validator can only validate instances of type '{1}'.", instance.GetType().Name, typeof(T).Name));
+                throw new InvalidOperationException(string.Format("Cannot validate instances of type '{0}'. This validator can only validate instances of type '{1}'.", instance.GetType().GetComplexTypeName(), typeof(T).GetComplexTypeName()));
             }
             
             return Validate((T)instance);

--- a/src/ServiceStack/FluentValidation/Internal/Extensions.cs
+++ b/src/ServiceStack/FluentValidation/Internal/Extensions.cs
@@ -120,7 +120,7 @@ namespace ServiceStack.FluentValidation.Internal
                 return new ChildValidatorAdaptor(childValidator);
             }
 
-            throw new InvalidOperationException(string.Format("The validator '{0}' cannot validate members of type '{1}' - the types are not compatible.", childValidator.GetType().Name, rule.TypeToValidate.Name));
+            throw new InvalidOperationException(string.Format("The validator '{0}' cannot validate members of type '{1}' - the types are not compatible.", childValidator.GetType().GetComplexTypeName(), rule.TypeToValidate.GetComplexTypeName()));
         }
 
         private static bool DoesImplementCompatibleIEnumerable(Type propertyType, IValidator childValidator) {

--- a/src/ServiceStack/FluentValidation/ValidationException.cs
+++ b/src/ServiceStack/FluentValidation/ValidationException.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.FluentValidation
             var errors = Errors.Map(x =>
                 new ValidationErrorField(x.ErrorCode, x.PropertyName, x.ErrorMessage));
 
-            var responseStatus = ResponseStatusUtils.CreateResponseStatus(typeof(ValidationException).Name, Message, errors);
+            var responseStatus = ResponseStatusUtils.CreateResponseStatus(typeof(ValidationException).GetComplexTypeName(), Message, errors);
             return responseStatus;
         }
     }

--- a/src/ServiceStack/Formats/HtmlFormat.cs
+++ b/src/ServiceStack/Formats/HtmlFormat.cs
@@ -76,7 +76,7 @@ namespace ServiceStack.Formats
                 url += url.Contains("?") ? "&" : "?";
 
                 var now = DateTime.UtcNow;
-                var requestName = request.OperationName ?? dto.GetType().Name;
+                var requestName = request.OperationName ?? dto.GetType().GetComplexTypeName();
 
                 html = HtmlTemplates.GetHtmlFormatTemplate()
                     .Replace("${Dto}", json)

--- a/src/ServiceStack/Formats/MarkdownFormat.cs
+++ b/src/ServiceStack/Formats/MarkdownFormat.cs
@@ -346,7 +346,7 @@ namespace ServiceStack.Formats
             {
                 dto = httpResult.Response;
             }
-            if (dto != null) return dto.GetType().Name;
+            if (dto != null) return dto.GetType().GetComplexTypeName();
             return httpRequest != null ? httpRequest.OperationName : null;
         }
 
@@ -365,7 +365,7 @@ namespace ServiceStack.Formats
 
             if (dto != null)
             {
-                var responseTypeName = dto.GetType().Name;
+                var responseTypeName = dto.GetType().GetComplexTypeName();
                 var markdownPage = GetViewPage(responseTypeName);
                 if (markdownPage != null) return markdownPage;
             }
@@ -436,7 +436,7 @@ namespace ServiceStack.Formats
             {
                 if (ShouldSkipPath(markDownFile)) continue;
 
-                if (markDownFile.GetType().Name != "ResourceVirtualFile")
+                if (markDownFile.GetType().GetComplexTypeName() != "ResourceVirtualFile")
                     hasReloadableWebPages = true;
 
                 var pageName = markDownFile.Name.WithoutExtension();

--- a/src/ServiceStack/Funq/Container.cs
+++ b/src/ServiceStack/Funq/Container.cs
@@ -442,7 +442,7 @@ namespace Funq
                 return ex;
 
             var errMsg = "Error trying to resolve Service '{0}' from Adapter '{1}': {2}"
-                .Fmt(typeof(TService).FullName, Adapter.GetType().Name, ex.Message);
+                .Fmt(typeof(TService).FullName, Adapter.GetType().GetComplexTypeName(), ex.Message);
 
             return new Exception(errMsg, ex);
         }

--- a/src/ServiceStack/Host/BasicRequest.cs
+++ b/src/ServiceStack/Host/BasicRequest.cs
@@ -55,7 +55,7 @@ namespace ServiceStack.Host
         private string operationName;
         public string OperationName
         {
-            get { return operationName ?? (operationName = Message.Body != null ? Message.Body.GetType().Name : null); }
+            get { return operationName ?? (operationName = Message.Body != null ? Message.Body.GetType().GetComplexTypeName() : null); }
             set { operationName = value; }
         }
 

--- a/src/ServiceStack/Host/Handlers/NotFoundHttpHandler.cs
+++ b/src/ServiceStack/Host/Handlers/NotFoundHttpHandler.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.Host.Handlers
 			var request = context.Request;
 			var response = context.Response;
 
-            var httpReq = context.ToRequest(GetType().Name);
+            var httpReq = context.ToRequest(GetType().GetComplexTypeName());
 			if (!request.IsLocal)
 			{
                 ProcessRequestAsync(httpReq, httpReq.Response, null);

--- a/src/ServiceStack/Host/Handlers/RequestInfoHandler.cs
+++ b/src/ServiceStack/Host/Handlers/RequestInfoHandler.cs
@@ -142,7 +142,7 @@ namespace ServiceStack.Host.Handlers
 
 		public override void ProcessRequest(HttpContextBase context)
 		{
-		    var request = context.ToRequest(GetType().Name);
+		    var request = context.ToRequest(GetType().GetComplexTypeName());
 			ProcessRequestAsync(request, request.Response, request.OperationName);
 		}
 

--- a/src/ServiceStack/Host/Handlers/SoapHandler.cs
+++ b/src/ServiceStack/Host/Handlers/SoapHandler.cs
@@ -58,7 +58,7 @@ namespace ServiceStack.Host.Handlers
 
             return requestMsg.Headers.Action == null
                 ? Message.CreateMessage(requestMsg.Version, null, response)
-                : Message.CreateMessage(requestMsg.Version, requestType.Name + "Response", response);
+                : Message.CreateMessage(requestMsg.Version, requestType.GetComplexTypeName() + "Response", response);
         }
 
         protected Message ExecuteMessage(Message message, RequestAttributes requestAttributes, IRequest httpRequest, IResponse httpResponse)
@@ -86,7 +86,7 @@ namespace ServiceStack.Host.Handlers
             var requestMsg = message ?? GetRequestMessageFromStream(httpReq.InputStream);
             string requestXml = GetRequestXml(requestMsg);
             var requestType = GetRequestType(requestMsg, requestXml);
-            if (!HostContext.Metadata.CanAccess(requestAttributes, soapFeature.ToFormat(), requestType.Name))
+            if (!HostContext.Metadata.CanAccess(requestAttributes, soapFeature.ToFormat(), requestType.GetComplexTypeName()))
                 throw HostContext.UnauthorizedAccess(requestAttributes);
 
             try
@@ -103,7 +103,7 @@ namespace ServiceStack.Host.Handlers
                     requiresSoapMessage.Message = requestMsg;
                 }
 
-                httpReq.OperationName = requestType.Name;
+                httpReq.OperationName = requestType.GetComplexTypeName();
                 httpReq.SetItem("SoapMessage", requestMsg);
 
                 var hasRequestFilters = HostContext.GlobalRequestFilters.Count > 0
@@ -137,11 +137,11 @@ namespace ServiceStack.Host.Handlers
                 if (useXmlSerializerResponse)
                     return requestMsg.Headers.Action == null
                         ? Message.CreateMessage(requestMsg.Version, null, response, new XmlSerializerWrapper(response.GetType()))
-                        : Message.CreateMessage(requestMsg.Version, requestType.Name + "Response", response, new XmlSerializerWrapper(response.GetType()));
+                        : Message.CreateMessage(requestMsg.Version, requestType.GetComplexTypeName() + "Response", response, new XmlSerializerWrapper(response.GetType()));
                 
                 return requestMsg.Headers.Action == null
                     ? Message.CreateMessage(requestMsg.Version, null, response)
-                    : Message.CreateMessage(requestMsg.Version, requestType.Name + "Response", response);
+                    : Message.CreateMessage(requestMsg.Version, requestType.GetComplexTypeName() + "Response", response);
             }
             catch (Exception ex)
             {

--- a/src/ServiceStack/Host/Handlers/StaticFileHandler.cs
+++ b/src/ServiceStack/Host/Handlers/StaticFileHandler.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.Host.Handlers
 
 		public override void ProcessRequest(HttpContextBase context)
 		{
-		    var httpReq = context.ToRequest(GetType().Name);
+		    var httpReq = context.ToRequest(GetType().GetComplexTypeName());
 			ProcessRequest(httpReq, httpReq.Response, httpReq.OperationName);
 		}
 

--- a/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
+++ b/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
@@ -216,13 +216,13 @@ namespace ServiceStack.Host.HttpListener
         {
             try
             {
-                Log.ErrorFormat("Error this.ProcessRequest(context): [{0}]: {1}", ex.GetType().Name, ex.Message);
+                Log.ErrorFormat("Error this.ProcessRequest(context): [{0}]: {1}", ex.GetType().GetComplexTypeName(), ex.Message);
 
                 var errorResponse = new ErrorResponse
                 {
                     ResponseStatus = new ResponseStatus
                     {
-                        ErrorCode = ex.GetType().Name,
+                        ErrorCode = ex.GetType().GetComplexTypeName(),
                         Message = ex.Message,
                         StackTrace = ex.StackTrace,
                     }
@@ -260,7 +260,7 @@ namespace ServiceStack.Host.HttpListener
             catch (Exception errorEx)
             {
                 var error = "Error this.ProcessRequest(context)(Exception while writing error to the response): [{0}]: {1}"
-                            .Fmt(errorEx.GetType().Name, errorEx.Message);
+                            .Fmt(errorEx.GetType().GetComplexTypeName(), errorEx.Message);
                 Log.ErrorFormat(error);
             }
         }

--- a/src/ServiceStack/Host/RestHandler.cs
+++ b/src/ServiceStack/Host/RestHandler.cs
@@ -79,7 +79,7 @@ namespace ServiceStack.Host
                         .AsTaskException();
                 }
 
-                operationName = restPath.RequestType.Name;
+                operationName = restPath.RequestType.GetComplexTypeName();
 
                 var callback = httpReq.GetJsonpCallback();
                 var doJsonp = HostContext.Config.AllowJsonpRequests

--- a/src/ServiceStack/Host/RestPath.cs
+++ b/src/ServiceStack/Host/RestPath.cs
@@ -218,7 +218,7 @@ namespace ServiceStack.Host
             catch (Exception)
             {
                 throw new AmbiguousMatchException("Property names are case-insensitive: "
-                    + this.RequestType.Name + "." + propertyName);
+                    + this.RequestType.GetComplexTypeName() + "." + propertyName);
             }
         }
 
@@ -401,7 +401,7 @@ namespace ServiceStack.Host
                     }
  
                     throw new ArgumentException("Could not find property "
-                        + variableName + " on " + RequestType.Name);
+                        + variableName + " on " + RequestType.GetComplexTypeName());
                 }
 
                 var value = requestComponents.Length > pathIx ? requestComponents[pathIx] : null; //wildcard has arg mismatch

--- a/src/ServiceStack/Host/RouteNamingConvention.cs
+++ b/src/ServiceStack/Host/RouteNamingConvention.cs
@@ -22,19 +22,19 @@ namespace ServiceStack.Host
 
         public static void WithRequestDtoName(IServiceRoutes routes, Type requestType, string allowedVerbs)
         {
-            routes.Add(requestType, restPath: "/{0}".Fmt(requestType.Name), verbs: allowedVerbs, priority:AutoGenPriority);
+            routes.Add(requestType, restPath: "/{0}".Fmt(requestType.GetComplexTypeName()), verbs: allowedVerbs, priority:AutoGenPriority);
         }
 
         public static void WithMatchingAttributes(IServiceRoutes routes, Type requestType, string allowedVerbs)
         {
             var membersWithAttribute = (from p in requestType.GetPublicProperties()
                                         let attributes = p.AllAttributes<Attribute>()
-                                        where attributes.Any(a => AttributeNamesToMatch.Contains(a.GetType().Name))
+                                        where attributes.Any(a => AttributeNamesToMatch.Contains(a.GetType().GetComplexTypeName()))
                                         select "{{{0}}}".Fmt(p.Name)).ToList();
 
             if (membersWithAttribute.Count == 0) return;
 
-            membersWithAttribute.Insert(0, "/{0}".Fmt(requestType.Name));
+            membersWithAttribute.Insert(0, "/{0}".Fmt(requestType.GetComplexTypeName()));
 
             var restPath = membersWithAttribute.Join("/");
             routes.Add(requestType, restPath: restPath, verbs: allowedVerbs, priority: AutoGenPriority);
@@ -49,7 +49,7 @@ namespace ServiceStack.Host
 
             if (membersWithName.Count == 0) return;
 
-            membersWithName.Insert(0, "/{0}".Fmt(requestType.Name));
+            membersWithName.Insert(0, "/{0}".Fmt(requestType.GetComplexTypeName()));
 
             var restPath = membersWithName.Join("/");
             routes.Add(requestType, restPath: restPath, verbs: allowedVerbs, priority: AutoGenPriority);

--- a/src/ServiceStack/Host/ServiceController.cs
+++ b/src/ServiceStack/Host/ServiceController.cs
@@ -93,7 +93,7 @@ namespace ServiceStack.Host
                     assemblyName = assembly.FullName;
                     foreach (var type in assembly.GetTypes())
                     {
-                        typeName = type.Name;
+                        typeName = type.GetComplexTypeName();
                         results.Add(type);
                     }
                 }
@@ -171,7 +171,7 @@ namespace ServiceStack.Host
                     }
 
                     Log.DebugFormat("Registering {0} service '{1}' with request '{2}'",
-                        (responseType != null ? "Reply" : "OneWay"), serviceType.Name, requestType.Name);
+                        (responseType != null ? "Reply" : "OneWay"), serviceType.GetComplexTypeName(), requestType.GetComplexTypeName());
                 }
             }
         }
@@ -203,7 +203,7 @@ namespace ServiceStack.Host
 
                 if (!restPath.IsValid)
                     throw new NotSupportedException(string.Format(
-                        "RestPath '{0}' on Type '{1}' is not Valid", attr.Path, requestType.Name));
+                        "RestPath '{0}' on Type '{1}' is not Valid", attr.Path, requestType.GetComplexTypeName()));
 
                 RegisterRestPath(restPath);
             }
@@ -214,10 +214,10 @@ namespace ServiceStack.Host
         public void RegisterRestPath(RestPath restPath)
         {
             if (!restPath.Path.StartsWith("/"))
-                throw new ArgumentException("Route '{0}' on '{1}' must start with a '/'".Fmt(restPath.Path, restPath.RequestType.Name));
+                throw new ArgumentException("Route '{0}' on '{1}' must start with a '/'".Fmt(restPath.Path, restPath.RequestType.GetComplexTypeName()));
             if (restPath.Path.IndexOfAny(InvalidRouteChars) != -1)
                 throw new ArgumentException(("Route '{0}' on '{1}' contains invalid chars. " +
-                                            "See https://github.com/ServiceStack/ServiceStack/wiki/Routing for info on valid routes.").Fmt(restPath.Path, restPath.RequestType.Name));
+                                            "See https://github.com/ServiceStack/ServiceStack/wiki/Routing for info on valid routes.").Fmt(restPath.Path, restPath.RequestType.GetComplexTypeName()));
 
             List<RestPath> pathsAtFirstMatch;
             if (!RestPathMap.TryGetValue(restPath.FirstMatchHashKey, out pathsAtFirstMatch))
@@ -474,7 +474,7 @@ namespace ServiceStack.Host
             ServiceExecFn handlerFn;
             if (!requestExecMap.TryGetValue(requestType, out handlerFn))
             {
-                throw new NotImplementedException(string.Format("Unable to resolve service '{0}'", requestType.Name));
+                throw new NotImplementedException(string.Format("Unable to resolve service '{0}'", requestType.GetComplexTypeName()));
             }
 
             return handlerFn;
@@ -514,7 +514,7 @@ namespace ServiceStack.Host
 
             throw new UnauthorizedAccessException(
                 string.Format("Could not execute service '{0}', The following restrictions were not met: '{1}'" + internalDebugMsg,
-                    requestType.Name, failedScenarios));
+                    requestType.GetComplexTypeName(), failedScenarios));
         }
     }
 

--- a/src/ServiceStack/Host/ServiceExec.cs
+++ b/src/ServiceStack/Host/ServiceExec.cs
@@ -19,7 +19,7 @@ namespace ServiceStack.Host
         public object Execute(IRequest requestContext, object instance, object request)
         {
             return ServiceExec<TService>.Execute(requestContext, instance, request,
-                typeof(TRequest).Name);
+                typeof(TRequest).GetComplexTypeName());
         }
     }
 
@@ -60,7 +60,7 @@ namespace ServiceStack.Host
                 var requestType = args[0].ParameterType;
                 var actionCtx = new ActionContext
                 {
-                    Id = ActionContext.Key(actionName, requestType.Name),
+                    Id = ActionContext.Key(actionName, requestType.GetComplexTypeName()),
                     ServiceType = typeof(TService),
                     RequestType = requestType,
                 };
@@ -171,7 +171,7 @@ namespace ServiceStack.Host
             var expectedMethodName = actionName.Substring(0, 1) + actionName.Substring(1).ToLower();
             throw new NotImplementedException(
                 "Could not find method named {1}({0}) or Any({0}) on Service {2}"
-                .Fmt(requestDto.GetType().Name, expectedMethodName, typeof(TService).Name));
+                .Fmt(requestDto.GetType().GetComplexTypeName(), expectedMethodName, typeof(TService).GetComplexTypeName()));
         }
     }
 }

--- a/src/ServiceStack/Host/ServiceRoutes.cs
+++ b/src/ServiceStack/Host/ServiceRoutes.cs
@@ -66,7 +66,7 @@ namespace ServiceStack.Host
 
             if (existingRoute != null)
             {
-                var existingRouteMsg = "Existing Route for '{0}' at '{1}' already exists".Fmt(requestType.Name, restPath);
+                var existingRouteMsg = "Existing Route for '{0}' at '{1}' already exists".Fmt(requestType.GetComplexTypeName(), restPath);
 
                 //if (!EndpointHostConfig.SkipRouteValidation) //wait till next deployment
                 //    throw new Exception(existingRouteMsg);

--- a/src/ServiceStack/Html/DynamicTypeGenerator.cs
+++ b/src/ServiceStack/Html/DynamicTypeGenerator.cs
@@ -109,7 +109,7 @@ namespace ServiceStack.Html
 			var parameterTypes = (from p in parameters select p.ParameterType).ToArray();
 
 			// based on http://msdn.microsoft.com/en-us/library/system.reflection.emit.typebuilder.definemethodoverride.aspx
-			var newMethod = newType.DefineMethod(interfaceMethod.DeclaringType.Name + "." + interfaceMethod.Name,
+			var newMethod = newType.DefineMethod(interfaceMethod.DeclaringType.GetComplexTypeName() + "." + interfaceMethod.Name,
 				MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual | MethodAttributes.Final,
 				interfaceMethod.ReturnType, parameterTypes);
 

--- a/src/ServiceStack/Html/ModelMetadata.cs
+++ b/src/ServiceStack/Html/ModelMetadata.cs
@@ -438,7 +438,7 @@ namespace ServiceStack.Html
 
 		public string GetDisplayName()
 		{
-			return DisplayName ?? PropertyName ?? ModelType.Name;
+			return DisplayName ?? PropertyName ?? ModelType.GetComplexTypeName();
 		}
 
 		private static ModelMetadata GetMetadataFromProvider(Func<object> modelAccessor, Type modelType, string propertyName, Type containerType)

--- a/src/ServiceStack/HttpHandlerFactory.cs
+++ b/src/ServiceStack/HttpHandlerFactory.cs
@@ -88,7 +88,7 @@ namespace ServiceStack
             var defaultRedirectHanlder = DefaultHttpHandler as RedirectHttpHandler;
             var debugDefaultHandler = defaultRedirectHanlder != null
                 ? defaultRedirectHanlder.RelativeUrl
-                : typeof(DefaultHttpHandler).Name;
+                : typeof(DefaultHttpHandler).GetComplexTypeName();
 
             SetApplicationBaseUrl(config.WebHostUrl);
 
@@ -311,7 +311,7 @@ namespace ServiceStack
             string contentType;
             var restPath = RestHandler.FindMatchingRestPath(httpMethod, pathInfo, out contentType);
             if (restPath != null) 
-                return new RestHandler { RestPath = restPath, RequestName = restPath.RequestType.Name, ResponseContentType = contentType };
+                return new RestHandler { RestPath = restPath, RequestName = restPath.RequestType.GetComplexTypeName(), ResponseContentType = contentType };
 
             var existingFile = pathParts[0].ToLower();
             if (WebHostRootFileNames.Contains(existingFile))
@@ -360,7 +360,7 @@ namespace ServiceStack
                 restPath = appHost.Config.FallbackRestPath(httpMethod, pathInfo, filePath);
                 if (restPath != null)
                 {
-                    return new RestHandler { RestPath = restPath, RequestName = restPath.RequestType.Name, ResponseContentType = contentType };
+                    return new RestHandler { RestPath = restPath, RequestName = restPath.RequestType.GetComplexTypeName(), ResponseContentType = contentType };
                 }
             }
 

--- a/src/ServiceStack/HttpResponseExtensionsInternal.cs
+++ b/src/ServiceStack/HttpResponseExtensionsInternal.cs
@@ -222,7 +222,7 @@ namespace ServiceStack
                     {
                         throw new ArgumentNullException("defaultAction", String.Format(
                         "As result '{0}' is not a supported responseType, a defaultAction must be supplied",
-                        (result != null ? result.GetType().Name : "")));
+                        (result != null ? result.GetType().GetComplexTypeName() : "")));
                     }
 
                     if (bodyPrefix != null) response.OutputStream.Write(bodyPrefix, 0, bodyPrefix.Length);
@@ -238,12 +238,12 @@ namespace ServiceStack
                     if (!HostContext.Config.WriteErrorsToResponse) return originalEx.AsTaskException<bool>();
 
                     var errorMessage = String.Format(
-                    "Error occured while Processing Request: [{0}] {1}", originalEx.GetType().Name, originalEx.Message);
+                    "Error occured while Processing Request: [{0}] {1}", originalEx.GetType().GetComplexTypeName(), originalEx.Message);
 
                     Log.Error(errorMessage, originalEx);
 
                     var operationName = result != null
-                        ? result.GetType().Name.Replace("Response", "")
+                        ? result.GetType().GetComplexTypeName().Replace("Response", "")
                         : "OperationName";
 
                     try

--- a/src/ServiceStack/Messaging/MessageHandler.cs
+++ b/src/ServiceStack/Messaging/MessageHandler.cs
@@ -100,7 +100,7 @@ namespace ServiceStack.Messaging
 
         public IMessageHandlerStats GetStats()
         {
-            return new MessageHandlerStats(typeof(T).Name,
+            return new MessageHandlerStats(typeof(T).GetComplexTypeName(),
                 TotalMessagesProcessed, TotalMessagesFailed, TotalRetries, 
                 TotalNormalMessagesReceived, TotalPriorityMessagesReceived, LastMessageProcessed);
         }
@@ -159,7 +159,7 @@ namespace ServiceStack.Messaging
                         var publishAllResponses = PublishResponsesWhitelist == null;
                         if (!publishAllResponses)
                         {
-                            var inWhitelist = PublishResponsesWhitelist.Any(publishResponse => responseType.Name == publishResponse);
+                            var inWhitelist = PublishResponsesWhitelist.Any(publishResponse => responseType.GetComplexTypeName() == publishResponse);
                             if (!inWhitelist) return;
                         }
 
@@ -179,7 +179,7 @@ namespace ServiceStack.Messaging
                         catch (Exception ex)
                         {
                             Log.Error("Could not send response to '{0}' with client '{1}'"
-                                .Fmt(mqReplyTo, replyClient.GetType().Name), ex);
+                                .Fmt(mqReplyTo, replyClient.GetType().GetComplexTypeName()), ex);
 
                             // Leave as-is to work around a Mono 2.6.7 compiler bug
                             if (!responseType.IsUserType()) return;

--- a/src/ServiceStack/Messaging/TransientMessageServiceBase.cs
+++ b/src/ServiceStack/Messaging/TransientMessageServiceBase.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.Messaging
         {
             if (handlerMap.ContainsKey(typeof(T)))
             {
-                throw new ArgumentException("Message handler has already been registered for type: " + typeof(T).Name);
+                throw new ArgumentException("Message handler has already been registered for type: " + typeof(T).GetComplexTypeName());
             }
 
             handlerMap[typeof(T)] = CreateMessageHandlerFactory(processMessageFn, processExceptionEx);

--- a/src/ServiceStack/Metadata/BaseMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/BaseMetadataHandler.cs
@@ -64,9 +64,9 @@ namespace ServiceStack.Metadata
             if (operationName != null)
             {
                 var allTypes = metadata.GetAllTypes();
-                var operationType = allTypes.Single(x => x.Name == operationName);
-                var op = metadata.GetOperation(operationType);
-
+				//var operationType = allTypes.Single(x => x.Name == operationName);
+				var operationType = allTypes.Single(x => x.GetComplexTypeName() == operationName);
+				var op = metadata.GetOperation(operationType);
                 var requestMessage = CreateResponse(operationType);
                 string responseMessage = null;
 

--- a/src/ServiceStack/Metadata/BaseSoapMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/BaseSoapMetadataHandler.cs
@@ -11,7 +11,7 @@ namespace ServiceStack.Metadata
     {
 		protected BaseSoapMetadataHandler()
 		{
-			OperationName = GetType().Name.Replace("Handler", "");
+			OperationName = GetType().GetComplexTypeName().Replace("Handler", "");
 		}
 		
 		public string OperationName { get; set; }

--- a/src/ServiceStack/Metadata/CustomMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/CustomMetadataHandler.cs
@@ -39,11 +39,11 @@ namespace ServiceStack.Metadata
 			catch (Exception ex)
 			{
 				var error = string.Format("Error serializing type '{0}' with custom format '{1}'",
-					dtoType.Name, this.ContentFormat);
+					dtoType.GetComplexTypeName(), this.ContentFormat);
 				Log.Error(error, ex);
 
 				return string.Format("{{Unable to show example output for type '{0}' using the custom '{1}' filter}}" + ex.Message,
-					dtoType.Name, this.ContentFormat);
+					dtoType.GetComplexTypeName(), this.ContentFormat);
 			}
 		}
 	}

--- a/src/ServiceStack/Metadata/MetadataTypesHandler.cs
+++ b/src/ServiceStack/Metadata/MetadataTypesHandler.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.Metadata
 
         public override void Execute(HttpContextBase context)
         {
-            var request = context.ToRequest(GetType().Name);
+            var request = context.ToRequest(GetType().GetComplexTypeName());
             ProcessRequestAsync(request, request.Response, request.OperationName);
         }
 
@@ -110,10 +110,10 @@ namespace ServiceStack.Metadata
 
             var metaType = new MetadataType
             {
-                Name = type.Name,
+                Name = type.GetComplexTypeName(),
                 Namespace = type.Namespace,
                 GenericArgs = type.IsGenericType
-                    ? type.GetGenericArguments().Select(x => x.Name).ToArray()
+                    ? type.GetGenericArguments().Select(x => x.GetComplexTypeName()).ToArray()
                     : null,
                 Attributes = type.ToAttributes(),
                 Properties = type.ToProperties(),
@@ -121,9 +121,9 @@ namespace ServiceStack.Metadata
 
             if (type.BaseType != null && type.BaseType != typeof(object))
             {
-                metaType.Inherits = type.BaseType.Name;
+                metaType.Inherits = type.BaseType.GetComplexTypeName();
                 metaType.InheritsGenericArgs = type.BaseType.IsGenericType
-                    ? type.BaseType.GetGenericArguments().Select(x => x.Name).ToArray()
+                    ? type.BaseType.GetGenericArguments().Select(x => x.GetComplexTypeName()).ToArray()
                     : null;
             }
 
@@ -136,7 +136,7 @@ namespace ServiceStack.Metadata
                 var genericMarker = type.GetTypeWithGenericTypeDefinitionOf(typeof(IReturn<>));
                 if (genericMarker != null)
                 {
-                    metaType.ReturnMarkerGenericArgs = genericMarker.GetGenericArguments().Select(x => x.Name).ToArray();
+                    metaType.ReturnMarkerGenericArgs = genericMarker.GetGenericArguments().Select(x => x.GetComplexTypeName()).ToArray();
                 }
             }
 
@@ -239,10 +239,10 @@ namespace ServiceStack.Metadata
             {
                 Name = pi.Name,
                 Attributes = pi.GetCustomAttributes(false).ToAttributes(),
-                Type = pi.PropertyType.Name,
+                Type = pi.PropertyType.GetComplexTypeName(),
                 DataMember = pi.GetDataMember().ToDataMember(),
                 GenericArgs = pi.PropertyType.IsGenericType
-                    ? pi.PropertyType.GetGenericArguments().Select(x => x.Name).ToArray()
+                    ? pi.PropertyType.GetGenericArguments().Select(x => x.GetComplexTypeName()).ToArray()
                     : null,
             };
             if (instance != null)
@@ -263,7 +263,7 @@ namespace ServiceStack.Metadata
             {
                 Name = pi.Name,
                 Attributes = propertyAttrs.ToAttributes(),
-                Type = pi.ParameterType.Name,
+                Type = pi.ParameterType.GetComplexTypeName(),
                 Description = pi.GetDescription(),
             };
 

--- a/src/ServiceStack/Metadata/WsdlMetadataHandlerBase.cs
+++ b/src/ServiceStack/Metadata/WsdlMetadataHandlerBase.cs
@@ -71,7 +71,7 @@ namespace ServiceStack.Metadata
                 OptimizeForFlash = optimizeForFlash,
             }.ToString();
 
-            var soapFormat = GetType().Name.StartsWith("Soap11", StringComparison.OrdinalIgnoreCase)
+            var soapFormat = GetType().GetComplexTypeName().StartsWith("Soap11", StringComparison.OrdinalIgnoreCase)
                 ? Format.Soap11 : Format.Soap12;
 
             var wsdlTemplate = GetWsdlTemplate();

--- a/src/ServiceStack/Metadata/XsdGenerator.cs
+++ b/src/ServiceStack/Metadata/XsdGenerator.cs
@@ -30,9 +30,9 @@ namespace ServiceStack.Metadata
                     if (assemblyType.GetCustomAttributes(typeof(DataContractAttribute), false).Length > 0)
                     {
                         var baseTypeWithSameName = XsdMetadata.GetBaseTypeWithTheSameName(assemblyType);
-                        if (uniqueTypeNames.Contains(baseTypeWithSameName.Name))
+                        if (uniqueTypeNames.Contains(baseTypeWithSameName.GetComplexTypeName()))
                         {
-                            log.WarnFormat("Skipping duplicate type with existing name '{0}'", baseTypeWithSameName.Name);
+                            log.WarnFormat("Skipping duplicate type with existing name '{0}'", baseTypeWithSameName.GetComplexTypeName());
                         }
                         uniqueTypes.Add(baseTypeWithSameName);
                     }

--- a/src/ServiceStack/MiniProfiler/Data/ProfiledDbCommand.cs
+++ b/src/ServiceStack/MiniProfiler/Data/ProfiledDbCommand.cs
@@ -54,7 +54,7 @@ namespace ServiceStack.MiniProfiler.Data
                 && (setter = prop.GetSetMethod()) != null
                 )
             {
-                var method = new DynamicMethod(commandType.Name + "_BindByName", null, new Type[] { typeof(IDbCommand), typeof(bool) });
+                var method = new DynamicMethod(commandType.GetComplexTypeName() + "_BindByName", null, new Type[] { typeof(IDbCommand), typeof(bool) });
                 var il = method.GetILGenerator();
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Castclass, commandType);
@@ -253,7 +253,7 @@ namespace ServiceStack.MiniProfiler.Data
         public ProfiledDbCommand Clone()
         { // EF expects ICloneable
             ICloneable tail = _cmd as ICloneable;
-            if (tail == null) throw new NotSupportedException("Underlying " + _cmd.GetType().Name + " is not cloneable");
+            if (tail == null) throw new NotSupportedException("Underlying " + _cmd.GetType().GetComplexTypeName() + " is not cloneable");
             return new ProfiledDbCommand((DbCommand)tail.Clone(), _conn, _profiler);
         }
         object ICloneable.Clone() { return Clone(); }

--- a/src/ServiceStack/MiniProfiler/Data/ProfiledDbConnection.cs
+++ b/src/ServiceStack/MiniProfiler/Data/ProfiledDbConnection.cs
@@ -71,7 +71,7 @@ namespace ServiceStack.MiniProfiler.Data
     		var dbConn = connection as DbConnection;
 
 			if (dbConn == null)
-				throw new ArgumentException(connection.GetType().Name + " does not inherit DbConnection");
+				throw new ArgumentException(connection.GetType().GetComplexTypeName() + " does not inherit DbConnection");
 			
 			Init(dbConn, profiler, autoDisposeConnection);
         }
@@ -192,7 +192,7 @@ namespace ServiceStack.MiniProfiler.Data
         public ProfiledDbConnection Clone()
         {
             ICloneable tail = _conn as ICloneable;
-            if (tail == null) throw new NotSupportedException("Underlying " + _conn.GetType().Name + " is not cloneable");
+            if (tail == null) throw new NotSupportedException("Underlying " + _conn.GetType().GetComplexTypeName() + " is not cloneable");
             return new ProfiledDbConnection((DbConnection)tail.Clone(), _profiler, autoDisposeConnection);
         }
         object ICloneable.Clone() { return Clone(); }

--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -482,7 +482,7 @@ namespace ServiceStack
                 }
                 catch (Exception ex)
                 {
-                    Log.Warn("Error loading plugin " + plugin.GetType().Name, ex);
+                    Log.Warn("Error loading plugin " + plugin.GetType().GetComplexTypeName(), ex);
                 }
             }
         }

--- a/src/ServiceStack/ServiceStackHttpHandler.cs
+++ b/src/ServiceStack/ServiceStackHttpHandler.cs
@@ -15,7 +15,7 @@ namespace ServiceStack
 
         public override void ProcessRequest(HttpContextBase context)
         {
-            var httpReq = context.ToRequest(GetType().Name);
+            var httpReq = context.ToRequest(GetType().GetComplexTypeName());
             ProcessRequest(httpReq, httpReq.Response, httpReq.OperationName);
         }
 

--- a/src/ServiceStack/Support/Markdown/TextBlock.cs
+++ b/src/ServiceStack/Support/Markdown/TextBlock.cs
@@ -957,7 +957,7 @@ namespace ServiceStack.Support.Markdown
                 {
                     mi = HtmlHelper.GetMethod(methodName);
                     if (mi == null)
-                        throw new ArgumentException("Unable to resolve method '" + methodExpr + "' on type " + type.Name);
+                        throw new ArgumentException("Unable to resolve method '" + methodExpr + "' on type " + type.GetComplexTypeName());
                 }
 
                 base.ReturnType = mi.ReturnType;

--- a/src/ServiceStack/Support/WebHost/HttpHandlerBase.cs
+++ b/src/ServiceStack/Support/WebHost/HttpHandlerBase.cs
@@ -19,7 +19,7 @@ namespace ServiceStack.Support.WebHost
 			var before = DateTime.UtcNow;
 			Execute(context);
             var elapsed = DateTime.UtcNow - before;
-			log.DebugFormat("'{0}' was completed in {1}ms", this.GetType().Name, elapsed.TotalMilliseconds);
+			log.DebugFormat("'{0}' was completed in {1}ms", this.GetType().GetComplexTypeName(), elapsed.TotalMilliseconds);
 		}
 
 		public abstract void Execute(HttpContextBase context);

--- a/src/ServiceStack/Testing/BasicAppHost.cs
+++ b/src/ServiceStack/Testing/BasicAppHost.cs
@@ -8,7 +8,7 @@ namespace ServiceStack.Testing
     public class BasicAppHost : ServiceStackHost
     {
         public BasicAppHost(params Assembly[] serviceAssemblies)
-            : base(typeof(BasicAppHost).Name,
+            : base(typeof(BasicAppHost).GetComplexTypeName(),
                    serviceAssemblies.Length > 0 ? serviceAssemblies : new[] { Assembly.GetExecutingAssembly() }) {}
 
         public override void Configure(Container container)

--- a/src/ServiceStack/Validation/ExecOnlyOnce.cs
+++ b/src/ServiceStack/Validation/ExecOnlyOnce.cs
@@ -16,10 +16,10 @@ namespace ServiceStack.Validation
         private readonly IRedisClient redis;
 
         public ExecOnceOnly(IRedisClientsManager redisManager, Type forType, string correlationId)
-            : this(redisManager, "hash:nx:" + forType.Name, correlationId) { }
+            : this(redisManager, "hash:nx:" + forType.GetComplexTypeName(), correlationId) { }
 
         public ExecOnceOnly(IRedisClientsManager redisManager, Type forType, Guid? correlationId)
-            : this(redisManager, "hash:nx:" + forType.Name, (correlationId.HasValue ? correlationId.Value.ToString("N") : null)) { }
+            : this(redisManager, "hash:nx:" + forType.GetComplexTypeName(), (correlationId.HasValue ? correlationId.Value.ToString("N") : null)) { }
 
         public ExecOnceOnly(IRedisClientsManager redisManager, string hashKey, string correlationId)
         {

--- a/src/ServiceStack/Validation/ValidationFeature.cs
+++ b/src/ServiceStack/Validation/ValidationFeature.cs
@@ -42,7 +42,7 @@ namespace ServiceStack.Validation
                 //Serializing request successfully is not critical and only provides added error info
             }
 
-            return string.Format("[{0}: {1}]:\n[REQUEST: {2}]", GetType().Name, DateTime.UtcNow, requestString);
+            return string.Format("[{0}: {1}]:\n[REQUEST: {2}]", GetType().GetComplexTypeName(), DateTime.UtcNow, requestString);
         }
     }
 


### PR DESCRIPTION
At the current time it is not possible to use nested Classes for DTOs if the names of the subclasses across are the same.
Simple Example:

`public class Test1Dto{
  public class Request{
  }
}
public class Test2Dto{
  public class Request{
  }
}`
