### PR TITLE
Only process the RequestFilters with priority >= 0

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
@@ -359,7 +359,7 @@ namespace ServiceStack.WebHost.Endpoints
                 }
 
                 //Exec remaining RequestFilter attributes with Priority >= 0
-                for (; i < attributes.Length; i++)
+                for (; i < attributes.Length && attributes[i].Priority >= 0; i++)
                 {
                     var attribute = attributes[i];
                     ServiceManager.Container.AutoWire(attribute);


### PR DESCRIPTION
RequestFilters with a priority <0 should not be executed two times.
