### PR TITLE
Fix wrong query/index on RavenDbUserAuthRepository

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenDbUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenDbUserAuthRepository.cs
@@ -52,7 +52,7 @@ namespace ServiceStack.Authentication.RavenDb
                         Search = new[] { user.UserName, user.Email }
                     };
 
-                Index(x => x.Search, FieldIndexing.Analyzed);
+                Index(x => x.Search, FieldIndexing.NotAnalyzed);
             }
         }
 
@@ -200,7 +200,7 @@ namespace ServiceStack.Authentication.RavenDb
             {
                 var userAuth = session.Query<UserAuth_By_UserNameOrEmail.Result, UserAuth_By_UserNameOrEmail>()
                        .Customize(x => x.WaitForNonStaleResultsAsOfNow())
-                       .Search(x => x.Search, userNameOrEmail)
+                       .Where(x => x.Search.Contains(userNameOrEmail))
                        .OfType<TUserAuth>()
                        .FirstOrDefault();
 


### PR DESCRIPTION
We just had a problem where a user named "user.name" was getting logged in as "user.name-special".

The problem is that the index used in raven to find the users matching a username or email analyses the username and email, and so it splits on some characters, including '-'.

Then the .Search method is used, which is used for full text search, where we want .Where, which is exact match.

This change fixes both issues.