### PR TITLE
StaticFileHandler: DefaultFilePath bug and large files improvement

### DIFF
--- a/src/ServiceStack/HttpHandlerFactory.cs
+++ b/src/ServiceStack/HttpHandlerFactory.cs
@@ -59,7 +59,7 @@ namespace ServiceStack
                     if (!fileNameLower.EndsWith(".aspx"))
                     {
                         DefaultRootFileName = fileNameLower;
-                        ((StaticFileHandler)StaticFileHandler).SetDefaultFile(file.Name, file.ReadAllBytes(), file.LastModified);
+                        ((StaticFileHandler)StaticFileHandler).SetDefaultFile(file.VirtualPath, file.ReadAllBytes(), file.LastModified);
 
                         if (DefaultHttpHandler == null)
                             DefaultHttpHandler = new RedirectHttpHandler { RelativeUrl = DefaultRootFileName };


### PR DESCRIPTION
Fix problem with DefaultFilePath: if you have a file in subfolder with the same name as the DefaultFilePath ServiceStack serves the DefaultFilePath always if the LastModified <= DefaultFileModified. Ex: "/index.html" and "/app/index.html"

WriteTo(this Stream inStream, Stream outStream) writes to outStream with
a 4Kb buffer. Downloading large files(+1Mb) is very slowly because is
sending chunks of 4kb to the client. Writing with a bigger buffer
increases the performance.
