### PR TITLE
Fix for MarkDataContractExtensible for VB.Net native types generator.

### DIFF
--- a/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
+++ b/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
@@ -351,7 +351,7 @@ namespace ServiceStack.NativeTypes.VbNet
                 if (wasAdded) sb.AppendLine();
                 wasAdded = true;
 
-                sb.AppendLine("Public {0}Property ExtensionData As ExtensionDataObject".Fmt(@virtual));
+                sb.AppendLine("Public {0}Property ExtensionData As ExtensionDataObject Implements IExtensibleDataObject.ExtensionData".Fmt(@virtual));
             }
         }
 


### PR DESCRIPTION
Previous generation was explicitly marking the property with `Implements` causing failure to compile generated DTOs
