### PR TITLE
Multiple joins can now be defined on a single AutoQuery request definition.

### DIFF
--- a/src/ServiceStack.Server/AutoQueryFeature.cs
+++ b/src/ServiceStack.Server/AutoQueryFeature.cs
@@ -490,25 +490,23 @@ namespace ServiceStack
         {
             if (model is IJoin)
             {
-                bool leftJoin = false;
                 var dtoInterfaces = model.GetType().GetInterfaces();
-                var join = dtoInterfaces.FirstOrDefault(x => x.Name.StartsWith("IJoin`"));
-                if (join == null)
+                foreach(var innerJoin in dtoInterfaces.Where(x => x.Name.StartsWith("IJoin`")))
                 {
-                    join = dtoInterfaces.FirstOrDefault(x => x.Name.StartsWith("ILeftJoin`"));
-                    if (join == null)
-                        throw new ArgumentException("No IJoin<T1,T2,..> interface found");
-
-                    leftJoin = true;
+                    var joinTypes = innerJoin.GetGenericArguments();
+                    for (var i = 1; i < joinTypes.Length; i++)
+                    {
+                        q.Join(joinTypes[i - 1], joinTypes[i]);
+                    }
                 }
 
-                var joinTypes = join.GetGenericArguments();
-                for (var i = 1; i < joinTypes.Length; i++)
+                foreach(var leftJoin in dtoInterfaces.Where(x => x.Name.StartsWith("ILeftJoin`")))
                 {
-                    if (!leftJoin)
-                        q.Join(joinTypes[i - 1], joinTypes[i]);
-                    else
+                    var joinTypes = leftJoin.GetGenericArguments();
+                    for (var i = 1; i < joinTypes.Length; i++)
+                    {
                         q.LeftJoin(joinTypes[i - 1], joinTypes[i]);
+                    } 
                 }
             }
         }


### PR DESCRIPTION
Previous fork was way out of date so rebased and applied this change again.

I could not find any tests for AutoQueryService in my updated fork so I have not added any for this modification. I have tested it locally on my app, (it was previously tested on the old forks unit tests) and works fine.
