### PR TITLE
Bug Fix - Exception in OnBeforeExecute causes logging failure

### DIFF
--- a/src/ServiceStack/Host/ServiceRunner.cs
+++ b/src/ServiceStack/Host/ServiceRunner.cs
@@ -40,13 +40,13 @@ namespace ServiceStack.Host
 
         public virtual void BeforeEachRequest(IRequest requestContext, TRequest request)
         {
-            OnBeforeExecute(requestContext, request);
-
             var requestLogger = AppHost.TryResolve<IRequestLogger>();
             if (requestLogger != null)
             {
                 requestContext.SetItem("_requestDurationStopwatch", Stopwatch.StartNew());
             }
+            
+            OnBeforeExecute(requestContext, request);
         }
 
         public virtual object AfterEachRequest(IRequest requestContext, TRequest request, object response)


### PR DESCRIPTION
If an exception is thrown in OnBeforeExecute the requestLogger doesn't get set which will cause a NullReferenceException in AfterEachRequest on stopWatch.Elapsed.
