### PR TITLE
Keep response headers in WebServiceException

### DIFF
--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -577,6 +577,7 @@ namespace ServiceStack
                 {
                     StatusCode = (int)errorResponse.StatusCode,
                     StatusDescription = errorResponse.StatusDescription,
+                    ResponseHeaders = errorResponse.Headers
                 };
 
                 try

--- a/src/ServiceStack.Client/WebServiceException.cs
+++ b/src/ServiceStack.Client/WebServiceException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Runtime.Serialization;
 using ServiceStack.Text;
 
@@ -21,6 +22,8 @@ namespace ServiceStack
         public int StatusCode { get; set; }
 
         public string StatusDescription { get; set; }
+
+        public WebHeaderCollection ResponseHeaders { get; set; }
 
         public object ResponseDto { get; set; }
         


### PR DESCRIPTION
Keeping headers is very useful for analysing exceptions and/or transfering some extra headers.
