### PR TITLE
Extended AuthDto with Info parameter so clients can query Session status

### DIFF
--- a/src/ServiceStack.Client/AuthDtos.cs
+++ b/src/ServiceStack.Client/AuthDtos.cs
@@ -17,13 +17,14 @@ namespace ServiceStack
         [DataMember(Order = 6)] public string Password { get; set; }
         [DataMember(Order = 7)] public bool? RememberMe { get; set; }
         [DataMember(Order = 8)] public string Continue { get; set; }
-        // Thise are used for digest auth
+        // These are used for digest auth
         [DataMember(Order = 9)] public string nonce { get; set; }
         [DataMember(Order = 10)] public string uri { get; set; }
         [DataMember(Order = 11)] public string response { get; set; }
         [DataMember(Order = 12)] public string qop { get; set; }
         [DataMember(Order = 13)] public string nc { get; set; }
         [DataMember(Order = 14)] public string cnonce { get; set; }
+        [DataMember(Order = 15)] public string Info { get; set; }
     }
 
     [DataContract]


### PR DESCRIPTION
I propose this change to allow clients like Single Page Application to query session status by making requests like `http://localhost:38866/auth.json?info=CurrentSession`

For example, in my angularjs SPA application I have controller which swaps "sign in|sign out" links in header menu. Since this is SPA and I it requests it's data in small chunks and present received data with appropriate templates. 

I could use $watch and listen to changes in my utmUserAuth service (a service as in angular domain) and set/reset session on login/logout by using the session information returned, but then I have to figure out how to handle oAuth logins, which just redirect to "success" url without providing explicit session details.

To workaround this, I had to create new DTO (thus minus one useful DTO on my "free-loader-license" :smile: ) VerifyAuth and assigned it to route "/auth/verify". 

The snippet bellow shows my workaround (commented out) and the use of the proposed change.

```
angular.module('app.controllers', [])
.controller('SiteHeaderController', [
    '$scope', '$http', '$location', 'utmUserAuth', function($scope, $http, $location, utmUserAuth) {
        $scope.isAuthenticated = false;
        $scope.userName = '';

        //// Old code uses custom VerifyAuth Dto with route "/auth/verify"
        //
        // $http.get($scope.apiPathPrefix + '/auth/verify.json')
        //     .success(function(data, status, headers, config){
        //         utmUserAuth.setSession(data.sessionId, data.userId, data.userName);
        //         $scope.userName = data.userName;
        //         $scope.isAuthenticated = true;
        //     })
        //     .error(function(data, status, headers, config){
        //         utmUserAuth.resetSession();
        //         $scope.isAuthenticated = false;
        //     })

        $http.get($scope.apiPathPrefix + '/auth.json?info=CurrentSession')
            .success(function(data, status, headers, config){
                if(data.userId !== undefined) {
                    utmUserAuth.setSession(data.sessionId, data.userId, data.userName);
                    $scope.userName = data.userName;
                    $scope.isAuthenticated = true;
                } else {
                    utmUserAuth.resetSession();
                    $scope.isAuthenticated = false;
                }
            })          
    }
])
```

and here is an animated screencapture of the result in action:
![header](https://cloud.githubusercontent.com/assets/204439/2994489/2601c6ea-dcce-11e3-920e-d75feb048e44.gif)

Kind regards,
Rouslan Grabar
