### PR TITLE
Remove unneeded Android Permissions

### DIFF
--- a/src/ServiceStack.Pcl.Android/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Pcl.Android/Properties/AssemblyInfo.cs
@@ -28,7 +28,3 @@ using Android.App;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.0.0.0")]
 [assembly: AssemblyFileVersion("4.0.0.0")]
-
-// Add some common permissions, these can be removed if not needed
-[assembly: UsesPermission(Android.Manifest.Permission.Internet)]
-[assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]


### PR DESCRIPTION
INTERNET and WRITE_EXTERNAL_STORAGE were part of the old Xamarin.Android project templates for VS. While INTERNET is likely needed by many apps that use ServiceStack, it's confusing when it's automatically added via a third-party library. WRITE_EXTERNAL_STORAGE is not needed at all.

See http://forums.xamarin.com/discussion/16197/stuck-manifest-permissions, https://bugzilla.xamarin.com/show_bug.cgi?id=19785
