### PR TITLE
Change to FileSystem scanning to handle any generic exceptions - also for Files.

### DIFF
--- a/src/ServiceStack/VirtualPath/FileSystemVirtualDirectory.cs
+++ b/src/ServiceStack/VirtualPath/FileSystemVirtualDirectory.cs
@@ -67,7 +67,7 @@ namespace ServiceStack.VirtualPath
             {
                 return BackingDirInfo.GetFiles();
             }
-            catch (DirectoryNotFoundException ex)
+            catch (Exception ex)
             {
                 //Possible exception from scanning symbolic links
                 Log.Warn("Unable to GetFiles for {0}".Fmt(RealPath), ex);


### PR DESCRIPTION
The previous commit didn't fix the problem (again), since UnauthorizedException is still being thrown in the GetFiles method for to the symlinks.  This update ensures that the Exception is also caught when calling GetFiles().
