### PR TITLE
Changed IRequest.GetBaseUrl() to use AbsoluteUri and PathInfo

### DIFF
--- a/src/ServiceStack/HttpRequestExtensions.cs
+++ b/src/ServiceStack/HttpRequestExtensions.cs
@@ -700,18 +700,19 @@ namespace ServiceStack
             var baseUrl = HttpHandlerFactory.GetBaseUrl();
             if (baseUrl != null) return baseUrl;
 
-            var handlerPath = HostContext.Config.HandlerFactoryPath;
-            if (handlerPath != null)
+            var pathInfo = httpReq.PathInfo;
+            if (pathInfo != null)
             {
                 var absoluteUri = httpReq.AbsoluteUri;
-                var pos = absoluteUri.IndexOf(handlerPath, StringComparison.OrdinalIgnoreCase);
+                var pos = absoluteUri.IndexOf(pathInfo, StringComparison.OrdinalIgnoreCase);
                 if (pos >= 0)
                 {
-                    baseUrl = absoluteUri.Substring(0, pos + handlerPath.Length);
+                    baseUrl = absoluteUri.Substring(0, pos);
                     return baseUrl.NormalizeScheme();
                 }
-                return "/" + handlerPath;
             }
+
+            var handlerPath = HostContext.Config.HandlerFactoryPath;
 
             return new Uri(httpReq.AbsoluteUri).GetLeftPart(UriPartial.Authority)
                 .NormalizeScheme()


### PR DESCRIPTION
I left the check for `HttpHandlerFactory.GetBaseUrl()` as well as the fallback to using the left part of the URL plus the `HandlerFactoryPath`.  This appears to work in ASP.NET regardless of location within the domain as well as location of SS within the project.  I verified correct behavior with self-hosting as well on Windows and with Mono.  I have not tested the behavior with XSP.
