### PR TITLE
Request Cancellation with CancellationToken

### DIFF
--- a/src/ServiceStack.Client/AsyncState.cs
+++ b/src/ServiceStack.Client/AsyncState.cs
@@ -110,6 +110,16 @@ namespace ServiceStack
                 this.Timer = null;
             }
         }
+        CancellationTokenRegistration? cancelRegistration;
+        public void SetCancelToken(CancellationToken cancelToken, Action onCancel)
+        {
+            cancelRegistration = cancelToken.Register(onCancel);
+        }
+
+
+       
+
+
 
 #if NETFX_CORE
             public void TimedOut(ThreadPoolTimer timer)
@@ -156,6 +166,11 @@ namespace ServiceStack
             {
                 this.Timer.Dispose();
                 this.Timer = null;
+            }
+            if(cancelRegistration.HasValue)
+            {
+                cancelRegistration.Value.Dispose();
+                cancelRegistration = null;
             }
         }
     }

--- a/src/ServiceStack.Client/CancelRequestDtos.cs
+++ b/src/ServiceStack.Client/CancelRequestDtos.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace ServiceStack
+{
+    [Route("/requests/canceled")]
+    [DataContract]
+    public class CancelRequest : IReturn<CancelRequestResponse>
+    {
+        public const string CancelRequestIdHeader = "X-SS-RequestId";
+
+        [DataMember(Order = 1)]
+        public Guid RequestId { get; set; }
+    }
+
+    [DataContract]
+    public class CancelRequestResponse
+    {
+        [DataMember(Order = 1)]
+        public ResponseStatus ResponseStatus { get; set; }
+
+        public CancelRequestResponse()
+        {
+            ResponseStatus = new ResponseStatus();
+        }
+    }
+}

--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -15,6 +15,7 @@ using ServiceStack.Logging;
 using ServiceStack.Messaging;
 using ServiceStack.Text;
 using ServiceStack.Web;
+using System.Threading;
 
 #if !(__IOS__ || SL5)
 #endif
@@ -969,6 +970,10 @@ namespace ServiceStack
             return DeleteAsync<byte[]>(requestDto.ToUrl(HttpMethods.Delete, Format));
         }
 
+        public virtual Task<TResponse> PostAsync<TResponse>(IReturn<TResponse> requestDto, CancellationToken token)
+        {
+            return asyncClient.SendAsync<TResponse>(HttpMethods.Post, GetUrl(requestDto.ToUrl(HttpMethods.Post, Format)), requestDto, token);
+        }
 
         public virtual Task<TResponse> PostAsync<TResponse>(IReturn<TResponse> requestDto)
         {

--- a/src/ServiceStack.Client/ServiceStack.Client.csproj
+++ b/src/ServiceStack.Client/ServiceStack.Client.csproj
@@ -64,6 +64,7 @@
     <Compile Include="AsyncServiceClient.cs" />
     <Compile Include="AsyncUtils.cs" />
     <Compile Include="AuthDtos.cs" />
+    <Compile Include="CancelRequestDtos.cs" />
     <Compile Include="ClientFactory.cs" />
     <Compile Include="ContentFormat.cs" />
     <Compile Include="Pcl.NameValueCollectionWrapper.cs" />

--- a/src/ServiceStack.Interfaces/Web/IHttpRequest.cs
+++ b/src/ServiceStack.Interfaces/Web/IHttpRequest.cs
@@ -3,6 +3,7 @@
 
 #if !SL5 && !XBOX
 using System;
+using System.Threading;
 
 namespace ServiceStack.Web
 {
@@ -40,6 +41,11 @@ namespace ServiceStack.Web
         /// The value of the X-Real-IP header, null if null or empty
         /// </summary>
         string XRealIp { get; }
+
+        /// <summary>
+        /// Used to cancel long-running requests
+        /// </summary>
+        CancellationToken CancelToken { get; }
     }
 }
 #endif

--- a/src/ServiceStack/Host/AspNet/AspNetRequest.cs
+++ b/src/ServiceStack/Host/AspNet/AspNetRequest.cs
@@ -10,6 +10,7 @@ using Funq;
 using ServiceStack.Logging;
 using ServiceStack.Text;
 using ServiceStack.Web;
+using System.Threading;
 
 namespace ServiceStack.Host.AspNet
 {
@@ -21,6 +22,7 @@ namespace ServiceStack.Host.AspNet
         public Container Container { get; set; }
         private readonly HttpRequestBase request;
         private readonly IHttpResponse response;
+        private readonly CancellationToken cancelToken;
         
         public AspNetRequest(HttpContextBase httpContext, string operationName = null)
             : this(httpContext, operationName, RequestAttributes.None)
@@ -52,6 +54,15 @@ namespace ServiceStack.Host.AspNet
                     if (strKey == null) continue;
                     Items[strKey] = httpContext.Items[key];
                 }
