### PR TITLE
Allow multiple newlines to be published on ServerEvents and silently consumed by the C# ServerEventsClient.

### DIFF
--- a/src/ServiceStack.Client/ServerEventsClient.cs
+++ b/src/ServiceStack.Client/ServerEventsClient.cs
@@ -389,14 +389,16 @@ namespace ServiceStack
                     {
                         if (text == "\n")
                         {
-                            ProcessEventMessage(currentMsg);
+                            if (currentMsg != null) 
+                                ProcessEventMessage(currentMsg);
                             currentMsg = null;
                             text = "";
                             break;
                         }
 
                         var line = text.Substring(0, pos);
-                        ProcessLine(line);
+                        if (!string.IsNullOrWhiteSpace(line)) 
+                            ProcessLine(line);
                         if (text.Length > pos + 1)
                             text = text.Substring(pos + 1);
                     }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
@@ -149,6 +149,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
         public bool UseRedisServerEvents { get; set; }
         public bool LimitToAuthenticatedUsers { get; set; }
+        public Action<Web.IResponse, string> OnPublish { get; set; }
 
         public override void Configure(Container container)
         {
@@ -156,6 +157,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             {
                 HeartbeatInterval = TimeSpan.FromMilliseconds(200),
                 LimitToAuthenticatedUsers = LimitToAuthenticatedUsers,
+                OnPublish = OnPublish
             });
 
             if (UseRedisServerEvents)
@@ -183,6 +185,25 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         public override bool TryAuthenticate(IServiceBase authService, string userName, string password)
         {
             return userName == "user" && password == "pass";
+        }
+    }
+
+
+    [TestFixture]
+    public class MemoryServerEventsWithNewlineOnPublishTests : ServerEventsTests
+    {
+        protected override ServiceStackHost CreateAppHost()
+        {
+            return new ServerEventsAppHost()
+            {
+                 
+                OnPublish = (res, msg) =>
+                {
+                    res.OutputStream.Write("\n\n\n\n\n\n\n\n\n\n");
+                }
+            }
+                .Init()
+                .Start(Config.AbsoluteBaseUri);
         }
     }
 


### PR DESCRIPTION
In some situations, response buffering is enabled on a server, causing ServerEvent messages to not be fully transmitted to the client.  One workaround is to remove dynamic compression, at a potential cost to all other API calls on the site.  The other option, [outlined by mythz here](http://stackoverflow.com/questions/25960723/servicestack-sever-sent-events/25983774#25983774), is to write an amount of bogus `\n` chars to the output stream.  This alternative locks up the `ServiceStack.ServerEventsClient` when attempting to digest the `\n` chars.

I'm not entirely happy with the logic, but it passes the unit tests.


    OnPublish = (res, msg) =>
    {
        res.OutputStream.Write("\n\n\n\n\n\n\n\n\n\n");
    }
