### PR TITLE
Propose serializing directly into compression stream when making compressed result

### DIFF
--- a/src/ServiceStack.Client/Support/NetDeflateProvider.cs
+++ b/src/ServiceStack.Client/Support/NetDeflateProvider.cs
@@ -34,6 +34,10 @@ namespace ServiceStack.Support
             }
         }
 
+        public Stream GetDeflateStream(Stream outputStream)
+        {
+            return new DeflateStream(outputStream, CompressionMode.Compress);
+        }
     }
 }
 #endif

--- a/src/ServiceStack.Client/Support/NetGZipProvider.cs
+++ b/src/ServiceStack.Client/Support/NetGZipProvider.cs
@@ -32,6 +32,11 @@ namespace ServiceStack.Support
                 return Encoding.UTF8.GetString(utf8Bytes, 0, utf8Bytes.Length);
             }
         }
+
+        public Stream GetGZipCompressionStream(Stream outputStream)
+        {
+            return new GZipStream(outputStream, CompressionMode.Compress);
+        }
     }
 }
 #endif

--- a/src/ServiceStack.Interfaces/Caching/IDeflateProvider.cs
+++ b/src/ServiceStack.Interfaces/Caching/IDeflateProvider.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace ServiceStack.Caching
 {
     public interface IDeflateProvider
@@ -5,5 +7,7 @@ namespace ServiceStack.Caching
         byte[] Deflate(string text);
 
         string Inflate(byte[] gzBuffer);
+
+        Stream GetDeflateStream(Stream outputStream);
     }
 }

--- a/src/ServiceStack.Interfaces/Caching/IGZipProvider.cs
+++ b/src/ServiceStack.Interfaces/Caching/IGZipProvider.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace ServiceStack.Caching
 {
     public interface IGZipProvider
@@ -5,5 +7,7 @@ namespace ServiceStack.Caching
         byte[] GZip(string text);
 
         string GUnzip(byte[] gzBuffer);
+
+        Stream GetGZipCompressionStream(Stream outputStream);
     }
 }


### PR DESCRIPTION
Avoid storing the uncompressed response as a string in memory; serialize into a GZip/Deflate stream directly. We have implemented this in a custom service runner for very large responses (hundreds of MB uncompressed) that compress well for a much healthier memory footprint. 

Please let me know what you think. Thanks.