### PR TITLE
updated QueryString parameter for error handler in FacebookAuthProvider

### DIFF
--- a/src/ServiceStack/Auth/FacebookAuthProvider.cs
+++ b/src/ServiceStack/Auth/FacebookAuthProvider.cs
@@ -33,14 +33,14 @@ namespace ServiceStack.Auth
             var tokens = Init(authService, ref session, request);
             var httpRequest = authService.Request;
 
-            var error = httpRequest.QueryString["error"];
+            var error = httpRequest.QueryString["error_code"];
             var hasError = !error.IsNullOrEmpty();
             if (hasError)
             {
                 Log.Error("Facebook error callback. {0}".Fmt(httpRequest.QueryString));
                 return authService.Redirect(session.ReferrerUrl);
-            } 
-            
+            }             
+        
             var code = httpRequest.QueryString["code"];
             var isPreAuthCallback = !code.IsNullOrEmpty();
             if (!isPreAuthCallback)


### PR DESCRIPTION
Facebook returns "error_code" and "error_message" if there is error in request, other than invalid token or app id. For example, if Facebook application is not yet open for production (i.e. only app admins can use it), then attempt to authenticate will result in URL like:

http://localhost:38866/api/v1/auth/facebook?error_code=1349126&error_message=App%20Not%20Setup%3A%20The%20developers%20of%20this%20app%20have%20not%20set%20up%20this%20app%20properly%20for%20Facebook%20Login.

Using current implementation leads to infinite loop (fortunately interrupted by modal dialog, otherwise the redirec loop would kill the app :) )

So, I am proposing this fix. 

Thank you,
Rouslan Grabar.
