### PR TITLE
Respect the X-Http-Method-Override header when choosing a handler.

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -197,7 +197,7 @@ namespace ServiceStack.WebHost.Endpoints
             }
 
             return GetHandlerForPathInfo(
-                context.Request.HttpMethod, pathInfo, context.Request.FilePath, pathTranslated)
+                httpReq.HttpMethod, pathInfo, context.Request.FilePath, pathTranslated)
                    ?? NotFoundHttpHandler;
         }
 


### PR DESCRIPTION
httpReq.HttpMethod checks the header, but context.Request.HttpMethod does not.
