### PR TITLE
bug fix: ss returns http code 403 for routes ending same way as the api route prefix

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
+++ b/src/ServiceStack/WebHost.Endpoints/ServiceStackHttpHandlerFactory.cs
@@ -178,7 +178,7 @@ namespace ServiceStack.WebHost.Endpoints
                 return ServeDefaultHandler ? DefaultHttpHandler : NonRootModeDefaultHttpHandler;
             }
 
-            if (mode != null && pathInfo.EndsWith(mode))
+            if (mode != null && (pathInfo.EndsWith("/" + mode) || pathInfo.EndsWith(mode+"/")))
             {
                 var requestPath = context.Request.Path.ToLower();
                 if (requestPath == "/" + mode


### PR DESCRIPTION
For example:
/ts/Utilities/GetStats where /ts/ prefix is same as end of word Stats
/api/Utilities/Testapi where /api/ prefix is same as end of word Testapi
