### PR TITLE
Fix build errors when running Xamarin Studio (Indie + Business).

### DIFF
--- a/src/ServiceStack.Client/PclExportClient.cs
+++ b/src/ServiceStack.Client/PclExportClient.cs
@@ -1622,7 +1622,7 @@ namespace ServiceStack
 #if SL5 || PCL
             return ServiceStack.Pcl.HttpUtility.ParseQueryString(query).InWrapper();
 #else
-            return HttpUtility.ParseQueryString(query).InWrapper();
+			return System.Web.HttpUtility.ParseQueryString(query).InWrapper();
 #endif
         }
 

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.Android.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.Android.csproj
@@ -198,9 +198,6 @@
     <Compile Include="Messaging\IMessageService.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Messaging\MessageError.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Messaging\MessageFactory.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.AndroidIndie.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.AndroidIndie.csproj
@@ -195,9 +195,6 @@
     <Compile Include="Messaging\IMessageService.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Messaging\MessageError.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Messaging\MessageFactory.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Trying to compile `ServiceStack.Android.sln` or `ServiceStack.AndroidIndie.sln` in Xamarin Studio results in compilation errors. This pull request fixes them for both Indie and Business editions of Xamarin Studio 4.2.2.
