### PR TITLE
fix file references, de-reference archaic files

### DIFF
--- a/src/ServiceStack.Client/ServiceStack.Client.AndroidIndie.csproj
+++ b/src/ServiceStack.Client/ServiceStack.Client.AndroidIndie.csproj
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{42E1C8C0-A163-44CC-92B1-8F416F2C0B01}</ProjectGuid>
+    <ProjectGuid>{923E3732-3AEE-42B3-96AB-D3235DAADD48}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -76,12 +76,10 @@
     <Compile Include="Messaging\RedisMessageProducer.cs" />
     <Compile Include="Messaging\RedisMessageQueueClient.cs" />
     <Compile Include="Messaging\RedisMessageQueueClientFactory.cs" />
-    <Compile Include="RequestContext.cs" />
     <Compile Include="ResponseStatusUtils.cs" />
     <Compile Include="RouteMember.cs" />
     <Compile Include="Serialization\DataContractSerializer.Deserialize.cs" />
     <Compile Include="Serialization\DataContractSerializer.cs" />
-    <Compile Include="Serialization\IStringSerializer.cs" />
     <Compile Include="Serialization\IStringStreamSerializer.cs" />
     <Compile Include="Serialization\JsonDataContractSerializer.Deserialize.cs" />
     <Compile Include="Serialization\JsonDataContractSerializer.cs" />
@@ -93,7 +91,7 @@
     <Compile Include="ServiceClientBase.cs" />
     <Compile Include="Soap11ServiceClient.cs" />
     <Compile Include="Soap12ServiceClient.cs" />
-    <Compile Include="StreamExtensions.cs" />
+    <Compile Include="StreamExt.cs" />
     <Compile Include="Support\NetDeflateProvider.cs" />
     <Compile Include="Support\NetGZipProvider.cs" />
     <Compile Include="UrlExtensions.cs" />
@@ -108,15 +106,15 @@
   <!--ItemGroup,Content-->
   <!--ItemGroup,None-->
   <ItemGroup>
-  <ProjectReference Include="..\..\..\ServiceStack.Text\src\ServiceStack.Text\ServiceStack.Text.AndroidIndie.csproj">
-    <Project>{579B3FDB-CDAD-44E1-8417-885C38E49A0E}</Project>
-    <Name>ServiceStack.Text.AndroidIndie</Name>
-  </ProjectReference>
-  <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.AndroidIndie.csproj">
-    <Project>{42E1C8C0-A163-44CC-92B1-8F416F2C0B01}</Project>
-    <Name>ServiceStack.Interfaces.AndroidIndie</Name>
-  </ProjectReference>
-</ItemGroup>
+    <ProjectReference Include="..\..\..\ServiceStack.Text\src\ServiceStack.Text\ServiceStack.Text.AndroidIndie.csproj">
+      <Project>{579B3FDB-CDAD-44E1-8417-885C38E49A0E}</Project>
+      <Name>ServiceStack.Text.AndroidIndie</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.AndroidIndie.csproj">
+      <Project>{42E1C8C0-A163-44CC-92B1-8F416F2C0B01}</Project>
+      <Name>ServiceStack.Interfaces.AndroidIndie</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.AndroidIndie.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.AndroidIndie.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -126,6 +126,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="IO\IEndpoint.cs" />
+    <Compile Include="IQuery.cs" />
     <Compile Include="IRestGateway.cs" />
     <Compile Include="Logging\DebugLogFactory.cs" />
     <Compile Include="Logging\DebugLogger.cs" />
@@ -288,6 +289,7 @@
     <Compile Include="Redis\RedisKeyType.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Redis\ScanResult.cs" />
     <Compile Include="Redis\SortOptions.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
it looks like recent work in other projects didn't get replicated down to the AndroidIndie projects.  This pull request goes together with another for the main ServiceStack.Text repo.
