### PR TITLE
Don't try to serialize null objects in JsonDataContractSerializer

### DIFF
--- a/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
+++ b/src/ServiceStack.Common/ServiceModel/Serialization/JsonDataContractSerializer.cs
@@ -55,6 +55,8 @@ namespace ServiceStack.ServiceModel.Serialization
 
         public void SerializeToStream<T>(T obj, Stream stream)
         {
+            if (obj == null) return;
+
             if (TextSerializer != null)
             {
                 TextSerializer.SerializeToStream(obj, stream);


### PR DESCRIPTION
NullRefException would occur when returning an HttpResult w/o an object.