### PR TITLE
Add failing test for Db.Dispose() in a razor partial.

### DIFF
--- a/tests/ServiceStack.RazorHostTests/CatchAll.cshtml
+++ b/tests/ServiceStack.RazorHostTests/CatchAll.cshtml
@@ -20,3 +20,5 @@
         <li>@person.FirstName - @person.LastName (@person.Age)</li>
     }
 </ul>
+
+@Html.Partial("_CatchAllPartial")

--- a/tests/ServiceStack.RazorHostTests/ServiceStack.RazorHostTests.csproj
+++ b/tests/ServiceStack.RazorHostTests/ServiceStack.RazorHostTests.csproj
@@ -189,6 +189,9 @@
   <ItemGroup>
     <Content Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="_CatchAllPartial.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/tests/ServiceStack.RazorHostTests/_CatchAllPartial.cshtml
+++ b/tests/ServiceStack.RazorHostTests/_CatchAllPartial.cshtml
@@ -1,0 +1,7 @@
+﻿<h3>Db.Select&lt;Person&gt;() Partial</h3>
+<ul>
+    @foreach (var person in Db.Select<Rockstar>(q => q.Age == 27))
+    {
+        <li>@person.FirstName - @person.LastName (@person.Age)</li>
+    }
+</ul>


### PR DESCRIPTION
Add a breakpoint at [line 515](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Razor/ViewPageBase.cs#L515) in `ViewPageBase.cs`
Browse to `localhost:59115/catchall`
`.Dispose()` is called for CatchAll and SimplyLayout, but not for CatchAllPartial
This causes leaked db connections which, over time, will end up exhausting the pool and crashing the site.