### PR TITLE
extended AuthenticateResponse w/Meta 'DisplayName'

### DIFF
--- a/src/ServiceStack/Auth/AuthenticateService.cs
+++ b/src/ServiceStack/Auth/AuthenticateService.cs
@@ -137,7 +137,9 @@ namespace ServiceStack.Auth
                     Meta = new Dictionary<string, string>
                     {
                       {
-                        "DisplayName", session.DisplayName ?? "{0} {1}".Fmt(session.FirstName, session.LastName).Trim()
+                        "DisplayName", session.DisplayName 
+                                ?? session.UserName 
+                                ?? "{0} {1}".Fmt(session.FirstName, session.LastName).Trim()
                       }
                     }
                 };


### PR DESCRIPTION
Relates to [this commit](https://github.com/ServiceStack/ServiceStack/commit/242de40773022aca0d90e85303691d010e06a36d)  The problem is that many OAuth provider do not have notion of userName, and we have name-less auth details. With "DisplayName" meta property clients (like Single Page Apps) would be able to provide more personalized experience (e.g. in login/logout UI elements)
