### PR TITLE
RequiresAnyRoleAttribute.HasAnyRoles made virtual

### DIFF
--- a/src/ServiceStack/RequiresAnyRoleAttribute.cs
+++ b/src/ServiceStack/RequiresAnyRoleAttribute.cs
@@ -44,7 +44,7 @@ namespace ServiceStack
             res.EndRequest();
         }
 
-        public bool HasAnyRoles(IRequest req, IAuthSession session, IAuthRepository userAuthRepo = null)
+        public virtual bool HasAnyRoles(IRequest req, IAuthSession session, IAuthRepository userAuthRepo = null)
         {
             if (HasAnyRoles(session)) return true;
 
@@ -58,7 +58,7 @@ namespace ServiceStack
             return false;
         }
 
-        public bool HasAnyRoles(IAuthSession session)
+        public virtual bool HasAnyRoles(IAuthSession session)
         {
             return this.RequiredRoles
                 .Any(requiredRole => session != null


### PR DESCRIPTION
The motivation behind this is to allow for overriding just HasAnyRoles to alter the list of target roles at runtime.

A few examples:
1. Adding super-priviledged role that are able to access anything.
2. Allowing for hierarchical nested roles (e.g. "Manager" role should have all the access that "Operator" have)
