### PR TITLE
fix dependency pointing to legacy project

### DIFF
--- a/NuGet/ServiceStack.Caching.Azure/servicestack.caching.azure.nuspec
+++ b/NuGet/ServiceStack.Caching.Azure/servicestack.caching.azure.nuspec
@@ -17,7 +17,7 @@
     <copyright>ServiceStack 2013 and contributors</copyright>
     <dependencies>
       <dependency id="ServiceStack.Common" version="4.0" />
-      <dependency id="WindowsAzure.Caching" version="2.2.0.0" />
+      <dependency id="Microsoft.WindowsAzure.Caching" version="2.2.0.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
The correct package is Microsoft.WindowsAzure.Caching and not WindowsAzure.Caching. All project references seem to point to that and version 2.2.0.0 which does not exist for the legacy package.
