### PR TITLE
Minor fixes in AutoQuery IncludeAggregates response filter.

### DIFF
--- a/src/ServiceStack.Server/AutoQueryFeature.cs
+++ b/src/ServiceStack.Server/AutoQueryFeature.cs
@@ -255,6 +255,8 @@ namespace ServiceStack
         {
             if (string.IsNullOrEmpty(model.Include)) return;
             var q = sqlExpression.GetUntypedSqlExpression().Clone();
+            q.ClearLimits();
+            q.OrderByExpression = "";
 
             var unknown = new List<string>();
             var columns = new List<string>();
@@ -338,6 +340,11 @@ namespace ServiceStack
 
                         sb.Append(" ")
                           .Append(alias.SafeVarName());
+                    }
+                    else
+                    {
+                        sb.Append(" ")
+                          .Append(q.DialectProvider.GetQuotedName(cmd));
                     }
                 }
                 else


### PR DESCRIPTION
1) clear limits and order by - we want to calculate aggregates for hole result not just current page and Order By will just fail in MS SQL without Group By on same fields
2) generate default alias if non supplied - MS SQL returns empty name for aggregates without alias

Current tests does not fail because of SqLite, they may require adjustments.