### PR TITLE
Update IdUtils to allow the PK attribute to take precendence over the Id...

### DIFF
--- a/src/ServiceStack.Common/IdUtils.cs
+++ b/src/ServiceStack.Common/IdUtils.cs
@@ -26,19 +26,19 @@ namespace ServiceStack
 
             if (typeof(T).IsClass() || typeof(T).IsInterface)
             {
-                var piId = typeof(T).GetPropertyInfo(IdUtils.IdField);
-                if (piId != null
-                    && piId.GetMethodInfo() != null)
-                {
-                    CanGetId = HasPropertyId<T>.GetId;
-                    return;
-                }
-
                 foreach (var pi in typeof(T).GetPublicProperties()
                     .Where(pi => pi.AllAttributes<Attribute>()
                              .Any(attr => attr.GetType().Name == "PrimaryKeyAttribute")))
                 {
                     CanGetId = StaticAccessors<T>.ValueUnTypedGetPropertyTypeFn(pi);
+                    return;
+                }
+
+                var piId = typeof(T).GetPropertyInfo(IdUtils.IdField);
+                if (piId != null
+                    && piId.GetMethodInfo() != null)
+                {
+                    CanGetId = HasPropertyId<T>.GetId;
                     return;
                 }
             }

--- a/tests/ServiceStack.Common.Tests/IdUtilsTests.cs
+++ b/tests/ServiceStack.Common.Tests/IdUtilsTests.cs
@@ -77,6 +77,26 @@ namespace ServiceStack.Common.Tests
             }
         }
 
+        public class HasNonConventionalId
+        {
+            public int Id
+            {
+                get
+                {
+                    return int.MaxValue;
+                }
+            }
+
+            [PrimaryKey]
+            public int Idx
+            {
+                get
+                {
+                    return IntValue;
+                }
+            }
+        }
+
         [Test]
         public void Can_get_if_HasIntId()
         {
@@ -129,5 +149,10 @@ namespace ServiceStack.Common.Tests
             Assert.That(new HasPrimaryKeyAttribute().GetId(), Is.EqualTo(IntValue));
         }
 
+        [Test]
+        public void Can_get_if_id_is_non_conventional()
+        {
+            Assert.That(new HasNonConventionalId().GetId(), Is.EqualTo(IntValue));
+        }
     }
 }


### PR DESCRIPTION
... name convention.

Hi, 

We discovered a few issues whereby if you have a field named **Id** that isn't the primary key, and another field that is marked with the primary key attribute, some of the OrmLite functions such as Save() and SaveAll() fail.  (A recent pull request to allow this schema structure in terms of table creation was submitted and accepted earlier this week).

I've added a test for the scenario and it was just a case of doing the attribute check before the conventional check.

Hope this is ok,

Richard
