### PR TITLE
Refactored to share common logic found in AuthAttribute

### DIFF
--- a/src/ServiceStack.Razor/ViewPageBase.cs
+++ b/src/ServiceStack.Razor/ViewPageBase.cs
@@ -530,21 +530,13 @@ namespace ServiceStack.Razor
         public void RedirectIfNotAuthenticated(string redirectUrl=null)
         {
             if (IsAuthenticated) return;
-            
-            if (redirectUrl != null)
-            {
-                Response.RedirectToUrl(redirectUrl);
-            }
-            else
-            {
-                var authFeature = AppHost.GetPlugin<AuthFeature>();
-                var virtualPath = authFeature != null && authFeature.HtmlRedirect != null
-                    ? authFeature.HtmlRedirect
-                    : HostContext.Config.DefaultRedirectPath ?? HostContext.Config.WebHostUrl ?? "/";
 
-                var url = AppHost.ResolveAbsoluteUrl(virtualPath, base.Request);
-                Response.RedirectToUrl(url);
-            }
+            redirectUrl = redirectUrl
+                ?? AuthenticateService.HtmlRedirect
+                ?? HostContext.Config.DefaultRedirectPath
+                ?? HostContext.Config.WebHostUrl
+                ?? "/";
+            AuthenticateAttribute.DoHtmlRedirect(redirectUrl, Request, Response, includeRedirectParam: true);
             throw new StopExecutionException();
         }
     }

--- a/src/ServiceStack/AuthenticateAttribute.cs
+++ b/src/ServiceStack/AuthenticateAttribute.cs
@@ -88,18 +88,22 @@ namespace ServiceStack
             var htmlRedirect = this.HtmlRedirect ?? AuthenticateService.HtmlRedirect;
             if (htmlRedirect != null && req.ResponseContentType.MatchesContentType(MimeTypes.Html))
             {
-                var url = req.ResolveAbsoluteUrl(htmlRedirect);
-                if (includeRedirectParam)
-                {
-                    var absoluteRequestPath = req.ResolveAbsoluteUrl("~" + req.PathInfo + ToQueryString(req.QueryString));
-                    url = url.AddQueryParam(HostContext.ResolveLocalizedString(LocalizedStrings.Redirect), absoluteRequestPath);
-                }
-
-                res.RedirectToUrl(url);
+                DoHtmlRedirect(htmlRedirect, req, res, includeRedirectParam);
                 return true;
             }
-
             return false;
+        }
+
+        public static void DoHtmlRedirect(string redirectUrl, IRequest req, IResponse res, bool includeRedirectParam)
+        {
+            var url = req.ResolveAbsoluteUrl(redirectUrl);
+            if (includeRedirectParam)
+            {
+                var absoluteRequestPath = req.ResolveAbsoluteUrl("~" + req.PathInfo + ToQueryString(req.QueryString));
+                url = url.AddQueryParam(HostContext.ResolveLocalizedString(LocalizedStrings.Redirect), absoluteRequestPath);
+            }
+
+            res.RedirectToUrl(url);
         }
 
         public static void AuthenticateIfBasicAuth(IRequest req, IResponse res)


### PR DESCRIPTION
Just a minor update to share existing code in AuthAttribute, important so that the redirect query string still gets appended (to be redirected back to protected razor page after login).

Not sure if you'd like to move the new static helper method `AuthenticateAttribute.DoHtmlRedirect` somewhere else more central, I just left it in the original class for now.

Also, the existing auth attribute code only used the explicit redirect url, or fallback to the auth service setting. In your new razor code you have a few more additional fallbacks. I left those as is, but both these sets of fallbacks might want to be centralized by being moved to the DoHtmlRedirect method too.
