### PR TITLE
use long.Parse when setting content length

### DIFF
--- a/src/ServiceStack/HttpResponseExtensionsInternal.cs
+++ b/src/ServiceStack/HttpResponseExtensionsInternal.cs
@@ -195,7 +195,7 @@ namespace ServiceStack
                             if (responseHeaders.Key.Contains(reservedOptions)) continue;
                             if (responseHeaders.Key == HttpHeaders.ContentLength)
                             {
-                                response.SetContentLength(int.Parse(responseHeaders.Value));
+                                response.SetContentLength(long.Parse(responseHeaders.Value));
                                 continue;
                             }
 


### PR DESCRIPTION
int.Parse fails on values greater than int.MaxValue
