### PR TITLE
Postman responses can't be null

### DIFF
--- a/src/ServiceStack/PostmanFeature.cs
+++ b/src/ServiceStack/PostmanFeature.cs
@@ -72,6 +72,11 @@ namespace ServiceStack
 
     public class PostmanRequest
     {
+        public PostmanRequest()
+        {
+            responses = new List<string>();
+        }
+        
         public string collectionId { get; set; }
         public string id { get; set; }
         public string name { get; set; }


### PR DESCRIPTION
From a support email, Postman expects the "responses" to be an empty array if empty, but never "null" or the import collection in the app will throw an error.
This prevents the responses property to be null and if empty, it will output an empty array instead.