### PR TITLE
Added caching support for compiled razor page assemblies.

### DIFF
--- a/src/ServiceStack.Razor/Compilation/CachedRazorPageHost.cs
+++ b/src/ServiceStack.Razor/Compilation/CachedRazorPageHost.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using ServiceStack.CacheAccess;
+using ServiceStack.IO;
+using ServiceStack.Logging;
+
+namespace ServiceStack.Razor.Compilation
+{
+    public class CachedRazorPageHost : RazorPageHost
+    {
+        public static ILog Log = LogManager.GetLogger(typeof(CachedRazorPageHost));
+
+        private readonly ICacheClient cache;
+
+        public CachedRazorPageHost(IVirtualPathProvider pathProvider,
+            IVirtualFile file,
+            IRazorCodeTransformer codeTransformer,
+            CodeDomProvider codeDomProvider,
+            IDictionary<string, string> directives,
+            ICacheClient cache)
+            : base(pathProvider, file, codeTransformer, codeDomProvider, directives)
+        {
+            this.cache = cache;
+        }
+
+        public override Type Compile()
+        {
+            var key = "razorcache:" + File.VirtualPath;
+            var currentHash = File.GetFileHash();
+
+            var cacheEntry = cache.Get<Entry>(key);
+            if (cacheEntry != null)
+            {
+                if (cacheEntry.Hash == currentHash)
+                {
+                    var assembly = Assembly.Load(cacheEntry.CompiledAssembly);
+                    Log.DebugFormat("Loaded Razor page '{0}' assembly from cache.", File.Name);
+                    return assembly.GetTypes().First();
+                }
+            }
+
+            byte[] assemblyBytes = null;
+            var compiledType = CompileAssembly(true, ref assemblyBytes);
+            cache.Set(key, new Entry {Hash = currentHash, CompiledAssembly = assemblyBytes});
+            return compiledType;
+        }
+
+        private class Entry
+        {
+            public string Hash { get; set; }
+            public byte[] CompiledAssembly { get; set; }
+        }
+    }
+}

--- a/src/ServiceStack.Razor/Managers/CachedRazorViewManager.cs
+++ b/src/ServiceStack.Razor/Managers/CachedRazorViewManager.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CSharp;
+using ServiceStack.CacheAccess;
+using ServiceStack.IO;
+using ServiceStack.Razor.Compilation;
+using ServiceStack.Razor.Managers.RazorGen;
+
+namespace ServiceStack.Razor.Managers
+{
+    public class CachedRazorViewManager : RazorViewManager
+    {
+        private readonly ICacheClient cache;
+
+        public CachedRazorViewManager(IRazorConfig viewConfig, IVirtualPathProvider virtualPathProvider, ICacheClient cache) 
+            : base(viewConfig, virtualPathProvider)
+        {
+            this.cache = cache;
+        }
+
+        public override RazorPageHost CreatePageHost(IVirtualFile file, RazorViewPageTransformer transformer)
+        {
+            return new CachedRazorPageHost(PathProvider, file, transformer, new CSharpCodeProvider(), new Dictionary<string, string>(), cache);
+        }
+    }
+}

--- a/src/ServiceStack.Razor/Managers/RazorViewManager.cs
+++ b/src/ServiceStack.Razor/Managers/RazorViewManager.cs
@@ -101,7 +101,7 @@ namespace ServiceStack.Razor.Managers
             //create a RazorPage
             var page = new RazorPage
             {
-                PageHost = new RazorPageHost(PathProvider, file, transformer, new CSharpCodeProvider(), new Dictionary<string, string>()),
+                PageHost = CreatePageHost(file, transformer),
                 IsValid = false,
                 File = file
             };
@@ -113,6 +113,11 @@ namespace ServiceStack.Razor.Managers
                 PrecompilePage(page);
             
             return page;
+        }
+
+        public virtual RazorPageHost CreatePageHost(IVirtualFile file, RazorViewPageTransformer transformer)
+        {
+            return new RazorPageHost(PathProvider, file, transformer, new CSharpCodeProvider(), new Dictionary<string, string>());
         }
 
         protected virtual RazorPage AddPage(RazorPage page)

--- a/src/ServiceStack.Razor/RazorFormat.cs
+++ b/src/ServiceStack.Razor/RazorFormat.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ServiceStack.CacheAccess;
 using ServiceStack.Html;
 using ServiceStack.IO;
 using ServiceStack.Logging;
@@ -42,6 +43,7 @@ namespace ServiceStack.Razor
         public List<Predicate<string>> Deny { get; set; }
         public bool PrecompilePages { get; set; }
         public bool WaitForPrecompilationOnStartup { get; set; }
+        public ICacheClient CompilerCache { get; set; }
         public IVirtualPathProvider VirtualPathProvider { get; set; }
         public ILiveReload LiveReload { get; set; }
         public Func<RazorViewManager, ILiveReload> LiveReloadFactory { get; set; }
@@ -137,6 +139,8 @@ namespace ServiceStack.Razor
 
         public virtual RazorViewManager CreateViewManager()
         {
+            if (CompilerCache != null)
+                return new CachedRazorViewManager(this, VirtualPathProvider, CompilerCache);
             return new RazorViewManager(this, VirtualPathProvider);
         }
 

--- a/src/ServiceStack.Razor/ServiceStack.Razor.csproj
+++ b/src/ServiceStack.Razor/ServiceStack.Razor.csproj
@@ -47,6 +47,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compilation\CachedRazorPageHost.cs" />
     <Compile Include="CSharpRazorBuildProvider.cs" />
     <Compile Include="json\DynamicJson.cs" />
     <Compile Include="Compilation\CompilerServices.cs" />
@@ -62,6 +63,7 @@
     <Compile Include="Compilation\CodeTransformers\RewriteLinePragmas.cs" />
     <Compile Include="Compilation\CodeTransformers\SetTypeNamespace.cs" />
     <Compile Include="Compilation\CodeTransformers\SetTypeVisibility.cs" />
+    <Compile Include="Managers\CachedRazorViewManager.cs" />
     <Compile Include="Managers\FileSystemWatcherLiveReload.cs" />
     <Compile Include="Managers\RazorGen\MvcHelperTransformer.cs" />
     <Compile Include="Managers\RazorGen\MvcViewTransformer.cs" />


### PR DESCRIPTION
Very useful for AppHarbor hosted apps. Saves the 10 to 60 second compile time every razor page takes on their CPU limited web server instances.

Only developed and tested against v3 (sorry, current project using this still on v3), but looks like it'll work verbatim for v4. And no unit tests yet, just wanted to throw it out there and see if this is in the right direction before putting time into that?
