### PR TITLE
Add CustomMethodAsync overload with url parameter to ServiceClientBase

### DIFF
--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -1032,23 +1032,23 @@ namespace ServiceStack
             return PatchAsync<byte[]>(requestDto.ToUrl(HttpMethods.Patch, Format), requestDto);
         }
 
-
         public virtual Task<TResponse> CustomMethodAsync<TResponse>(string httpVerb, IReturn<TResponse> requestDto)
         {
-            if (!HttpMethods.HasVerb(httpVerb))
-                throw new NotSupportedException("Unknown HTTP Method is not supported: " + httpVerb);
-
-            var requestBody = httpVerb.HasRequestBody() ? requestDto : null;
-            return asyncClient.SendAsync<TResponse>(httpVerb, GetUrl(requestDto.ToUrl(httpVerb, Format)), requestBody);
+            return CustomMethodAsync<TResponse>(httpVerb, requestDto.ToUrl(httpVerb, Format), requestDto);
         }
 
         public virtual Task<TResponse> CustomMethodAsync<TResponse>(string httpVerb, object requestDto)
         {
+            return CustomMethodAsync<TResponse>(httpVerb, requestDto.ToUrl(httpVerb, Format), requestDto);
+        }
+
+        public virtual Task<TResponse> CustomMethodAsync<TResponse>(string httpVerb, string relativeOrAbsoluteUrl, object request)
+        {
             if (!HttpMethods.HasVerb(httpVerb))
                 throw new NotSupportedException("Unknown HTTP Method is not supported: " + httpVerb);
 
-            var requestBody = httpVerb.HasRequestBody() ? requestDto : null;
-            return asyncClient.SendAsync<TResponse>(httpVerb, GetUrl(requestDto.ToUrl(httpVerb, Format)), requestBody);
+            var requestBody = httpVerb.HasRequestBody() ? request : null;
+            return asyncClient.SendAsync<TResponse>(httpVerb, GetUrl(relativeOrAbsoluteUrl), requestBody);
         }
 
         public virtual Task CustomMethodAsync(string httpVerb, IReturnVoid requestDto)


### PR DESCRIPTION
I added the CustomMethodAsync<TResponse>(string httpVerb, string relativeOrAbsoluteUrl, object request) to the ServiceClientBase.

I did not take the risk to add it to IRestClientAsync because I have trouble to build/tests all the sln.