### PR TITLE
Log when errors are detected during application initialization

### DIFF
--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -156,10 +156,31 @@ namespace ServiceStack
 
             OnAfterInit();
 
-            var elapsed = DateTime.UtcNow - this.StartedAt;
-            Log.InfoFormat("Initializing Application took {0}ms", elapsed.TotalMilliseconds);
+            LogInitComplete();
 
             return this;
+        }
+
+        private void LogInitComplete()
+        {
+            var elapsed = DateTime.UtcNow - StartedAt;
+            var hasErrors = StartUpErrors.Any();
+
+            if (!hasErrors)
+            {
+                Log.InfoFormat(
+                    "Initializing Application {0} took {1}ms. No errors detected.",
+                    ServiceName,
+                    elapsed.TotalMilliseconds);
+                return;
+            }
+
+            Log.ErrorFormat(
+                "Initializing Application {0} took {1}ms. {2} error detected. {3}",
+                ServiceName,
+                elapsed.TotalMilliseconds,
+                StartUpErrors.Count,
+                StartUpErrors.ToJson());
         }
 
         public virtual List<IVirtualPathProvider> GetVirtualPathProviders()


### PR DESCRIPTION
1) Add the service name to initialization-complete message. This helps analysis when multiple logs from different processes get merged into a single stream.

2) Examine the StartupErrors collection to determine if anything went wrong during initialization.

Log.Info => when we know no errors occurred
Log.Error => when we know at least one error occurred. Also log the entire StartUpErrors collection as JSON, to help guide post-mortem analysis.