### PR TITLE
RabbitMqProducer: Don't redeclare queue when publishing to server named (exclusive) queue

### DIFF
--- a/src/ServiceStack.RabbitMq/RabbitMqExtensions.cs
+++ b/src/ServiceStack.RabbitMq/RabbitMqExtensions.cs
@@ -143,6 +143,16 @@ namespace ServiceStack.RabbitMq
             return ex.Message.Contains("code=404");
         }
 
+        public static bool IsServerNamedQueue(this string queueName)
+        {
+            if (string.IsNullOrEmpty(queueName))
+            {
+                throw new ArgumentNullException("queueName");
+            }
+
+            return queueName.ToLower().StartsWith("amq.");
+        }	
+
         public static void PopulateFromMessage(this IBasicProperties props, IMessage message)
         {
             props.MessageId = message.Id.ToString();


### PR DESCRIPTION
Use-Case: MQ-based RPC call with anonymously declared queue 
Client code sends request message to normal incoming queue but sets ReplyTo to temporary queue name.

Excerpt from client-code: 
string responseQueueName = channel.QueueDeclare().QueueName;
var props = channel.CreateBasicProperties();
props.ReplyTo = responseQueueName;
channel.BasicPublish(EXCHANGE_NAME, INQ_QUEUE_NAME, props, body));

MessageProducer should not try to redeclare queue since it would result in error anyway. 
Instead it should just publish response message to default exchange ("") assuming queue and default binding  exist.
