### PR TITLE
Fix exception handling of async actions of services

### DIFF
--- a/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
+++ b/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
@@ -59,18 +59,19 @@ namespace ServiceStack.Host.Handlers
                     return taskResponse
                         .ContinueWith(task =>
                         {
+                            if (task.IsFaulted)
+                                return errorCallback(task.Exception);
+
+                            if (task.IsCanceled)
+                                return errorCallback(new OperationCanceledException("The async Task operation was cancelled"));
+
                             if (task.IsCompleted)
                             {
                                 var taskResult = task.GetResult();
                                 return callback(taskResult);
                             }
 
-                            if (task.IsFaulted)
-                                return errorCallback(task.Exception);
-
-                            return task.IsCanceled
-                                ? errorCallback(new OperationCanceledException("The async Task operation was cancelled"))
-                                : errorCallback(new InvalidOperationException("Unknown Task state"));
+                            return errorCallback(new InvalidOperationException("Unknown Task state"));
                         });
                 }
 


### PR DESCRIPTION
The continuation Task in `ServiceStackHandlerBase.HandleResponse()`
examines the Task state in wrong order. Checks `task.IsCompleted` first,
which is ["true when the task is in one of the three final states:
RanToCompletion, Faulted, or Canceled."](http://msdn.microsoft.com/en-us/library/system.threading.tasks.task.iscompleted)

Therefore the `errorCallback()` never gets called, defeating the [Error Handling](https://github.com/ServiceStack/ServiceStack/wiki/Error-Handling)
mechanism whenever a service returns asynchronous Tasks that raise Exceptions.

The fix I suggest is not tested, although seems to be trivial.
