### PR TITLE
Adds the ability to specify static (constant) values with REST requests

### DIFF
--- a/src/ServiceStack.Interfaces/Web/IServiceRoutes.cs
+++ b/src/ServiceStack.Interfaces/Web/IServiceRoutes.cs
@@ -1,3 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+
 namespace ServiceStack.Web
 {
 	/// <summary>
@@ -35,7 +38,31 @@ namespace ServiceStack.Web
 		///		never <see langword="null"/>.</returns>
 		IServiceRoutes Add<TRequest>(string restPath, string verbs);
 
-		/// <summary>
+	    ///  <summary>
+	    /// 		Maps the specified REST path to the specified request DTO, binds
+	    ///      the given properties to URL variables, and  specifies the HTTP 
+	    ///      verbs supported by the path.
+	    ///  </summary>
+	    ///  <typeparam name="TRequest">The type of request DTO to map 
+	    /// 		the path to.</typeparam>
+	    ///  <param name="restPath">The path to map the request DTO to.
+	    /// 		See <see cref="RouteAttribute.Path">RouteAttribute.Path</see>
+	    /// 		for details on the correct format.</param>
+	    ///  <param name="verbs">
+	    /// 		The comma-delimited list of HTTP verbs supported by the path, 
+	    /// 		such as "GET,PUT,DELETE".  Specify empty or <see langword="null"/>
+	    /// 		to indicate that all verbs are supported.
+	    ///  </param>
+	    /// <param name="variableBindings">
+	    ///         Specifies constant values that are to be bound with the request. 
+	    ///         This is for cases where the DTO type has variables that should
+	    ///         be filled out but are not included in the request path itself.
+	    /// </param>
+	    /// <returns>The same <see cref="IServiceRoutes"/> instance;
+	    /// 		never <see langword="null"/>.</returns>
+	    IServiceRoutes Add<TRequest>(string restPath, string verbs, IDictionary<string, object> variableBindings);
+        
+        /// <summary>
 		///		Maps the specified REST path to the specified request DTO, 
 		///		specifies the HTTP verbs supported by the path, and indicates
 		///		the default MIME type of the returned response.

--- a/src/ServiceStack/Host/ServiceRoutes.cs
+++ b/src/ServiceStack/Host/ServiceRoutes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using ServiceStack.Logging;
 using ServiceStack.Text;
@@ -31,6 +32,15 @@ namespace ServiceStack.Host
             appHost.RestPaths.Add(new RestPath(typeof(TRequest), restPath, verbs));
             return this;
         }
+
+        public IServiceRoutes Add<TRequest>(string restPath, string verbs, IDictionary<string, object> variableBindings)
+        {
+            if (HasExistingRoute(typeof(TRequest), restPath)) return this;
+
+            appHost.RestPaths.Add(new RestPath(typeof(TRequest), restPath, verbs, variableBindings: variableBindings));
+            return this;
+        }
+
 
         public IServiceRoutes Add(Type requestType, string restPath, string verbs)
         {

--- a/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
@@ -119,6 +119,44 @@ namespace ServiceStack.ServiceHost.Tests
             }
         }
 
+        [Test]
+        public void Can_include_StaticValuesForVariables_request()
+        {
+            using (JsConfig.With(includePublicFields: true))
+            {
+                var variableBindings = new Dictionary<string, object>
+                {
+                    {"Id", 5},
+                    {"Name", "Is Alive"}
+                };
+                var restPath = new RestPath(typeof (ComplexTypeWithFields),
+                    "/Complex/Unique/{UniqueId}", null, null, null, variableBindings);
+                var request = restPath.CreateRequest(
+                    "/complex/unique/4583B364-BBDC-427F-A289-C2923DEBD547") as ComplexTypeWithFields;
+
+                Assert.That(request, Is.Not.Null);
+                Assert.That(request.Id, Is.EqualTo(5));
+                Assert.That(request.Name, Is.EqualTo("Is Alive"));
+                Assert.That(request.UniqueId, Is.EqualTo(new Guid("4583B364-BBDC-427F-A289-C2923DEBD547")));
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Cannot_include_invalidStaticValuesForVariables_request()
+        {
+            using (JsConfig.With(includePublicFields: true))
+            {
+                var variableBindings = new Dictionary<string, object>
+                {
+                    {"IdX", 5},
+                    {"Name", "Is Alive"}
+                };
+                var restPath = new RestPath(typeof (ComplexTypeWithFields),
+                    "/Complex/Unique/{UniqueId}", null, null, null, variableBindings);
+            }
+        }
+
 
         public class BbcMusicRequest
         {


### PR DESCRIPTION
Adds the ability to specify static (constant) values with REST requests. This allows values to be bound to DTO variables without being included in a REST request path.

This is useful for cases where an intermediate Service would otherwise be necessary for the sole purpose of re-routing the request.
