### PR TITLE
MiniProfiler: Show SQL parameter names, types, and values below the command string

### DIFF
--- a/src/ServiceStack/MiniProfiler/UI/includes.tmpl
+++ b/src/ServiceStack/MiniProfiler/UI/includes.tmpl
@@ -136,10 +136,20 @@
       <div class="query">
         <pre class="stack-trace"><%= s.StackTraceSnippet %></pre>
         <pre class="prettyprint lang-sql"><code><%= s.FormattedCommandString %></code></pre>
+        <% if (s.Parameters){ %>
+          <pre class="stack-trace"/>
+        <% $._each(s.Parameters, function($value){ %>
+            <%= $.tmpl("#sqlParameterTemplate", $value) %>
+        <% }) %>
+        <% } %>
       </div>
     </td>
   </tr>
 
+</script>
+
+<script id="sqlParameterTemplate" type="text/x-jquery-tmpl">
+  <pre class="stack-trace"><code><%= Name %>(<%= DbType %>): <%= Value %></code></pre>
 </script>
 
 <script id="sqlGapTemplate" type="text/x-jquery-tmpl">


### PR DESCRIPTION
@mythz This is a tweak to the profiler output that will show the parameter values used in a SQL statement.

The MiniProfiler was already capturing the bound parameter values, it just wasn't displaying them. So I added conditional block in the template that displays each parameter/value on a line below the command string.

As you can see from the included screenshot, the CSS styling is not right. It's leaving huge whitespace between each parameter.

I really don't like raising half a pull request, but my CSS skillz are just not up to par. So after struggling with CSS for an hour, I decided to raise the PR and maybe you or another SS dev can finish the styling part?

![image](https://cloud.githubusercontent.com/assets/54773/6975203/93a47c74-d94e-11e4-925b-7cc84b21ece8.png)
