### PR TITLE
Add "Class" to escaped keywords for VbNetGenerator NativeTypes

### DIFF
--- a/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
+++ b/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
@@ -62,7 +62,8 @@ namespace ServiceStack.NativeTypes.VbNet
             "Then",
             "With",
             "When",
-            "Operator"
+            "Operator",
+            "Class"
         };
 
         public string GetCode(MetadataTypes metadata, IRequest request)


### PR DESCRIPTION
Found a case where we used a public property named "Class" in C#. NativeTypes generated DTOs for VB.NET are not valid due to the Class keyword not being escaped.

Corrected by adding the "Class" keyword to KeyWords hashset.