### PR TITLE
avoid NRE when setting null value to cache

### DIFF
--- a/src/ServiceStack.Caching.Memcached/MemcachedValueWrapper.cs
+++ b/src/ServiceStack.Caching.Memcached/MemcachedValueWrapper.cs
@@ -25,6 +25,7 @@ namespace ServiceStack.Caching.Memcached
 
         public MemcachedValueWrapper(object value)
         {
+            if (value == null) return;
             ValueType = value.GetType();
             _value = value;
             JsonString = value.ToJson();


### PR DESCRIPTION
Setting null-value to ICacheClient caused NRE when using Memcached backend