### PR TITLE
Swagger ApiMemberAttribute DataType 

### DIFF
--- a/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
+++ b/src/ServiceStack.Api.Swagger/SwaggerApiService.cs
@@ -378,10 +378,16 @@ namespace ServiceStack.Api.Swagger
                 else
                 {
                     ParseModel(models, propertyType, route, verb);
+
+                    var propAttr = prop.AllAttributes<ApiMemberAttribute>().ToList();
+                    if (propAttr.Count > 0 && !string.IsNullOrEmpty(propAttr.FirstOrDefault().DataType))
+                    {
+                        modelProp.Type = propAttr.FirstOrDefault().DataType;
+                    }
                 }
-
+                
                 modelProp.Description = prop.GetDescription();
-
+                
                 if (apiDoc != null && modelProp.Description == null)
                     modelProp.Description = apiDoc.Description;
 


### PR DESCRIPTION
The problem that I was having was that the ApiMemberAttribute down the object chain inside Employee would not be picked up by swagger, such as in the example situation below.

The changes committed here add the DataType from ApiMemberAttribute if it exists.

```C#
public class SaveEmployee : IReturn<SaveEmployeeResponse>
{
       [ApiMember(IsRequired = true, ParameterType = "path", AllowMultiple = false, DataType = "int")]
        public string id { get; set; }

        [ApiMember(ParameterType = "body", IsRequired = true, AllowMultiple = false, DataType = "Employee")]
        public Employee employee { get; set; }
}

public class Employee
{
        [ApiMember(IsRequired = true, AllowMultiple = false, DataType = "int")]
        public string id { get; set; }
}
```

![image](https://cloud.githubusercontent.com/assets/13242926/8580307/f2138216-2587-11e5-87b5-8919df622de8.png)