### PR TITLE
Fix for partial content 'Range' header bigger than actual content size

### DIFF
--- a/src/ServiceStack.Common/Web/HttpResult.cs
+++ b/src/ServiceStack.Common/Web/HttpResult.cs
@@ -265,6 +265,9 @@ namespace ServiceStack.Common.Web
             long rangeStart, rangeEnd;
             rangeHeader.ExtractHttpRanges(contentLength, out rangeStart, out rangeEnd);
 
+            if (rangeEnd > contentLength - 1)
+                rangeEnd = contentLength - 1;
+
             response.AddHttpRangeResponseHeaders(rangeStart, rangeEnd, contentLength);
 
             var outputStream = response.OutputStream;

--- a/src/ServiceStack/WebHost.Endpoints/Support/StaticFileHandler.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/StaticFileHandler.cs
@@ -159,6 +159,10 @@ namespace ServiceStack.WebHost.Endpoints.Support
                     if (EndpointHost.Config.AllowPartialResponses && rangeHeader != null)
                     {
                         rangeHeader.ExtractHttpRanges(contentLength, out rangeStart, out rangeEnd);
+
+                        if (rangeEnd > contentLength - 1)
+                            rangeEnd = contentLength - 1;
+
                         r.AddHttpRangeResponseHeaders(rangeStart: rangeStart, rangeEnd: rangeEnd, contentLength: contentLength);
                     }
                     else

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/PartialContentResultTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/PartialContentResultTests.cs
@@ -233,6 +233,37 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         }
 
         [Test]
+        public void Can_seek_from_beginning_to_further_than_end()
+        {
+            // Not sure if this would ever occur in real streaming scenarios, but it does occur
+            // when some crawlers use range headers to specify a max size to return.
+            // e.g. Facebook crawler always sends range header of 'bytes=0-524287'.
+
+            var mockRequest = new HttpRequestMock();
+            var mockResponse = new HttpResponseMock();
+
+            mockRequest.Headers[HttpHeaders.Range] = "bytes=0-524287";
+
+            string customText = "1234567890";
+            byte[] customTextBytes = customText.ToUtf8Bytes();
+            var ms = new MemoryStream();
+            ms.Write(customTextBytes, 0, customTextBytes.Length);
+
+            var httpResult = new HttpResult(ms, "audio/mpeg");
+
+            bool reponseWasAutoHandled = mockResponse.WriteToResponse(mockRequest, httpResult);
+            Assert.That(reponseWasAutoHandled, Is.True);
+
+            string writtenString = mockResponse.GetOutputStreamAsString();
+            Assert.That(writtenString, Is.EqualTo(customText));
+
+            Assert.That(mockResponse.Headers["Content-Range"], Is.EqualTo("bytes 0-9/10"));
+            Assert.That(mockResponse.Headers["Content-Length"], Is.EqualTo(writtenString.Length.ToString()));
+            Assert.That(mockResponse.Headers["Accept-Ranges"], Is.EqualTo("bytes"));
+            Assert.That(mockResponse.StatusCode, Is.EqualTo(206));
+        }
+
+        [Test]
         public void Can_seek_from_beginning_to_middle()
         {
             var mockRequest = new HttpRequestMock();


### PR DESCRIPTION
e.g. Facebook crawler always sends range header of 'bytes=0-524287'.
