### PR TITLE
Don't create SessionId's with Url unfriendly chars

### DIFF
--- a/src/ServiceStack.ServiceInterface/SessionExtensions.cs
+++ b/src/ServiceStack.ServiceInterface/SessionExtensions.cs
@@ -72,11 +72,27 @@ namespace ServiceStack.ServiceInterface
         }
 
         static readonly RandomNumberGenerator randgen = new RNGCryptoServiceProvider();
-        internal static string CreateRandomSessionId()
+        public static string CreateRandomSessionId()
         {
-            var data = new byte[15];
-            randgen.GetBytes(data);
-            return Convert.ToBase64String(data);
+            string base64Id;
+            do
+            {
+                base64Id = CreateRandomBase64Id();
+            } while( IsBase64UrlFriendly( base64Id ) );
+            return base64Id;
+        }
+
+        public static string CreateRandomBase64Id()
+        {
+            var data = new byte[ 15 ];
+            randgen.GetBytes( data );
+            return Convert.ToBase64String( data );
+        }
+
+        static readonly char[] UrlUnsafeBase64Chars = new[] { '+', '/' };
+        public static bool IsBase64UrlFriendly( string base64 )
+        {
+            return base64.IndexOfAny( UrlUnsafeBase64Chars ) >= 0;
         }
 
         public static string CreatePermanentSessionId(this IHttpResponse res, IHttpRequest req)

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -194,6 +194,7 @@
     <Compile Include="ServiceClient.Web\ServiceClientBaseTester.cs" />
     <Compile Include="ServiceClient.Web\ServiceClientBaseTests.cs" />
     <Compile Include="ServiceClient.Web\UrlExtensionsTests.cs" />
+    <Compile Include="SessionExtensionTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
     <Compile Include="StringExtensionTests.cs" />
     <Compile Include="ReflectionUtilTests.cs" />

--- a/tests/ServiceStack.Common.Tests/SessionExtensionTests.cs
+++ b/tests/ServiceStack.Common.Tests/SessionExtensionTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+using ServiceStack.ServiceInterface;
+
+namespace ServiceStack.Common.Tests
+{
+    [TestFixture]
+    public class SessionExtensionTests
+    {
+        [Test]
+        public void Does_CreateRandomSessionId_without_url_unfriendly_chars()
+        {
+            1000.Times( i =>
+            {
+                var sessionId = SessionExtensions.CreateRandomSessionId();
+                Assert.That( sessionId, Is.Not.StringContaining( "+" ) );
+                Assert.That( sessionId, Is.Not.StringContaining( "/" ) );
+            } );
+        }
+
+        [Test]
+        public void CreateRandomBase64Id_contains_url_unfriendly_chars()
+        {
+            Assert.Throws<ArgumentException>( () =>
+                1000.Times( i =>
+                {
+                    var sessionId = SessionExtensions.CreateRandomBase64Id();
+                    if( sessionId.ContainsAny( "+", "-" ) )
+                        throw new ArgumentException( "Url Unfriendly Chars found" );
+                } ) );
+        }
+    }
+}


### PR DESCRIPTION
Merging v4 fix to the v3 branch for unfriendly url chars in the
sessionid.