### PR TITLE
Fixes problem with fanout outq

### DIFF
--- a/src/ServiceStack.RabbitMq/RabbitMqExtensions.cs
+++ b/src/ServiceStack.RabbitMq/RabbitMqExtensions.cs
@@ -30,7 +30,7 @@ namespace ServiceStack.RabbitMq
 
         public static void RegisterTopicExchange(this IModel channel, string exchangeName = null)
         {
-            channel.ExchangeDeclare(exchangeName ?? QueueNames.ExchangeTopic, "fanout", durable: false, autoDelete: false, arguments:null);
+            channel.ExchangeDeclare(exchangeName ?? QueueNames.ExchangeTopic, "topic", durable: false, autoDelete: false, arguments:null);
         }
 
         public static void RegisterQueues<T>(this IModel channel)


### PR DESCRIPTION
Once exchange for outq queues is configured to be fanout, every .outq
queue gets messages from all .inq queues handlers, which messes them
with unnecessary load. I simply can't think of a meaningful processing
for messages of all these types. Registering this exchange as "topic"
makes messages flow to only configured .outq queues, and with default
bindings it will work as "direct" exchange with option to configure it
in any way later.
