### PR TITLE
Use Redis cache by default when ICacheClient is undefined

### DIFF
--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -326,8 +326,8 @@ namespace ServiceStack
             {
                 if (registeredCacheClient == null)
                 {
-					var redisClientsManager = Container.Resolve<IRedisClientsManager>();
-					Container.Register<ICacheClient>(redisClientsManager != null ? redisClientsManager.GetCacheClient() : new MemoryCacheClient());
+		    var redisClientsManager = Container.TryResolve<IRedisClientsManager>();
+		    Container.Register<ICacheClient>(redisClientsManager != null ? redisClientsManager.GetCacheClient() : new MemoryCacheClient());
                 }
             }
 


### PR DESCRIPTION
I would think that it's more typical to move from an in-memory cache to a Redis cache. As such wouldn't it be better to use Redis as the default when no cache is explicitly specified? 

If `ICacheClient` is undefined and `IRedisClientsManager` is defined, default to a Redis cache rather than an in-memory cache. 

If somebody needs the two types of cache in a single application, would it not be better that they define the `MemoryCacheClient` explicitly as this use-case should be less prevalent?