+            }
+            cancelToken = RequestCancelService.TryRegisterCancelableRequest(this);
+        }
+
+        public CancellationToken CancelToken
+        {
+            get
+            {
+                return cancelToken;
             }
         }
 

--- a/src/ServiceStack/Host/HttpListener/ListenerRequest.cs
+++ b/src/ServiceStack/Host/HttpListener/ListenerRequest.cs
@@ -11,6 +11,7 @@ using System.Web;
 using Funq;
 using ServiceStack.Text;
 using ServiceStack.Web;
+using System.Threading;
 
 namespace ServiceStack.Host.HttpListener
 {
@@ -19,6 +20,7 @@ namespace ServiceStack.Host.HttpListener
         public Container Container { get; set; }
         private readonly HttpListenerRequest request;
         private readonly IHttpResponse response;
+        private readonly CancellationToken cancelToken;
 
         public ListenerRequest(HttpListenerContext httpContext, string operationName, RequestAttributes requestAttributes)
         {
@@ -28,6 +30,12 @@ namespace ServiceStack.Host.HttpListener
             this.response = new ListenerResponse(httpContext.Response, this);
 
             this.RequestPreferences = new RequestPreferences(this);
+            cancelToken = RequestCancelService.TryRegisterCancelableRequest(this);
+        }
+
+        public CancellationToken CancelToken
+        {
+            get { return cancelToken; }
         }
 
         public HttpListenerRequest HttpRequest

--- a/src/ServiceStack/RequestCancelService.cs
+++ b/src/ServiceStack/RequestCancelService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 
@@ -12,13 +13,21 @@ namespace ServiceStack
     {
         private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> cancelationTokens = new ConcurrentDictionary<Guid, CancellationTokenSource>();
 
-        public static CancellationToken TryRegisterCancelableRequest(IHttpRequest httReq)
+        private static Guid? TryGetRequestId(IHttpRequest httReq)
         {
             Guid requestId;
             var requestIdStr = httReq.Headers.Get(CancelRequest.CancelRequestIdHeader);
             if (!string.IsNullOrWhiteSpace(requestIdStr) && Guid.TryParse(requestIdStr, out requestId))
+                return requestId;
+            return null;
+        }
+
+        public static CancellationToken TryRegisterCancelableRequest(IHttpRequest httReq)
+        {
+            Guid? requestId = TryGetRequestId(httReq);
+            if(requestId.HasValue)
             {
-                var cs = cancelationTokens.GetOrAdd(requestId, new CancellationTokenSource());
+                var cs = cancelationTokens.GetOrAdd(requestId.Value, new CancellationTokenSource());
                 return cs.Token;
             }
             return default(CancellationToken);
@@ -26,14 +35,21 @@ namespace ServiceStack
 
         public static void TryRemoveCancelableRequest(IHttpRequest httReq)
         {
-            Guid requestId;
-            var requestIdStr = httReq.Headers.Get(CancelRequest.CancelRequestIdHeader);
-            if (!string.IsNullOrWhiteSpace(requestIdStr) && Guid.TryParse(requestIdStr, out requestId))
+            Guid? requestId = TryGetRequestId(httReq);
+            if (requestId.HasValue)
             {
                 CancellationTokenSource cs;
-                if (cancelationTokens.TryRemove(requestId, out cs))
+                if (cancelationTokens.TryRemove(requestId.Value, out cs))
                     cs.Dispose();                
             }           
+        }
+
+        public static CancellationToken GetCancellationToken(IRequest req)
+        {
+            var httpReq = req as IHttpRequest;
+            if(httpReq != null)
+                return TryRegisterCancelableRequest(httpReq);
+            return default(CancellationToken);
         }
         
         public void Any(CancelRequest req)
@@ -44,6 +60,49 @@ namespace ServiceStack
                 cs.Cancel();
                 cs.Dispose();
             }
+            else
+            {
+                throw new HttpError(HttpStatusCode.ExpectationFailed, 
+                    new InvalidOperationException("Failed to cancel request id:" + req.RequestId));
+            }
         }
+    }
+
+    /*  
+     *  Another way to support cancelation without changing IHttpRequest
+     *  and its implementations. In fact we dont even need request filter, 
+     *  CancellationTokenSource will be created when and if GetCancellationToken 
+     *  is called from service
+     *  
+     *  Response filter will dispose CancellationTokenSource if it was created.
+     *  Maybe there is more efficient way to do this?
+     */
+    public class AsyncRequestCancelationFeature : IPlugin
+    {
+
+        public void Register(IAppHost appHost)
+        {
+            appHost.GlobalRequestFilters.Add(RegisterCancelationSource);
+            appHost.GlobalResponseFilters.Add(UnRegisterCancelationSource);
+        }
+       
+        private void RegisterCancelationSource(IRequest req, IResponse resp, object dto)
+        {
+            var httpReq = req as IHttpRequest;
+            if(httpReq != null)
+            {
+                RequestCancelService.TryRegisterCancelableRequest(httpReq);
+            }
+        }
+
+        private void UnRegisterCancelationSource(IRequest req, IResponse resp, object dto)
+        {
+            var httpReq = req as IHttpRequest;
+            if (httpReq != null)
+            {
+                RequestCancelService.TryRemoveCancelableRequest(httpReq);
+            }
+        }
+        
     }
 }

