### PR TITLE
Add "Operator" to escaped keywords for VbNet NativeTypes

### DIFF
--- a/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
+++ b/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
@@ -62,6 +62,7 @@ namespace ServiceStack.NativeTypes.VbNet
             "Then",
             "With",
             "When",
+            "Operator"
         };
 
         public string GetCode(MetadataTypes metadata, IRequest request)


### PR DESCRIPTION
Fix in regards to [problem posted on ServiceStack forums](https://forums.servicestack.net/t/add-servicestack-reference-created-dtos-do-not-handle-properties-using-reserved-keywords-properly-in-vb-net/690).

