### PR TITLE
Add global api version to swagger response

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerResourcesService.cs
@@ -59,7 +59,8 @@ namespace ServiceStack.Api.Swagger
             {
                 SwaggerVersion = "1.1",
                 BasePath = basePath,
-                Apis = new List<RestService>()
+                Apis = new List<RestService>(),
+                ApiVersion = HostContext.Config.ApiVersion
             };
             var operations = HostContext.Metadata;
             var allTypes = operations.GetAllTypes();


### PR DESCRIPTION
The property for setting the global API version already exists, however it is never set and cannot be modified by either of the Swagger events. Use the existing `AppHost.ApiVersion` value to specify this. If set, this value will appear on the bottom of the page next to the Base URL as seen on the [demo page](http://petstore.swagger.wordnik.com/).

Note: The `ApiVersion` is already specified for each [individual route](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Api.Swagger/SwaggerApiService.cs#L182), however that does not appear anywhere on the resulting swagger page.