--- a/src/ServiceStack/RequestCancelService.cs
+++ b/src/ServiceStack/RequestCancelService.cs
@@ -1,0 +1,49 @@
+﻿using ServiceStack.Web;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace ServiceStack
+{
+    public class RequestCancelService : Service
+    {
+        private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> cancelationTokens = new ConcurrentDictionary<Guid, CancellationTokenSource>();
+
+        public static CancellationToken TryRegisterCancelableRequest(IHttpRequest httReq)
+        {
+            Guid requestId;
+            var requestIdStr = httReq.Headers.Get(CancelRequest.CancelRequestIdHeader);
+            if (!string.IsNullOrWhiteSpace(requestIdStr) && Guid.TryParse(requestIdStr, out requestId))
+            {
+                var cs = cancelationTokens.GetOrAdd(requestId, new CancellationTokenSource());
+                return cs.Token;
+            }
+            return default(CancellationToken);
+        }
+
+        public static void TryRemoveCancelableRequest(IHttpRequest httReq)
+        {
+            Guid requestId;
+            var requestIdStr = httReq.Headers.Get(CancelRequest.CancelRequestIdHeader);
+            if (!string.IsNullOrWhiteSpace(requestIdStr) && Guid.TryParse(requestIdStr, out requestId))
+            {
+                CancellationTokenSource cs;
+                if (cancelationTokens.TryRemove(requestId, out cs))
+                    cs.Dispose();                
+            }           
+        }
+        
+        public void Any(CancelRequest req)
+        {
+            CancellationTokenSource cs;
+            if (cancelationTokens.TryRemove(req.RequestId, out cs))
+            {
+                cs.Cancel();
+                cs.Dispose();
+            }
+        }
+    }
+}

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -115,6 +115,7 @@
     <Compile Include="NativeTypes\Swift\SwiftGenerator.cs" />
     <Compile Include="NativeTypes\TypeScript\TypeScriptGenerator.cs" />
     <Compile Include="NativeTypes\VbNet\VbNetGenerator.cs" />
+    <Compile Include="RequestCancelService.cs" />
     <Compile Include="ServiceStackProvider.cs" />
     <Compile Include="AsyncExtensions.cs" />
     <Compile Include="Auth\AspNetWindowsAuthProvider.cs" />

--- a/src/ServiceStack/Testing/MockHttpRequest.cs
+++ b/src/ServiceStack/Testing/MockHttpRequest.cs
@@ -168,5 +168,7 @@ namespace ServiceStack.Testing
         }
 
         public Uri UrlReferrer { get { return null; } }
+
+        public System.Threading.CancellationToken CancelToken { get { return System.Threading.CancellationToken.None; } }
     }
 }


### PR DESCRIPTION
Support long-running request  cancellation using cancellation token.
Requests that support cancellation will include request id header. CancellationService will create CancellationSource for such requests and provide tokens for other services to monitor cancelltaion, which may be invoked by client with provided route and request id.

I added CancellationToke to IHttpRequest and it's implementations. But maybe this is not such a good idea to add something that will be used only by very few requests at such a level. I tried another approach with global request/response filter which provides the same functionality. On client-side we need to provide methods receiving CancellationToke, subscribe to cancellation request and invoke CancellationService if requested.

Service
```c#
public class TestService : Service
{
    public TestRequestResponse Any(TestRequest req)
    {
        // or just var token = RequestCancelService.GetCancellationToken(this.Request);
        var httpReq = this.Request as IHttpRequest;
        if(httpReq == null) return new TestRequestResponse();
        while(true)
        {
            httpReq.CancelToken.ThrowIfCancellationRequested();
            Thread.Sleep(100);
        }
    }    
// OR
    public TestRequestResponse Any(TestRequest req)
    {
        var token = RequestCancelService.GetCancellationToken(this.Request);
        while(true)
        {
            token.ThrowIfCancellationRequested();
            Thread.Sleep(100);
        }
    }
}
```

Client
```c#
var cs = new System.Threading.CancellationTokenSource();

client.PostAsync(new TestRequest(), cs.Token);

cs.Cancel();
```
I would like to know your opinion, maybe there is better way to implement this.