### PR TITLE
Added missing override in HttpListenerBase

### DIFF
--- a/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
+++ b/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
@@ -36,8 +36,10 @@ namespace ServiceStack.Host.HttpListener
         protected HttpListenerBase(string serviceName, params Assembly[] assembliesWithServices)
             : base(serviceName, assembliesWithServices) {}
 
-        public virtual void OnAfterInit()
+        public override void OnAfterInit()
         {
+            base.OnAfterInit();
+
             SetAppDomainData();
         }
 


### PR DESCRIPTION
OnAfterInit() in HttpListenerBase didn't override the one in ServiceStackHost, causing it not to be called at all. Fixes ServiceStack/Issues#9
