### PR TITLE
Update IAuthHttpGateway.cs

### DIFF
--- a/src/ServiceStack/Auth/IAuthHttpGateway.cs
+++ b/src/ServiceStack/Auth/IAuthHttpGateway.cs
@@ -15,7 +15,7 @@ namespace ServiceStack.Auth
     {
         public const string TwitterUserUrl = "https://api.twitter.com/1.1/users/lookup.json?user_id={0}";
 
-        public const string FacebookUserUrl = "https://graph.facebook.com/me?access_token={0}";
+        public const string FacebookUserUrl = "https://graph.facebook.com/v2.0/me?access_token={0}";
 
         public const string YammerUserUrl = "https://www.yammer.com/api/v1/users/{0}.json";
 


### PR DESCRIPTION
At the end of April 2015 facebook will require all API calls to be on at least v2.0.    In the future it might make sense to make this configurable in web.config.    They are currently on V2.3 I think.