### PR TITLE
Upgrade Markdown's ShouldSkipPaths as a global Config.ScanSkipPaths opti...

### DIFF
--- a/src/ServiceStack/VirtualPath/AbstractVirtualFileBase.cs
+++ b/src/ServiceStack/VirtualPath/AbstractVirtualFileBase.cs
@@ -6,6 +6,7 @@ using System.Text;
 using ServiceStack.Common;
 using ServiceStack.IO;
 using ServiceStack.Text;
+using ServiceStack.WebHost.Endpoints;
 
 namespace ServiceStack.VirtualPath
 {
@@ -99,6 +100,22 @@ namespace ServiceStack.VirtualPath
         public override string ToString()
         {
             return string.Format("{0} -> {1}", RealPath, VirtualPath);
+        }
+    }
+}
+
+namespace ServiceStack
+{
+    public static class VirtualFileExtensions
+    {
+        public static bool ShouldSkipPath(this IVirtualNode node)
+        {
+            foreach (var skipPath in EndpointHostConfig.Instance.ScanSkipPaths)
+            {
+                if (node.VirtualPath.StartsWith(skipPath, StringComparison.InvariantCultureIgnoreCase))
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/src/ServiceStack/VirtualPath/FileSystemVirtualDirectory.cs
+++ b/src/ServiceStack/VirtualPath/FileSystemVirtualDirectory.cs
@@ -47,7 +47,8 @@ namespace ServiceStack.VirtualPath
         public override IEnumerator<IVirtualNode> GetEnumerator()
         {
             var directoryNodes = BackingDirInfo.GetDirectories()
-                .Select(dInfo => new FileSystemVirtualDirectory(VirtualPathProvider, this, dInfo));
+                .Select(dInfo => new FileSystemVirtualDirectory(VirtualPathProvider, this, dInfo))
+                .Where(x => !x.ShouldSkipPath());
 
             var fileNodes = BackingDirInfo.GetFiles()
                 .Select(fInfo => new FileSystemVirtualFile(VirtualPathProvider, this, fInfo));

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -120,6 +120,11 @@ namespace ServiceStack.WebHost.Endpoints
                         Return204NoContentForEmptyResponse = true,
                         AllowPartialResponses = true,
                         AllowAclUrlReservation = true,
+                        StripApplicationVirtualPath = true,
+                        ScanSkipPaths = new List<string> {
+                            "/obj/", 
+                            "/bin/",
+                        },
                         IgnoreWarningsOnPropertyNames = new List<string> {
                             "format", "callback", "debug", "_", "authsecret"
                         }
@@ -197,6 +202,8 @@ namespace ServiceStack.WebHost.Endpoints
             this.PostExecuteServiceFilter = instance.PostExecuteServiceFilter;
             this.FallbackRestPath = instance.FallbackRestPath;
             this.AllowAclUrlReservation = instance.AllowAclUrlReservation;
+            this.StripApplicationVirtualPath = instance.StripApplicationVirtualPath;
+            this.ScanSkipPaths = instance.ScanSkipPaths;
             this.AdminAuthSecret = instance.AdminAuthSecret;
         }
 
@@ -457,6 +464,10 @@ namespace ServiceStack.WebHost.Endpoints
         public bool AllowPartialResponses { get; set; }
         public bool AllowNonHttpOnlyCookies { get; set; }
         public bool AllowAclUrlReservation { get; set; }
+        public bool StripApplicationVirtualPath { get; set; }
+
+        //Skip scanning common VS.NET extensions
+        public List<string> ScanSkipPaths { get; private set; }
 
         public bool UseHttpsLinks { get; set; }
 

--- a/src/ServiceStack/WebHost.Endpoints/Formats/MarkdownFormat.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Formats/MarkdownFormat.cs
@@ -77,8 +77,6 @@ namespace ServiceStack.WebHost.Endpoints.Formats
 
         readonly TemplateProvider templateProvider = new TemplateProvider(DefaultTemplateName);
 
-        public List<string> SkipPaths { get; set; }
-
         public MarkdownFormat()
         {
             markdown = new MarkdownSharp.Markdown(); //Note: by default MarkdownDeep is used
@@ -87,11 +85,6 @@ namespace ServiceStack.WebHost.Endpoints.Formats
             this.MarkdownGlobalHelpers = new Dictionary<string, Type>();
             this.FindMarkdownPagesFn = FindMarkdownPages;
             this.ReplaceTokens = new Dictionary<string, string>();
-            //Skip scanning common VS.NET extensions
-            this.SkipPaths = new List<string> {
-                "/obj/", 
-                "/bin/",
-            };
         }
 
         internal static readonly char[] DirSeps = new[] { '\\', '/' };
@@ -439,7 +432,7 @@ namespace ServiceStack.WebHost.Endpoints.Formats
             var markDownFiles = VirtualPathProvider.GetAllMatchingFiles("*." + MarkdownExt);
             foreach (var markDownFile in markDownFiles)
             {
-                if (ShouldSkipPath(markDownFile)) continue;
+                if (markDownFile.ShouldSkipPath()) continue;
 
                 if (markDownFile.GetType().Name != "ResourceVirtualFile")
                     hasReloadableWebPages = true;
@@ -471,16 +464,6 @@ namespace ServiceStack.WebHost.Endpoints.Formats
 		public void RegisterMarkdownPage(MarkdownPage markdownPage)
         {
             AddPage(markdownPage);
-        }
-
-        private bool ShouldSkipPath(IVirtualFile csHtmlFile)
-        {
-            foreach (var skipPath in SkipPaths)
-            {
-                if (csHtmlFile.VirtualPath.StartsWith(skipPath, StringComparison.InvariantCultureIgnoreCase))
-                    return true;
-            }
-            return false;
         }
 
         public void AddPage(MarkdownPage page)


### PR DESCRIPTION
...on which VFS now avoids scanning.

Upgrade Markdown's ShouldSkipPaths as a global Config.ScanSkipPaths
option which VFS now avoids scanning.
This change corresponds to commit
16f36d061472162b61825c6f69e1b8a486b372f1 on master (by mythz, Nov 26,
2013).

---

This (partially) fixes the problem reported on uservoice.com (sorry for misusing that platform): http://servicestack.uservoice.com/forums/176786-feature-requests/suggestions/6502203-possible-performance-problem-in-markdownformat-plu

I noticed that the problem was already fixed in master, so I just applied the same changes in branch v3.

The fix seems not completely correct IMO:
When I set tell to skip a path, e.g:
  EndpointHostConfig.Instance.ScanSkipPaths.Add("/data/");
then no subfolders of /data/ will be scanned, but files inside /data/ will still be scanned and processed.

I don't know if this is by design or not. In any case, this commit fixes the performance problems reported on uservoice.com, since it stops scanning folders below the paths listed in ScanSkipPath.
