### PR TITLE
Fixed bug regarding unauthorised errors returning 302 instead of 401 when HtmlRedirect is null

### DIFF
--- a/src/.vs/config/applicationhost.config
+++ b/src/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="ServiceStack.WebHost.IntegrationTests" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.WebHost.IntegrationTests" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.WebHost.IntegrationTests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:50000:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="ServiceStack.RazorHostTests" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.RazorHostTests" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.RazorHostTests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:58772:localhost" />
@@ -179,7 +179,7 @@
             </site>
             <site name="RazorRockstars.Web" id="4">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\RazorRockstars.Web" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\RazorRockstars.Web" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:1338:localhost" />
@@ -187,7 +187,7 @@
             </site>
             <site name="ServiceStack.Razor.Tests" id="5">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.Razor.Tests" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.Razor.Tests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8181:localhost" />
@@ -195,7 +195,7 @@
             </site>
             <site name="ServiceStack.AuthWeb.Tests" id="6">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.AuthWeb.Tests" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.AuthWeb.Tests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:11001:localhost" />
@@ -203,7 +203,7 @@
             </site>
             <site name="CheckWeb" id="7">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\CheckWeb" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\CheckWeb" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:55799:localhost" />
@@ -211,7 +211,7 @@
             </site>
             <site name="CheckMvc" id="8">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\CheckMvc" />
+                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\CheckMvc" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:49435:localhost" />

--- a/src/.vs/config/applicationhost.config
+++ b/src/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="ServiceStack.WebHost.IntegrationTests" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.WebHost.IntegrationTests" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.WebHost.IntegrationTests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:50000:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="ServiceStack.RazorHostTests" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.RazorHostTests" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.RazorHostTests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:58772:localhost" />
@@ -179,7 +179,7 @@
             </site>
             <site name="RazorRockstars.Web" id="4">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\RazorRockstars.Web" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\RazorRockstars.Web" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:1338:localhost" />
@@ -187,7 +187,7 @@
             </site>
             <site name="ServiceStack.Razor.Tests" id="5">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.Razor.Tests" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.Razor.Tests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8181:localhost" />
@@ -195,7 +195,7 @@
             </site>
             <site name="ServiceStack.AuthWeb.Tests" id="6">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\ServiceStack.AuthWeb.Tests" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\ServiceStack.AuthWeb.Tests" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:11001:localhost" />
@@ -203,7 +203,7 @@
             </site>
             <site name="CheckWeb" id="7">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\CheckWeb" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\CheckWeb" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:55799:localhost" />
@@ -211,7 +211,7 @@
             </site>
             <site name="CheckMvc" id="8">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\src\ServiceStack\tests\CheckMvc" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\jmk\Documents\Github\ServiceStack\tests\CheckMvc" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:49435:localhost" />

--- a/src/ServiceStack/AspNet/ServiceStackPage.cs
+++ b/src/ServiceStack/AspNet/ServiceStackPage.cs
@@ -24,7 +24,7 @@ namespace ServiceStack.AspNet
         /// </summary>
         public virtual string UnauthorizedRedirectUrl
         {
-            get { return HostContext.GetPlugin<AuthFeature>().GetHtmlRedirect() + "?redirect={0}#f=Unauthorized"; }
+            get { return HostContext.GetPlugin<AuthFeature>().GetHtmlRedirect(); }
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace ServiceStack.AspNet
         /// </summary>
         public virtual string ForbiddenRedirectUrl
         {
-            get { return HostContext.GetPlugin<AuthFeature>().GetHtmlRedirect() + "?redirect={0}#f=Forbidden"; }
+            get { return HostContext.GetPlugin<AuthFeature>().GetHtmlRedirect(); }
         }
 
         protected virtual void ServiceStack_PreLoad(object sender, EventArgs e)
@@ -146,10 +146,6 @@ namespace ServiceStack.AspNet
         {
             return ServiceStackProvider.SessionAs<TUserSession>();
         }
-        protected virtual void SaveSession(IAuthSession session, TimeSpan? expiresIn = null)
-        {
-            ServiceStackProvider.Request.SaveSession(session, expiresIn);
-        }
         public virtual void ClearSession()
         {
             ServiceStackProvider.ClearSession();
@@ -174,11 +170,6 @@ namespace ServiceStack.AspNet
                 serviceStackProvider = null;
             }
 
-            EndServiceStackRequest();
-        }
-
-        public virtual void EndServiceStackRequest()
-        {
             HostContext.AppHost.OnEndRequest(ServiceStackRequest);
         }
     }


### PR DESCRIPTION
As discussed [here](https://github.com/ServiceStack/Issues/issues/363)