### PR TITLE
RestPath.IsMatch should match a lowercase http method.

### DIFF
--- a/src/ServiceStack/ServiceHost/RestPath.cs
+++ b/src/ServiceStack/ServiceHost/RestPath.cs
@@ -280,7 +280,7 @@ namespace ServiceStack.ServiceHost
             wildcardMatchCount = 0;
 
             if (withPathInfoParts.Length != this.PathComponentsCount && !this.IsWildCardPath) return false;
-            if (!this.allowsAllVerbs && !this.allowedVerbs.Contains(httpMethod)) return false;
+            if (!this.allowsAllVerbs && !this.allowedVerbs.Contains(httpMethod.ToUpper())) return false;
 
             if (!ExplodeComponents(ref withPathInfoParts)) return false;
             if (this.TotalComponentsCount != withPathInfoParts.Length && !this.IsWildCardPath) return false;

--- a/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
@@ -472,5 +472,13 @@ namespace ServiceStack.ServiceHost.Tests
 
             Assert.That(isMatch, "Expected:\n{0}\n  Actual:\n{1}".Fmt(expected.Join("\n"), matchingDefinitions.Join("\n")));
         }
+
+        [Test]
+        public void Can_match_lowercase_http_method()
+        {
+            var restPath = new RestPath(typeof (ComplexType), "/Complex/{Id}/{Name}/Unique/{UniqueId}", "PUT");
+            var withPathInfoParts = RestPath.GetPathPartsForMatching("/complex/5/Is Alive/unique/4583B364-BBDC-427F-A289-C2923DEBD547");
+            Assert.That(restPath.IsMatch("put", withPathInfoParts));
+        }
     }
 }


### PR DESCRIPTION
allowedVerbs is taken ToUpper so the httpMethod should also be ToUpper to
check for a match.
