### PR TITLE
Fixed FourSquare OAuth2 Profile Image URL

### DIFF
--- a/tests/ServiceStack.AuthWeb.Tests/AppHost.cs
+++ b/tests/ServiceStack.AuthWeb.Tests/AppHost.cs
@@ -162,7 +162,7 @@ namespace ServiceStack.AuthWeb.Tests
                     UserName = "mythz",
                 }, "test");
             }
-            catch (Exception ignoreExistingUser) {}
+            catch (Exception) {}
 
             Plugins.Add(new RequestLogsFeature());
         }


### PR DESCRIPTION
Added missing profile image dimensions to the URL. Defaulted the dimensions to 64x64, but the developer can set them using oauth.FourSquare.ProfileImageWidth and oauth.FourSquare.ProfileImageHeight appsettings.