### PR TITLE
Update ServiceClientBase.cs

### DIFF
--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -1172,16 +1172,16 @@ namespace ServiceStack
         }
 
 #if !PCL
-        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, object request, string fieldName = "upload")
+        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, FileInfo fileToUpload, object request, ProgressDelegate uploadProgress, string fieldName = "upload")
         {
             using (FileStream fileStream = fileToUpload.OpenRead())
             {
-                return PostFileWithRequest<TResponse>(relativeOrAbsoluteUrl, fileStream, fileToUpload.Name, request, fieldName);
+                return PostFileWithRequest<TResponse>(relativeOrAbsoluteUrl, fileStream, fileToUpload.Name, request, fieldName, uploadProgress);
             }
         }
 #endif
 
-        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, object request, string fieldName = "upload")
+        public virtual TResponse PostFileWithRequest<TResponse>(string relativeOrAbsoluteUrl, Stream fileToUpload, string fileName, object request, ProgressDelegate uploadProgress, string fieldName = "upload")
         {
             var requestUri = GetUrl(relativeOrAbsoluteUrl);
             var currentStreamPosition = fileToUpload.Position;
@@ -1214,6 +1214,7 @@ namespace ServiceStack
                     while ((byteCount = fileToUpload.Read(buffer, 0, 4096)) > 0)
                     {
                         outputStream.Write(buffer, 0, byteCount);
+                        uploadProgress(fileToUpload.Position, fileToUpload.Length);
                     }
                     outputStream.Write(newLine);
                     outputStream.Write(boundary + "--");


### PR DESCRIPTION
Changed signature of `PostFileWithRequest` so that it reports progress through the `ProgressDelegate`, which can be either provided as a parameter (like in this commit) or as a property like it's already the case with `OnDownloadProgress`.
Sorry if this doesn't compile I've edited it online in GitHub's editor ;)
This is only to illustrate our feature request from [here](http://servicestack.uservoice.com/forums/176786-feature-requests/suggestions/5374611-add-an-overload-of-postfilewithrequest-which-accep)
Unless I'm missing something obvious this is really a simple change that shouldn't take long, but I've been incorrect before :) so please let me know if there are other concerns our if you need additional info, thanks!
