### PR TITLE
HTTP 201 Created includes content (DTO) for other formats than HTML, so ...

### DIFF
--- a/src/ServiceStack/Formats/HtmlFormat.cs
+++ b/src/ServiceStack/Formats/HtmlFormat.cs
@@ -36,7 +36,8 @@ namespace ServiceStack.Formats
         public void SerializeToStream(IRequest request, object response, IResponse httpRes)
         {
             var httpResult = request.GetItem("HttpResult") as IHttpResult;
-            if (httpResult != null && httpResult.Headers.ContainsKey(HttpHeaders.Location))
+            if (httpResult != null && httpResult.Headers.ContainsKey(HttpHeaders.Location) 
+                && httpResult.StatusCode != System.Net.HttpStatusCode.Created)  
                 return;
 
             try


### PR DESCRIPTION
...I've included it for HTML as well, so Content Types behave the same.

I don't know if I'm correct, but when running the examples (RestIntro from AllExamples) and POSTing a new customer, there is code like:

```
var pathToNewResource = base.Request.AbsoluteUri.CombineWith(customer.Id.ToString());
return HttpResult.Status201Created(customer, pathToNewResource);
```

For JSON and XML, it returns the DTO + 201 status code, but for HTML it returns blank body, just a white page.
I see two ways of dealing with this
1. change and use a redirect instead
2. make HTML behave the same as JSON/XML, e.g. include DTO in body, which I suggest here.

Please comment.
