### PR TITLE
Authenticate override for Instagram no longer needed

### DIFF
--- a/src/ServiceStack.Authentication.OAuth2/InstagramOAuth2Provider.cs
+++ b/src/ServiceStack.Authentication.OAuth2/InstagramOAuth2Provider.cs
@@ -33,81 +33,8 @@ namespace ServiceStack.Authentication.OAuth2
                     "basic"
                 };
             }
-        }
-
-        public override object Authenticate(IServiceBase authService, IAuthSession session, Authenticate request)
-        {
-            var tokens = this.Init(authService, ref session, request);
-
-            var authServer = new AuthorizationServerDescription { AuthorizationEndpoint = new Uri(this.AuthorizeUrl), TokenEndpoint = new Uri(this.AccessTokenUrl) };
-            var authClient = new WebServerClient(authServer, this.ConsumerKey)
-            {
-                ClientCredentialApplicator = ClientCredentialApplicator.PostParameter(this.ConsumerSecret),
-            };
-
-            /*
-             * Because we are exceeding the default max depth (2) we need to increase the quota. 
-             * http://stackoverflow.com/questions/14691358/how-do-i-set-jsonreaderquotas-property-on-the-dotnetopenauth-oauth2clientchan
-             * */
-            authClient.JsonReaderQuotas.MaxDepth = 10;
-
-            var authState = authClient.ProcessUserAuthorization();
-            if (authState == null)
-            {
-                try
-                {
-                    var authReq = authClient.PrepareRequestUserAuthorization(this.Scopes, new Uri(this.CallbackUrl));
-                    var authContentType = authReq.Headers[HttpHeaders.ContentType];
-                    var httpResult = new HttpResult(authReq.ResponseStream, authContentType) { StatusCode = authReq.Status, StatusDescription = "Moved Temporarily" };
-                    foreach (string header in authReq.Headers)
-                    {
-                        httpResult.Headers[header] = authReq.Headers[header];
-                    }
-
-                    foreach (string name in authReq.Cookies)
-                    {
-                        var cookie = authReq.Cookies[name];
-
-                        if (cookie != null)
-                        {
-                            httpResult.SetSessionCookie(name, cookie.Value, cookie.Path);
-                        }
-                    }
-
-                    authService.SaveSession(session, this.SessionExpiry);
-                    return httpResult;
-                }
-                catch (ProtocolException ex)
-                {
-                    Log.Error("Failed to login to {0}".Fmt(this.Provider), ex);
-                    return authService.Redirect(session.ReferrerUrl.AddHashParam("f", "Unknown"));
-                }
-            }
-
-            var accessToken = authState.AccessToken;
-            if (accessToken != null)
-            {
-                try
-                {
-                    tokens.AccessToken = accessToken;
-                    tokens.RefreshToken = authState.RefreshToken;
-                    tokens.RefreshTokenExpiry = authState.AccessTokenExpirationUtc;
-                    session.IsAuthenticated = true;
-                    var authInfo = this.CreateAuthInfo(accessToken);
-                    this.OnAuthenticated(authService, session, tokens, authInfo);
-                    return authService.Redirect(session.ReferrerUrl.AddHashParam("s", "1"));
-                }
-                catch (WebException we)
-                {
-                    var statusCode = ((HttpWebResponse)we.Response).StatusCode;
-                    if (statusCode == HttpStatusCode.BadRequest)
-                    {
-                        return authService.Redirect(session.ReferrerUrl.AddHashParam("f", "AccessTokenFailed"));
-                    }
-                }
-            }
-
-            return authService.Redirect(session.ReferrerUrl.AddHashParam("f", "RequestTokenFailed"));
+            
+            this.AuthClientFilter += authClient => authClient.JsonReaderQuotas.MaxDepth = 10;
         }
 
         protected override Dictionary<string, string> CreateAuthInfo(string accessToken)


### PR DESCRIPTION
A recent change in Authenticate handled the return value of OnAuthenticated as the return value, but that behaviour was missing on this provider and broke a particular flow on our app.

A quick comparisson between the base provider and this one seemed to show that the only relevant difference could be handled by AuthClientFilter.

I'm not 100% sure on this, but thought it's easier to show the change this way.