### PR TITLE
Added LoadUserAuthInfo override to AspNetWindowsAuthProvider

### DIFF
--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -73,6 +73,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Runtime.Serialization">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
Added LoadUserAuthInfo override to AspNetWindowsAuthProvider to populate
the tokens with the user's metadata from PrincipalContext. 

This addition unfortunately requires a dependency to System.DirectoryServices.AccountManagement. This provider is only for use with an IIS host, so Mono functionality should not be an issue.
