### PR TITLE
proposing an annotation to indicate that on insert, the tagged proper…

### DIFF
--- a/src/ServiceStack.Interfaces/DataAnnotations/InsertDatabaseUtcAttribute.cs
+++ b/src/ServiceStack.Interfaces/DataAnnotations/InsertDatabaseUtcAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ServiceStack.DataAnnotations
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class InsertDatabaseUtcAttribute : AttributeBase
+    {
+    }
+}

--- a/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
+++ b/src/ServiceStack.Interfaces/ServiceStack.Interfaces.csproj
@@ -91,6 +91,7 @@
     <Compile Include="DataAnnotations\IgnoreAttribute.cs" />
     <Compile Include="DataAnnotations\PrimaryKeyAttribute.cs" />
     <Compile Include="DataAnnotations\RequiredAttribute.cs" />
+    <Compile Include="DataAnnotations\InsertDatabaseUtcAttribute.cs" />
     <Compile Include="DataAnnotations\RowVersionAttribute.cs" />
     <Compile Include="DataAnnotations\SchemaAttribute.cs" />
     <Compile Include="DataAnnotations\SequenceAttribute.cs" />


### PR DESCRIPTION
…ty is always set to UTC from database server
the attribute will indicate to ormlite to generate insert statement with embedded database utc function for the property, instead of using the property value (if any) .  for example, for an entity like
```
public class Test
        {
            [PrimaryKey]
            public int Id
            {
                get;
                set;
            }            
            [InsertDatabaseUtcAttribute]
            public DateTime CreatedTimeUtc
            {
                get;
                set;
            }
        }
```
the insert statement would be
```
oracle- insert into Test (Id, CreatedTimeUtc) values (1, sys_extract_utc(systimestamp))
sqlserver - insert into Test (Id, CreatedTimeUtc) values (1, SYSUTCDATETIME())
mysql - insert into Test (Id, CreatedTimeUtc) values (1, UTC_TIMESTAMP())
```
etc

please let me know what you think, thanks