### PR TITLE
Add RememberMe support to AuthService Authenticate API method

### DIFF
--- a/src/ServiceStack/Auth/AuthenticateService.cs
+++ b/src/ServiceStack/Auth/AuthenticateService.cs
@@ -173,6 +173,15 @@ namespace ServiceStack.Auth
             //Remove HTML Content-Type to avoid auth providers issuing browser re-directs
             this.Request.ResponseContentType = MimeTypes.PlainText;
 
+            if (request.RememberMe.HasValue)
+            {
+                var opt = request.RememberMe.GetValueOrDefault(false)
+                    ? SessionOptions.Permanent
+                    : SessionOptions.Temporary;
+
+                base.Request.AddSessionOptions(opt);
+            }
+
             var provider = request.provider ?? AuthProviders[0].Provider;
             var oAuthConfig = GetAuthProvider(provider);
             if (oAuthConfig == null)


### PR DESCRIPTION
This patch adds "Remember Me" (ss-opt) support for callers of the AuthService.Authenticate method.

The Post method of the auth. service supports persisting the users RememberMe preference for sessions (ss-opt cookie).  

The public API method "Authenticate" looks like it should also support this behaviour to enable persistent user sessions, but it currently doesn't. When calling the service from code (say MVC), you're required to put this fragment of code in each of the calling clients, rather than the service. 

This was confirmed by another user on stackoverflow: http://stackoverflow.com/questions/17996022/authservice-authenticate-does-not-create-a-persistent-session-when-rememberme
