### PR TITLE
Added ability to join multiple times to AutoQuery, plus test.

### DIFF
--- a/src/ServiceStack.Server/AutoQueryFeature.cs
+++ b/src/ServiceStack.Server/AutoQueryFeature.cs
@@ -490,25 +490,23 @@ namespace ServiceStack
         {
             if (model is IJoin)
             {
-                bool leftJoin = false;
                 var dtoInterfaces = model.GetType().GetInterfaces();
-                var join = dtoInterfaces.FirstOrDefault(x => x.Name.StartsWith("IJoin`"));
-                if (join == null)
+                foreach(var innerJoin in dtoInterfaces.Where(x => x.Name.StartsWith("IJoin`")))
                 {
-                    join = dtoInterfaces.FirstOrDefault(x => x.Name.StartsWith("ILeftJoin`"));
-                    if (join == null)
-                        throw new ArgumentException("No IJoin<T1,T2,..> interface found");
-
-                    leftJoin = true;
+                    var joinTypes = innerJoin.GetGenericArguments();
+                    for (var i = 1; i < joinTypes.Length; i++)
+                    {
+                        q.Join(joinTypes[i - 1], joinTypes[i]);
+                    }
                 }
 
-                var joinTypes = join.GetGenericArguments();
-                for (var i = 1; i < joinTypes.Length; i++)
+                foreach(var leftJoin in dtoInterfaces.Where(x => x.Name.StartsWith("ILeftJoin`")))
                 {
-                    if (!leftJoin)
-                        q.Join(joinTypes[i - 1], joinTypes[i]);
-                    else
+                    var joinTypes = leftJoin.GetGenericArguments();
+                    for (var i = 1; i < joinTypes.Length; i++)
+                    {
                         q.LeftJoin(joinTypes[i - 1], joinTypes[i]);
+                    } 
                 }
             }
         }


### PR DESCRIPTION
I encountered an issue where I wanted to join in two different directions for a single query, and found that it could be supported but just wasn't: http://stackoverflow.com/questions/26783587/servicestack-autoquery-multiple-ijoin

Here is my proposed change to enable this, you are welcome to change the test data to stay in keeping with the theme.

This should be merged into the v4 source tree.
