### PR TITLE
Added SS.Caching.AwsDynamoDbV2 and update deps

### DIFF
--- a/src/ServiceStack.Authentication.MongoDb/ServiceStack.Authentication.MongoDB.csproj
+++ b/src/ServiceStack.Authentication.MongoDb/ServiceStack.Authentication.MongoDB.csproj
@@ -44,13 +44,13 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Bson, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Driver, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Driver.dll</HintPath>
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>

--- a/src/ServiceStack.Authentication.MongoDb/packages.config
+++ b/src/ServiceStack.Authentication.MongoDb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.9.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/src/ServiceStack.Authentication.NHibernate/packages.config
+++ b/src/ServiceStack.Authentication.NHibernate/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net40" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net40" />
-  <package id="NHibernate" version="4.0.2.4000" targetFramework="net40" />
+  <package id="NHibernate" version="4.0.3.4000" targetFramework="net40" />
 </packages>

--- a/src/ServiceStack.Caching.AwsDynamoDb/packages.config
+++ b/src/ServiceStack.Caching.AwsDynamoDb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="1.5.45.0" targetFramework="net40" />
+  <package id="AWSSDK" version="1.5.45.0" targetFramework="net40" allowedVersions="(,2)" />
 </packages>

--- a/src/ServiceStack.Caching.AwsDynamoDbV2/DynamoDbCacheClient.cs
+++ b/src/ServiceStack.Caching.AwsDynamoDbV2/DynamoDbCacheClient.cs
@@ -1,0 +1,437 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DocumentModel;
+using Amazon.DynamoDBv2.Model;
+using ServiceStack.Logging;
+
+namespace ServiceStack.Caching.AwsDynamoDbV2
+{
+    public class DynamoDbCacheClient : ICacheClient
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(DynamoDbCacheClient));
+
+        private AmazonDynamoDBClient _client;
+        private Table _awsCacheTableObj;
+
+        private string _cacheTableName;
+        private int _cacheReadCapacity = 10; // free-tier settings
+        private int _cacheWriteCapacity = 5; // free-tier settings
+        private readonly bool _cacheTableCreate;
+        private const string KeyName = "urn";
+        private const string ValueName = "value";
+        private const string ExpiresAtName = "expiresAt";
+
+        /// <summary>
+        /// AWS Access Key ID
+        /// </summary>
+        public string AwsAccessKey { get; set; }
+
+        /// <summary>
+        /// The name of the DynamoDB Table - either make sure it is already created with HashKey string named "urn" or pass true into constructor createTableIfMissing argument
+        /// </summary>
+        public string CacheTableName
+        {
+            get { return _cacheTableName; }
+            set { _cacheTableName = value; }
+        }
+
+        /// <summary>
+        /// AWS Secret Key ID
+        /// </summary>
+        public string AwsSecretKey { get; set; }
+
+        /// <summary>
+        /// AWS Region where the DynamoDB Table is stored
+        /// </summary>
+        public RegionEndpoint AwsRegion { get; set; }
+
+        /// <summary>
+        /// If the client needs to delete/re-create the DynamoDB table, this is the Read Capacity to use
+        /// </summary>
+        public int CacheReadCapacity
+        {
+            get { return _cacheReadCapacity; }
+            set { _cacheReadCapacity = value; }
+        }
+
+        /// <summary>
+        /// If the client needs to delete/re-create the DynamoDB table, this is the Write Capacity to use
+        /// </summary> 
+        public int CacheWriteCapacity
+        {
+            get { return _cacheWriteCapacity; }
+            set { _cacheWriteCapacity = value; }
+        }
+
+        /// <summary>
+        /// DynamoDbCacheClient constructor
+        /// </summary>
+        /// <param name="awsAccessKey">AWS Access Key ID</param>
+        /// <param name="awsSecretKey">AWS Secret Key ID</param>
+        /// <param name="region">AWS Region</param>
+        /// <param name="cacheTableName">Name of DynamoDB Table</param>
+        /// <param name="readCapacity">Desired DynamoDB Read Capacity</param>
+        /// <param name="writeCapacity">Desired DynamoDB Write Capacity</param>
+        /// <param name="createTableIfMissing">Pass true if you'd like the client to create the DynamoDB table on startup</param>
+        public DynamoDbCacheClient(string awsAccessKey, string awsSecretKey, RegionEndpoint region,
+                                   string cacheTableName = "ICacheClientDynamo", int readCapacity = 10,
+                                   int writeCapacity = 5, bool createTableIfMissing = false)
+        {
+            CacheTableName = cacheTableName;
+            AwsAccessKey = awsAccessKey;
+            AwsSecretKey = awsSecretKey;
+            AwsRegion = region;
+            CacheReadCapacity = readCapacity;
+            CacheWriteCapacity = writeCapacity;
+            _cacheTableCreate = createTableIfMissing;
+
+            Init();
+        }
+
+        private void Init()
+        {
+            if (String.IsNullOrEmpty(CacheTableName))
+            {
+                throw new MissingFieldException("DynamoCacheClient", "_cacheTableName");
+            }
+            if (String.IsNullOrEmpty(AwsAccessKey))
+            {
+                throw new MissingFieldException("DynamoCacheClient", "_awsAccessKey");
+            }
+            _client = new AmazonDynamoDBClient(AwsAccessKey, AwsSecretKey, AwsRegion);
+            Log.Info("Successfully created AmazonDynamoDBClient");
+            if (_cacheTableCreate) CreateDynamoCacheTable();
+        }
+
+        private void CreateDynamoCacheTable()
+        {
+            if (String.IsNullOrEmpty(AwsSecretKey))
+            {
+                throw new MissingFieldException("DynamoCacheClient", "_awsSecretKey");
+            }
+            Log.InfoFormat("Attempting to load DynamoDB table {0}", _cacheTableName);
+            if (!Table.TryLoadTable(_client, CacheTableName, out _awsCacheTableObj))
+            {
+                Log.InfoFormat("DynamoDB table {0} does not exist, attempting to create", _cacheTableName);
+                try
+                {
+                    _client.CreateTable(new CreateTableRequest
+                    {
+                        TableName = CacheTableName,
+                        KeySchema = new List<KeySchemaElement>() {
+                                new KeySchemaElement { 
+                                    AttributeName = KeyName, 
+                                    KeyType = KeyType.HASH, 
+                                }
+                            },
+                        ProvisionedThroughput = new ProvisionedThroughput
+                        {
+                            ReadCapacityUnits = CacheReadCapacity,
+                            WriteCapacityUnits = CacheWriteCapacity,
+                        }
+
+                    });
+                    Log.InfoFormat("Successfully created DynamoDB table {0}", _cacheTableName);
+                    WaitUntilTableReady(_cacheTableName);
+                }
+                catch (Exception)
+                {
+                    Log.ErrorFormat("Could not create DynamoDB table {0}", _cacheTableName);
+                    throw;
+                }
+
+            }
+        }
+
+        private void WaitUntilTableDeleted(string tableName)
+        {
+            string status;
+            DateTime startWaitTime = DateTime.Now;
+            // Let us wait until table is created. Call DescribeTable.
+            do
+            {
+                System.Threading.Thread.Sleep(5000); // Wait 5 seconds.
+                try
+                {
+                    var res = _client.DescribeTable(new DescribeTableRequest
+                    {
+                        TableName = tableName
+                    });
+
+                    Log.InfoFormat("Table name: {0}, status: {1}",
+                                   res.Table.TableName,
+                                   res.Table.TableStatus);
+                    status = res.Table.TableStatus;
+                    if (DateTime.Now.Subtract(startWaitTime).Seconds > 60)
+                    {
+                        throw new Exception(
+                            "Waiting for too long for DynamoDB table to be deleted, please check your AWS Console");
+                    }
+                }
+                catch (ResourceNotFoundException)
+                {
+                    // When the resource is reported as not found, it's deleted so break out of the loop
+                    break;
+                }
+            } while (status == "DELETING");
+        }
+
+        private void WaitUntilTableReady(string tableName)
+        {
+            string status = null;
+            DateTime startWaitTime = DateTime.Now;
+            // Let us wait until table is created. Call DescribeTable.
+            do
+            {
+                System.Threading.Thread.Sleep(5000); // Wait 5 seconds.
+                try
+                {
+                    var res = _client.DescribeTable(new DescribeTableRequest
+                    {
+                        TableName = tableName
+                    });
+
+                    Log.InfoFormat("Table name: {0}, status: {1}",
+                                   res.Table.TableName,
+                                   res.Table.TableStatus);
+                    status = res.Table.TableStatus;
+                    if (DateTime.Now.Subtract(startWaitTime).Seconds > 60)
+                    {
+                        throw new Exception(
+                            "Waiting for too long for DynamoDB table to be created, please check your AWS Console");
+                    }
+                }
+                catch (ResourceNotFoundException)
+                {
+                    // DescribeTable is eventually consistent. So you might
+                    // get resource not found. So we handle the potential exception.
+                }
+            } while (status != "ACTIVE");
+        }
+
+        private bool TryGetValue<T>(string key, out T entry)
+        {
+            Log.InfoFormat("Attempting cache get of key: {0}", key);
+            entry = default(T);
+            var itemKey = new Dictionary<string, AttributeValue> { { KeyName, new AttributeValue() { S = key } } };
+            var response = _client.GetItem(CacheTableName, itemKey);
+
+            var item = response.Item;
+            if (item != null)
+            {
+                DateTime expiresAt = Convert.ToDateTime(item[ExpiresAtName].S);
+                if (DateTime.UtcNow > expiresAt)
+                {
+                    Log.InfoFormat("Cache key: {0} has expired, removing from cache!", key);
+                    Remove(key);
+                    return false;
+                }
+                string jsonData = item[ValueName].S;
+                entry = jsonData.FromJson<T>();
+                Log.InfoFormat("Cache hit on key: {0}", key);
+                return true;
+            }
+            return false;
+        }
+
+        private bool CacheAdd<T>(string key, T value, DateTime expiresAt)
+        {
+            T entry;
+            if (TryGetValue(key, out entry)) return false;
+
+            CacheSet(key, value, expiresAt);
+            return true;
+        }
+
+        private bool CacheSet<T>(string key, T value, DateTime expiresAt)
+        {
+            try
+            {
+                _client.PutItem(
+                    new PutItemRequest
+                    {
+                        TableName = CacheTableName,
+                        Item = new Dictionary<string, AttributeValue>
+                        {
+                            { KeyName, new AttributeValue {S = key } },
+                            { ValueName, new AttributeValue {S = value.ToJson()} },
+                            {
+                                ExpiresAtName,
+                                new AttributeValue {S = expiresAt.ToUniversalTime().ToString(CultureInfo.InvariantCulture)}
+                            }
+                        }
+                    }
+                    );
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private int UpdateCounter(string key, int value)
+        {
+            var itemKey = new Dictionary<string, AttributeValue> { { KeyName, new AttributeValue() { S = key } } };
+            var response = _client.UpdateItem(new UpdateItemRequest
+            {
+                TableName = CacheTableName,
+                Key = itemKey,
+                AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                {
+                    {
+                        ValueName,
+                        new AttributeValueUpdate
+                        {
+                            Action = "ADD",
+                            Value = new AttributeValue
+                            {
+                                N =value.ToString(CultureInfo.InvariantCulture)
+                            }
+                        }
+                    }
+                },
+                ReturnValues = "ALL_NEW"
+            });
+            return Convert.ToInt32(response.Attributes[ValueName].N);
+        }
+
+        public bool Add<T>(string key, T value, TimeSpan expiresIn)
+        {
+            return CacheAdd(key, value, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Add<T>(string key, T value, DateTime expiresAt)
+        {
+            return CacheAdd(key, value, expiresAt.ToUniversalTime());
+        }
+
+        public bool Add<T>(string key, T value)
+        {
+            return CacheAdd(key, value, DateTime.MaxValue.ToUniversalTime());
+        }
+
+        public long Decrement(string key, uint amount)
+        {
+            return UpdateCounter(key, (int)-amount);
+        }
+
+        /// <summary>
+        /// IMPORTANT: This method will delete and re-create the DynamoDB table in order to reduce read/write capacity costs, make sure the proper table name and throughput properties are set!
+        /// TODO: This method may take upwards of a minute to complete, need to look into a faster implementation
+        /// </summary>
+        public void FlushAll()
+        {
+            // Is this the cheapest method per AWS pricing to clear a table? (instead of table scan / remove each item) ??
+            _client.DeleteTable(new DeleteTableRequest { TableName = CacheTableName });
+            // Scaning the table is limited to 1 MB chunks, with a large cache it could result in many Read requests and many Delete requests occurring very quickly which may tap out 
+            // the throughput capacity...
+            WaitUntilTableDeleted(_cacheTableName);
+            CreateDynamoCacheTable();
+        }
+
+        public T Get<T>(string key)
+        {
+            T value;
+            return TryGetValue(key, out value) ? value : default(T);
+        }
+
+        public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys)
+        {
+            var valueMap = new Dictionary<string, T>();
+            foreach (var key in keys)
+            {
+                var value = Get<T>(key);
+                valueMap[key] = value;
+            }
+            return valueMap;
+        }
+
+        public long Increment(string key, uint amount)
+        {
+            return UpdateCounter(key, (int)amount);
+        }
+
+        public bool Remove(string key)
+        {
+            try
+            {
+                var itemKey = new Dictionary<string, AttributeValue> { { KeyName, new AttributeValue() { S = key } } };
+                _client.DeleteItem(new DeleteItemRequest
+                {
+                    TableName = CacheTableName,
+                    Key = itemKey
+                });
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void RemoveAll(IEnumerable<string> keys)
+        {
+            foreach (var key in keys)
+            {
+                try
+                {
+                    Remove(key);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(string.Format("Error trying to remove {0} from the cache", key), ex);
+                }
+            }
+        }
+
+        public bool Replace<T>(string key, T value, TimeSpan expiresIn)
+        {
+            return Set(key, value, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Replace<T>(string key, T value, DateTime expiresAt)
+        {
+            return Set(key, value, expiresAt.ToUniversalTime());
+        }
+
+        public bool Replace<T>(string key, T value)
+        {
+            return Set(key, value, DateTime.MaxValue.ToUniversalTime());
+        }
+
+        public bool Set<T>(string key, T value, TimeSpan expiresIn)
+        {
+            return CacheSet(key, value, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Set<T>(string key, T value, DateTime expiresAt)
+        {
+            return CacheSet(key, value, expiresAt.ToUniversalTime());
+        }
+
+        public bool Set<T>(string key, T value)
+        {
+            return CacheSet(key, value, DateTime.MaxValue.ToUniversalTime());
+        }
+
+        public void SetAll<T>(IDictionary<string, T> values)
+        {
+            foreach (var entry in values)
+            {
+                Set(entry.Key, entry.Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_client != null)
+            {
+                _client.Dispose();
+            }
+        }
+    }
+}

--- a/src/ServiceStack.Caching.AwsDynamoDbV2/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Caching.AwsDynamoDbV2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Service Stack LLC")]
+[assembly: AssemblyProduct("ServiceStack")]
+[assembly: AssemblyCopyright("Copyright (c) ServiceStack 2015")]
+[assembly: AssemblyTrademark("Service Stack")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("95e6e10a-af25-42bb-8dbc-c1d817e2aaa6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/ServiceStack.Caching.AwsDynamoDbV2/ServiceStack.Caching.AwsDynamoDbV2.csproj
+++ b/src/ServiceStack.Caching.AwsDynamoDbV2/ServiceStack.Caching.AwsDynamoDbV2.csproj
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{E5C9B657-D8AF-4DF2-9BB8-C09AA8F5CBE2}</ProjectGuid>
+    <ProjectGuid>{AA7027C6-2C94-4E44-83A2-275EEE473045}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ServiceStack.Authentication.NHibernate</RootNamespace>
-    <AssemblyName>ServiceStack.Authentication.NHibernate</AssemblyName>
+    <RootNamespace>ServiceStack.Caching.AwsDynamoDb</RootNamespace>
+    <AssemblyName>ServiceStack.Caching.AwsDynamoDb</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -24,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\ServiceStack.Authentication.NHibernate.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\ServiceStack.Caching.AwsDynamoDb.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed|AnyCPU'">
     <OutputPath>bin\Signed\</OutputPath>
@@ -42,19 +43,11 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentNHibernate, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
-    </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
-    </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="AWSSDK">
+      <HintPath>..\packages\AWSSDK.2.3.23.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>
@@ -66,28 +59,16 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NHibernateUserAuthRepository.cs" />
+    <Compile Include="DynamoDbCacheClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UserAuthMap.cs" />
-    <Compile Include="UserAuthDetailsMap.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.csproj">
-      <Project>{982416db-c143-4028-a0c3-cf41892d18d3}</Project>
-      <Name>ServiceStack.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ServiceStack\ServiceStack.csproj">
-      <Project>{680a1709-25eb-4d52-a87f-ee03ffd94baa}</Project>
-      <Name>ServiceStack</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />

--- a/src/ServiceStack.Caching.AwsDynamoDbV2/packages.config
+++ b/src/ServiceStack.Caching.AwsDynamoDbV2/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AWSSDK" version="2.3.23.0" targetFramework="net40" allowedVersions="[2,)" />
+</packages>

--- a/src/ServiceStack.Caching.Azure/ServiceStack.Caching.Azure.csproj
+++ b/src/ServiceStack.Caching.Azure/ServiceStack.Caching.Azure.csproj
@@ -45,31 +45,31 @@
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationServer.Caching.AzureClientHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.ApplicationServer.Caching.AzureClientHelper.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.ApplicationServer.Caching.AzureClientHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationServer.Caching.AzureCommon, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.ApplicationServer.Caching.AzureCommon.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.ApplicationServer.Caching.AzureCommon.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationServer.Caching.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.ApplicationServer.Caching.Client.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.ApplicationServer.Caching.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationServer.Caching.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.ApplicationServer.Caching.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.ApplicationServer.Caching.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.DistributedCache, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.Web.DistributedCache.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.Web.DistributedCache.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsFabric.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.WindowsFabric.Common.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.WindowsFabric.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsFabric.Data.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.0.0\lib\net40-full\Microsoft.WindowsFabric.Data.Common.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.Caching.2.5.1.0\lib\net40-full\Microsoft.WindowsFabric.Data.Common.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>

--- a/src/ServiceStack.Caching.Azure/packages.config
+++ b/src/ServiceStack.Caching.Azure/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.Caching" version="2.5.0.0" targetFramework="net40" />
+  <package id="Microsoft.WindowsAzure.Caching" version="2.5.1.0" targetFramework="net40" />
 </packages>

--- a/src/ServiceStack.Caching.Memcached/ServiceStack.Caching.Memcached.csproj
+++ b/src/ServiceStack.Caching.Memcached/ServiceStack.Caching.Memcached.csproj
@@ -87,9 +87,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Enyim.Caching, Version=2.12.0.0, Culture=neutral, PublicKeyToken=cec98615db04012e, processorArchitecture=MSIL">
+    <Reference Include="Enyim.Caching, Version=2.13.0.0, Culture=neutral, PublicKeyToken=cec98615db04012e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EnyimMemcached.2.12\lib\net35\Enyim.Caching.dll</HintPath>
+      <HintPath>..\packages\EnyimMemcached.2.13\lib\net35\Enyim.Caching.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>

--- a/src/ServiceStack.Caching.Memcached/packages.config
+++ b/src/ServiceStack.Caching.Memcached/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EnyimMemcached" version="2.12" targetFramework="net35" />
+  <package id="EnyimMemcached" version="2.13" targetFramework="net40" />
 </packages>

--- a/src/ServiceStack.MsgPack/ServiceStack.MsgPack.csproj
+++ b/src/ServiceStack.MsgPack/ServiceStack.MsgPack.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <Reference Include="MsgPack, Version=0.5.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MsgPack.Cli.0.5.8\lib\net40-client\MsgPack.dll</HintPath>
+      <HintPath>..\packages\MsgPack.Cli.0.5.11\lib\net40-client\MsgPack.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>

--- a/src/ServiceStack.MsgPack/packages.config
+++ b/src/ServiceStack.MsgPack/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MsgPack.Cli" version="0.5.8" targetFramework="net40" />
+  <package id="MsgPack.Cli" version="0.5.11" targetFramework="net40" />
 </packages>

--- a/src/ServiceStack.sln
+++ b/src/ServiceStack.sln
@@ -163,6 +163,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.ServerV45", "S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Authentication.RavenDbV45", "ServiceStack.Authentication.RavenDbV45\ServiceStack.Authentication.RavenDbV45.csproj", "{2E728F63-E19A-4FC7-9C30-46D1396852C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Caching.AwsDynamoDbV2", "ServiceStack.Caching.AwsDynamoDbV2\ServiceStack.Caching.AwsDynamoDbV2.csproj", "{AA7027C6-2C94-4E44-83A2-275EEE473045}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1672,6 +1674,41 @@ Global
 		{2E728F63-E19A-4FC7-9C30-46D1396852C1}.STATIC_ONLY NO_EXPRESSIONS|Mixed Platforms.ActiveCfg = Signed|Any CPU
 		{2E728F63-E19A-4FC7-9C30-46D1396852C1}.STATIC_ONLY NO_EXPRESSIONS|Mixed Platforms.Build.0 = Signed|Any CPU
 		{2E728F63-E19A-4FC7-9C30-46D1396852C1}.STATIC_ONLY NO_EXPRESSIONS|x86.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoDebug|Any CPU.Build.0 = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoDebug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoDebug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoDebug|x86.ActiveCfg = Debug|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoRelease|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoRelease|Mixed Platforms.Build.0 = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoRelease|x86.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoTouch|Any CPU.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoTouch|Any CPU.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoTouch|Mixed Platforms.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoTouch|Mixed Platforms.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.MonoTouch|x86.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Signed|Any CPU.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Signed|Any CPU.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Signed|Mixed Platforms.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Signed|Mixed Platforms.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.Signed|x86.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.STATIC_ONLY NO_EXPRESSIONS|Mixed Platforms.ActiveCfg = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.STATIC_ONLY NO_EXPRESSIONS|Mixed Platforms.Build.0 = Signed|Any CPU
+		{AA7027C6-2C94-4E44-83A2-275EEE473045}.STATIC_ONLY NO_EXPRESSIONS|x86.ActiveCfg = Signed|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1709,6 +1746,7 @@ Global
 		{9982317F-831C-478B-9CC3-57F888BCD97A} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{213EF4BA-786A-432F-B147-5702B18DE3CC} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{2E728F63-E19A-4FC7-9C30-46D1396852C1} = {2E143186-E565-48B8-A8AE-6FE03B70FE68}
+		{AA7027C6-2C94-4E44-83A2-275EEE473045} = {515043B6-1FFD-4CBF-8916-23B82C67CF8C}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = ..\tests\RazorRockstars.Console\RazorRockstars.Console.csproj

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -26,6 +26,7 @@
   <repository path="..\ServiceStack.Authentication.RavenDb\packages.config" />
   <repository path="..\ServiceStack.Authentication.RavenDbV45\packages.config" />
   <repository path="..\ServiceStack.Caching.AwsDynamoDb\packages.config" />
+  <repository path="..\ServiceStack.Caching.AwsDynamoDbV2\packages.config" />
   <repository path="..\ServiceStack.Caching.Azure\packages.config" />
   <repository path="..\ServiceStack.Caching.Memcached\packages.config" />
   <repository path="..\ServiceStack.Logging.Elmah\packages.config" />


### PR DESCRIPTION
Added new ServiceStack.Caching.AwsDynamoDbV2 project that uses version 2.0+ of the 3rd party dependency and locked the current ServiceStack.Caching.AwsDynamoDb library to use only NuGet packages version prior to 2.0. 

Updated several NuGet packages in other projects to the most recent version of their 3rd party dependencies.