### PR TITLE
FluentValidation: auto-fill Meta with PlaceholderValues if no CustomState provided

### DIFF
--- a/src/ServiceStack/FluentValidation/Internal/MessageFormatter.cs
+++ b/src/ServiceStack/FluentValidation/Internal/MessageFormatter.cs
@@ -9,6 +9,16 @@ namespace ServiceStack.FluentValidation.Internal
         readonly Dictionary<string, object> placeholderValues = new Dictionary<string, object>();
         object[] additionalArgs;
 
+        internal Dictionary<string, string> PlaceholderValues
+        {
+            get
+            {
+                return
+                    placeholderValues.ToDictionary(
+                        kv => new KeyValuePair<string, string>(kv.Key, kv.Value != null ? kv.Value.ToString() : null));
+            }
+        }
+
         /// <summary>
         /// Default Property Name placeholder.
         /// </summary>

--- a/src/ServiceStack/FluentValidation/Results/ValidationFailure.cs
+++ b/src/ServiceStack/FluentValidation/Results/ValidationFailure.cs
@@ -16,6 +16,8 @@
 // The latest version of this file can be found at http://www.codeplex.com/FluentValidation
 #endregion
 
+using System.Collections.Generic;
+
 namespace ServiceStack.FluentValidation.Results
 {
     using System;
@@ -64,6 +66,11 @@ namespace ServiceStack.FluentValidation.Results
         /// Custom state associated with the failure.
         /// </summary>
         public object CustomState { get; set; }
+
+        /// <summary>
+        /// Placeholder values used for string substitution when building ErrorMessage
+        /// </summary>
+        public Dictionary<string,string> PlaceholderValues { get; set; }
 
         /// <summary>
         /// Creates a textual representation of the failure.

--- a/src/ServiceStack/FluentValidation/ValidationException.cs
+++ b/src/ServiceStack/FluentValidation/ValidationException.cs
@@ -42,7 +42,7 @@ namespace ServiceStack.FluentValidation
         {
             var errors = Errors.Map(x =>
                 new ValidationErrorField(x.ErrorCode, x.PropertyName, x.ErrorMessage) {
-                    Meta = x.CustomState as Dictionary<string,string>
+                    Meta = x.CustomState as Dictionary<string,string> ?? x.PlaceholderValues
                 });
 
             var responseStatus = ResponseStatusUtils.CreateResponseStatus(typeof(ValidationException).GetOperationName(), Message, errors);

--- a/src/ServiceStack/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/ServiceStack/FluentValidation/Validators/PropertyValidator.cs
@@ -96,7 +96,10 @@ namespace ServiceStack.FluentValidation.Validators
 
             string error = context.MessageFormatter.BuildMessage(errorSource.GetString());
 
-            var failure = new ValidationFailure(context.PropertyName, error, errorCode, context.PropertyValue);
+            var failure = new ValidationFailure(context.PropertyName, error, errorCode, context.PropertyValue)
+            {
+                PlaceholderValues = context.MessageFormatter.PlaceholderValues
+            };
 
             if (CustomStateProvider != null) {
                 failure.CustomState = CustomStateProvider(context.Instance);

--- a/src/ServiceStack/ValidationResultExtensions.cs
+++ b/src/ServiceStack/ValidationResultExtensions.cs
@@ -17,7 +17,7 @@ namespace ServiceStack
             foreach (var error in result.Errors)
             {
                 validationResult.Errors.Add(new ValidationErrorField(error.ErrorCode, error.PropertyName, error.ErrorMessage, error.AttemptedValue) {
-                    Meta = error.CustomState as Dictionary<string, string>
+                    Meta = error.CustomState as Dictionary<string, string> ?? error.PlaceholderValues
                 });
             }
 

--- a/tests/ServiceStack.Common.Tests/FluentValidation/ErrorCodeTests.cs
+++ b/tests/ServiceStack.Common.Tests/FluentValidation/ErrorCodeTests.cs
@@ -121,6 +121,12 @@ namespace ServiceStack.Common.Tests.FluentValidation
         }
 
         [Test]
+        public void LengthContainsPlaceholders()
+        {
+            Assert.IsTrue(Result.Errors.Where(f => f.ErrorCode == ValidationErrors.Length).Any(f => f.PlaceholderValues.ContainsKey("MinLength")));
+        }
+
+        [Test]
         public void LessThan()
         {
             Assert.IsTrue(Result.Errors.Any(f => f.ErrorCode == ValidationErrors.LessThan));


### PR DESCRIPTION
Automatically fills Meta with PlaceholderValues if no CustomState
provided for the rule.
The PlaceholderValues is a dict used internally by FV to build
ErrorMessage

There is no need to use ``WithState`` for built-in validators