### PR TITLE
Added fieldName property to PostFileWithRequest

### DIFF
--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -1146,16 +1146,16 @@ namespace ServiceStack
         }
 
 #if !PCL
-        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, object request)
+        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, object request, string fieldName = "upload")
         {
             using (FileStream fileStream = fileToUpload.OpenRead())
             {
-                return PostFileWithRequest<TResponse>(relativeOrAbsoluteUrl, fileStream, fileToUpload.Name, request);
+                return PostFileWithRequest<TResponse>(relativeOrAbsoluteUrl, fileStream, fileToUpload.Name, request, fieldName);
             }
         }
 #endif
 
-        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, object request)
+        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, object request, string fieldName = "upload)
         {
             var requestUri = GetUrl(relativeOrAbsoluteUrl);
             var currentStreamPosition = fileToUpload.Position;
@@ -1182,7 +1182,7 @@ namespace ServiceStack
                     }
 
                     outputStream.Write(boundary + newLine);
-                    outputStream.Write("Content-Disposition: form-data;name=\"{0}\";filename=\"{1}\"{2}{3}".FormatWith("upload", fileName, newLine, newLine));
+                    outputStream.Write("Content-Disposition: form-data;name=\"{0}\";filename=\"{1}\"{2}{3}".FormatWith(fieldName, fileName, newLine, newLine));
                     var buffer = new byte[4096];
                     int byteCount;
                     while ((byteCount = fileToUpload.Read(buffer, 0, 4096)) > 0)


### PR DESCRIPTION
I have added optional `fieldName` property to `PostFileWithRequest<TResponse>` method. As noted in [this SO question](http://stackoverflow.com/q/18326403/1295344) the field name to which the upload is made, is currently hardcoded to the value _"upload"_, and this limits the usability of the method.

This optional parameter allows the field name to be specified, and if not specified it defaults to the original value "upload", so this addition will not break any existing functionality.
