### PR TITLE
Duplicate types from CSharpGenerator

### DIFF
--- a/src/ServiceStack/NativeTypes/CSharp/CSharpGenerator.cs
+++ b/src/ServiceStack/NativeTypes/CSharp/CSharpGenerator.cs
@@ -146,6 +146,7 @@ namespace ServiceStack.NativeTypes.CSharp
                 {
                     lastNS = AppendType(ref sb, type, lastNS, allTypes, 
                         new CreateTypeOptions { IsType = true });
+                    existingOps.Add(fullTypeName);
                 }
             }
 


### PR DESCRIPTION
Bug causing duplicate types due to not adding processed type to existingOps hashset.