### PR TITLE
fix NullReferenceException in SqlTimingParameter.GetHashCode

### DIFF
--- a/src/ServiceStack/MiniProfiler/SqlTimingParameter.cs
+++ b/src/ServiceStack/MiniProfiler/SqlTimingParameter.cs
@@ -55,7 +55,7 @@ namespace ServiceStack.MiniProfiler
         /// </summary>
         public override int GetHashCode()
         {
-            return ParentSqlTimingId.GetHashCode() ^ Name.GetHashCode() ^ Value.GetHashCode();
+            return ParentSqlTimingId.GetHashCode() ^ Name.GetHashCode() ^ (Value != null ? Value.GetHashCode() : 0);
         }
     }
 }


### PR DESCRIPTION
null Value is perfectly acceptable.
