### PR TITLE
Redis SPOP with count (Updated interfaces for Redis)

### DIFF
--- a/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisClient.cs
@@ -163,6 +163,7 @@ namespace ServiceStack.Redis
         void AddRangeToSet(string setId, List<string> items);
         void RemoveItemFromSet(string setId, string item);
         string PopItemFromSet(string setId);
+        List<string> PopItemsFromSet(string setId, int count);
         void MoveBetweenSets(string fromSetId, string toSetId, string item);
         long GetSetCount(string setId);
         bool SetContainsItem(string setId, string item);

--- a/src/ServiceStack.Interfaces/Redis/IRedisNativeClient.cs
+++ b/src/ServiceStack.Interfaces/Redis/IRedisNativeClient.cs
@@ -142,6 +142,7 @@ namespace ServiceStack.Redis
         long SAdd(string setId, byte[][] value);
         long SRem(string setId, byte[] value);
         byte[] SPop(string setId);
+        byte[][] SPop(string setId, int count);
         void SMove(string fromSetId, string toSetId, byte[] value);
         long SCard(string setId);
         long SIsMember(string setId, byte[] value);


### PR DESCRIPTION
Adds support for `count` parameter to [`SPOP`](http://redis.io/commands/spop) allowing multiple items to be removed from a set at random.

    SPOP key [count]

With high level equivalent method `PopItemsFromSet`.