### PR TITLE
metadata feature: improve documentation to document nested properties and support multiple values

### DIFF
--- a/src/ServiceStack/Templates/OperationControl.html
+++ b/src/ServiceStack/Templates/OperationControl.html
@@ -75,6 +75,16 @@
 		table, tr, th, td {
             border: none;
 		}
+		table.membersTable, table.membersTable tr, table.membersTable th, table.membersTable td {
+			border: 1px solid #DEE3EA; 
+		}
+		table.membersTable .valuesHeader {
+			margin: 5px 0 0 0;
+			font-style: italic;
+		}
+		table.membersTable ul, table.membersTable li {
+			margin-top: 0px;
+		} 
         .operations, .operation {
             padding: 0 0 0 15px;
         }

--- a/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
+++ b/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
@@ -158,8 +158,6 @@
     <Content Include="Default.aspx" />
     <Content Include="default.html" />
     <Content Include="Subpages\Test.aspx" />
-    <EmbeddedResource Include="Templates\OperationControl.html" />
-    <EmbeddedResource Include="Templates\HtmlFormat.html" />
     <Content Include="user-notfound.htm" />
     <Content Include="user-default.htm" />
     <Content Include="Global.asax" />
@@ -299,7 +297,7 @@
       <Name>ServiceStack.Server</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\ServiceStack\ServiceStack.csproj">
-      <Project>{680A1709-25EB-4D52-A87F-EE03FFD94BAA}</Project>
+      <Project>{680a1709-25eb-4d52-a87f-ee03ffd94baa}</Project>
       <Name>ServiceStack</Name>
     </ProjectReference>
     <ProjectReference Include="..\ServiceStack.Common.Tests\ServiceStack.Common.Tests.csproj">
@@ -310,7 +308,9 @@
   <ItemGroup>
     <Content Include="packages.config" />
     <Content Include="static-root.txt" />
-    <Content Include="App.config" />
+    <Content Include="App.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Properties\DataSources\ServiceStack.ServiceInterface.ServiceModel.ResponseStatus.datasource" />
     <None Include="README.md" />
     <Content Include="sample.pdf" />
@@ -318,6 +318,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
+    <Folder Include="Templates\" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/tests/ServiceStack.WebHost.IntegrationTests/Services/SwaggerTestService.cs
+++ b/tests/ServiceStack.WebHost.IntegrationTests/Services/SwaggerTestService.cs
@@ -26,6 +26,28 @@ namespace ServiceStack.WebHost.IntegrationTests.Services
         [ApiMember(Description = "Not Aliased Description",
                    ParameterType = "path", DataType = "string", IsRequired = true)]
         public string NotAliased { get; set; }
+
+		[ApiMember( Description = "Nested model 1", DataType = "SwaggerNestedModel" )]
+		public SwaggerNestedModel NestedModel1{ get; set; }
+
+		[ApiMember( Description = "Nested model 2", DataType = "SwaggerNestedModel2" )]
+		public SwaggerNestedModel2 NestedModel2{ get; set; }
+    }
+
+    public class SwaggerNestedModel
+    {
+        [ApiMember( Description = "NestedProperty description")]
+        public bool NestedProperty { get; set;}
+    }
+
+    public class SwaggerNestedModel2
+    {
+        [ApiMember( Description = "NestedProperty2 description")]
+        public bool NestedProperty2 { get; set;}
+
+        [ApiMember( Description = "MultipleValues description")]
+		[ApiAllowableValues( "NestedProperty2", new [] { "val1", "val2" } ) ]
+        public string MultipleValues { get; set;}
     }
 
     public class SwaggerTestService : Service


### PR DESCRIPTION
This pull request allows to reuse Swagger documentation attributes to provide much better metadata documentation.
- Updated metadata feature generating documentation to recursively process all properties of DTO object and generate documentation for all used types
- Added support for ApiAllowableValuesAttribute

I wasn't 100% on which code can be correctly reused from Swagger, so there is duplication.
