### PR TITLE
Proposing an extension to Default attribute

### DIFF
--- a/src/ServiceStack.Interfaces/DataAnnotations/DefaultAttribute.cs
+++ b/src/ServiceStack.Interfaces/DataAnnotations/DefaultAttribute.cs
@@ -11,8 +11,11 @@ namespace ServiceStack.DataAnnotations
         public Type DefaultType { get; set; }
         public string DefaultValue { get; set; }
 
+        public bool UseOnUpdate { get; set; }
+
         public DefaultAttribute(int intValue)
         {
+            this.UseOnUpdate = false;
             this.IntValue = intValue;
             this.DefaultType = typeof(int);
             this.DefaultValue = this.IntValue.ToString();
@@ -20,6 +23,7 @@ namespace ServiceStack.DataAnnotations
 
         public DefaultAttribute(double doubleValue)
         {
+            this.UseOnUpdate = false;
             this.DoubleValue = doubleValue;
             this.DefaultType = typeof(double);
             this.DefaultValue = doubleValue.ToString();
@@ -27,12 +31,14 @@ namespace ServiceStack.DataAnnotations
 
         public DefaultAttribute(string defaultValue)
         {
+            this.UseOnUpdate = false;
             this.DefaultType = typeof(string);
             this.DefaultValue = defaultValue;
         }
 
         public DefaultAttribute(Type defaultType, string defaultValue)
         {
+            this.UseOnUpdate = false;
             this.DefaultValue = defaultValue;
             this.DefaultType = defaultType;
         }


### PR DESCRIPTION
Rationale: When using the Default attribute, especially with arguments such
as OrmLiteVariables.SystemUtc, it is frequently true that you want the default
value set on an update. Currently the only way to do that in OrmLite is to
use custom SQL.

You may remember https://github.com/ServiceStack/ServiceStack/pull/1005 which
you rejected in favor of the Default attribute. So we are using the Default
attribute and finding that it needs update functionality. Hence this PR and if
you approve, the actual work to implement it in OrmLite.

The "UseOnUpdate=true" extension would be implemented by each dialect provider
by either generating SQL to set the column value on an update operation or by
creating a trigger which does it. For an UpdateOnly operation, any UseOnUpdate
columns would only be updated if the onlyFields expression includes them. For
an UpdateNonDefaults operation UseOnUpdate columns would not be updated.