### PR TITLE
Fix Android compilation errors

### DIFF
--- a/src/ServiceStack.Client/PclExportClient.cs
+++ b/src/ServiceStack.Client/PclExportClient.cs
@@ -1619,7 +1619,7 @@ namespace ServiceStack
 
         public virtual INameValueCollection ParseQueryString(string query)
         {
-            return HttpUtility.ParseQueryString(query).InWrapper();
+            return ServiceStack.Pcl.HttpUtility.ParseQueryString(query).InWrapper();
         }
 
         public virtual string UrlEncode(string url)
@@ -1629,7 +1629,7 @@ namespace ServiceStack
 #elif PCL
             return WebUtility.UrlEncode(url);
 #else
-            return HttpUtility.UrlEncode(url);
+            return System.Web.HttpUtility.UrlEncode(url);
 #endif
         }
 
@@ -1640,7 +1640,7 @@ namespace ServiceStack
 #elif PCL
             return WebUtility.UrlDecode(url);
 #else
-            return HttpUtility.UrlDecode(url);
+            return System.Web.HttpUtility.UrlDecode(url);
 #endif
         }
 
@@ -1651,7 +1651,7 @@ namespace ServiceStack
 #elif PCL
             return WebUtility.HtmlEncode(html);
 #else
-            return HttpUtility.HtmlEncode(html);
+            return System.Web.HttpUtility.HtmlEncode(html);
 #endif
         }
 
@@ -1662,7 +1662,7 @@ namespace ServiceStack
 #elif PCL
             return WebUtility.HtmlDecode(html);
 #else
-            return HttpUtility.HtmlDecode(html);
+            return System.Web.HttpUtility.HtmlDecode(html);
 #endif
         }
  

--- a/src/ServiceStack.Client/ServiceStack.Client.Android.csproj
+++ b/src/ServiceStack.Client/ServiceStack.Client.Android.csproj
@@ -31,7 +31,6 @@
     <DefineConstants>TRACE;ANDROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>
@@ -46,6 +45,7 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncState.cs" />

--- a/src/ServiceStack.Client/ServiceStack.Client.AndroidIndie.csproj
+++ b/src/ServiceStack.Client/ServiceStack.Client.AndroidIndie.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncState.cs" />

--- a/src/ServiceStack.Client/Soap11ServiceClient.cs
+++ b/src/ServiceStack.Client/Soap11ServiceClient.cs
@@ -344,10 +344,20 @@ namespace ServiceStack
             throw new NotImplementedException();
         }
 
+		public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, string mimeType)
+		{
+			throw new NotImplementedException();
+		}
+
         public TResponse PostFile<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, string mimeType)
         {
             throw new NotImplementedException();
         }
+
+		public TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, object request)
+		{
+			throw new NotImplementedException();
+		}
 
         public TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName,
                                                         object request)

--- a/src/ServiceStack.Client/StreamExtensions.cs
+++ b/src/ServiceStack.Client/StreamExtensions.cs
@@ -14,7 +14,7 @@ namespace ServiceStack
 {
     public static class StreamExtensions
     {
-#if !(SL5 || XBOX || __IOS__)
+		#if !(SL5 || XBOX || ANDROID || __IOS__)
         /// <summary>
         /// Compresses the specified text using the default compression method: Deflate
         /// </summary>

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.Android.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.Android.csproj
@@ -31,7 +31,6 @@
     <DefineConstants>TRACE;ANDROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request fixes a number of compilation errors that occur when trying to build `/src/ServiceStack.Android.sln` in Xamarin Studio using Xamarin.Android Business Edition and `/src/ServiceStack.AndroidIndie.sln` using Xamarin.Android Indie edition.
