### PR TITLE
Microsoft Account OAuth 2 Provider added.

### DIFF
--- a/src/ServiceStack.Authentication.OAuth2/MicrosoftOAuth2Provider.cs
+++ b/src/ServiceStack.Authentication.OAuth2/MicrosoftOAuth2Provider.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using ServiceStack.Configuration;
+using ServiceStack.Text;
+
+namespace ServiceStack.Authentication.OAuth2
+{
+        /*
+            Create an OAuth2 App at: https://account.live.com/developers/applications
+            The Apps Callback URL should match the CallbackUrl here.
+     
+            Microsoft Account OAuth2 info: https://msdn.microsoft.com/en-us/library/dn659752.aspx
+            Microsoft Account OAuth2 Scopes from: https://msdn.microsoft.com/en-us/library/hh243646.aspx)
+
+         */
+        public class MicrosoftOAuth2Provider : OAuth2Provider
+        {
+            public const string Name = "MicrosoftOAuth";
+
+            public const string Realm = "https://login.live.com/oauth20_authorize.srf";
+
+            public MicrosoftOAuth2Provider(IAppSettings appSettings)
+                : base(appSettings, Realm, Name)
+            {
+                this.AuthorizeUrl = this.AuthorizeUrl ?? Realm;
+                this.AccessTokenUrl = this.AccessTokenUrl ?? "https://login.live.com/oauth20_token.srf";
+                this.UserProfileUrl = this.UserProfileUrl ?? "https://apis.live.net/v5.0/me";
+
+                if (this.Scopes.Length == 0)
+                {
+                    this.Scopes = new[] {
+                    "wl.signin",
+                    "wl.basic",
+                    "wl.emails"
+                };
+                }
+            }
+
+            protected override Dictionary<string, string> CreateAuthInfo(string accessToken)
+            {
+                var url = this.UserProfileUrl.AddQueryParam("access_token", accessToken);
+                string json = url.GetJsonFromUrl();
+                var obj = JsonObject.Parse(json);
+                var emails = JsonObject.Parse(obj.GetUnescaped("emails"));
+                var authInfo = new Dictionary<string, string>
+            {
+                { "user_id", obj["id"] }, 
+                { "username", emails["account"] }, 
+                { "email", emails["preferred"] }, 
+                { "name", obj["name"] }, 
+                { "first_name", obj["first_name"] }, 
+                { "last_name", obj["last_name"] },
+                { "gender", obj["gender"] },
+                { "locale", obj["locale"] }
+            };
+                return authInfo;
+            }
+        }
+    }

--- a/src/ServiceStack.Authentication.OAuth2/ServiceStack.Authentication.OAuth2.csproj
+++ b/src/ServiceStack.Authentication.OAuth2/ServiceStack.Authentication.OAuth2.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="GoogleOAuth2Provider.cs" />
     <Compile Include="LinkedInOAuth2Provider.cs" />
+    <Compile Include="MicrosoftOAuth2Provider.cs" />
     <Compile Include="OAuth2Provider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Note:
- Gender is always null even if defined online in Microsoft Account site 
- http://localhost:11001 cannot be used as RedirectURL, for testing you should use something like http://devmachine.local:11001/