### PR TITLE
Added explicit help-inline/help-block 'data-for' attributes

### DIFF
--- a/src/ServiceStack/js/ss-utils.js
+++ b/src/ServiceStack/js/ss-utils.js
@@ -80,6 +80,11 @@
                     fieldLabelMap[key] = $next;
                 }
             });
+            this.find(".help-inline[data-for],.help-block[data-for]").each(function() {
+                var $el = $(this);
+                var key = $el.data("for").toLowerCase();
+                fieldLabelMap[key] = $el;
+            });
             $.each(errors, function (i, error) {
                 var key = (error.fieldName || "").toLowerCase();
                 var $field = fieldMap[key];


### PR DESCRIPTION
Something I use in my projects for when its not possible to put the help-inline/help-block elements directly next to the input elements. e.g:

```
<fieldset id="days">
    <legend>Days</legend>
    <div class="labelled-checkbox">
        <label for="mondayCheckbox">Monday</label>
        <input id="mondayCheckbox" name="days[]" value="Monday" type="checkbox"/>
    </div>
    <div class="labelled-checkbox">
        <label for="tuesdayCheckbox">Tuesday</label>
        <input id="tuesdayCheckbox" name="days[]" value="Tuesday" type="checkbox"/>
    </div>
    ...
</fieldset>
<div class="help-block" data-for="days"></div>
```

(`data-for` follows the `<label for=...` pattern.)

No probs if its too specific, just thought I'd throw it out there. 
