### PR TITLE
Suggestion for generated help message

### DIFF
--- a/src/ServiceStack/LocalizedStrings.cs
+++ b/src/ServiceStack/LocalizedStrings.cs
@@ -65,4 +65,10 @@
         public static string ConstructorNotFoundForType = "Constructor not found for Type '{0}'";
         public static string ServiceNotFoundForType = "Service not found for Type '{0}'";
     }
+
+    public static class HelpMessages
+    {
+        public static string NativeTypesDtoOptionsTip =
+            "To override a DTO option, remove \"{0}\" prefix before updating.";
+    }
 }

--- a/src/ServiceStack/NativeTypes/CSharp/CSharpGenerator.cs
+++ b/src/ServiceStack/NativeTypes/CSharp/CSharpGenerator.cs
@@ -57,6 +57,7 @@ namespace ServiceStack.NativeTypes.CSharp
             sb.AppendLine("/* Options:");
             sb.AppendLine("Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T"," ")));
             sb.AppendLine("Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("//")));
             sb.AppendLine("BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine();
             sb.AppendLine("{0}GlobalNamespace: {1}".Fmt(defaultValue("GlobalNamespace"), Config.GlobalNamespace));

--- a/src/ServiceStack/NativeTypes/FSharp/FSharpGenerator.cs
+++ b/src/ServiceStack/NativeTypes/FSharp/FSharpGenerator.cs
@@ -43,6 +43,7 @@ namespace ServiceStack.NativeTypes.FSharp
             sb.AppendLine("(* Options:");
             sb.AppendLine("Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T", " ")));
             sb.AppendLine("Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("//")));
             sb.AppendLine("BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine();
             sb.AppendLine("{0}GlobalNamespace: {1}".Fmt(defaultValue("GlobalNamespace"), Config.GlobalNamespace));

--- a/src/ServiceStack/NativeTypes/Java/JavaGenerator.cs
+++ b/src/ServiceStack/NativeTypes/Java/JavaGenerator.cs
@@ -107,6 +107,7 @@ namespace ServiceStack.NativeTypes.Java
             sb.AppendLine("/* Options:");
             sb.AppendLine("Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T", " ")));
             sb.AppendLine("Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("//")));
             sb.AppendLine("BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine();
             sb.AppendLine("{0}Package: {1}".Fmt(defaultValue("Package"), Config.Package));

--- a/src/ServiceStack/NativeTypes/Swift/SwiftGenerator.cs
+++ b/src/ServiceStack/NativeTypes/Swift/SwiftGenerator.cs
@@ -70,6 +70,7 @@ namespace ServiceStack.NativeTypes.Swift
             sb.AppendLine("Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T", " ")));
             sb.AppendLine("SwiftVersion: 2.0");
             sb.AppendLine("Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("//")));
             sb.AppendLine("BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine();
 

--- a/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -67,6 +67,7 @@ namespace ServiceStack.NativeTypes.TypeScript
             sb.AppendLine("/* Options:");
             sb.AppendLine("Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T", " ")));
             sb.AppendLine("Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("//")));
             sb.AppendLine("BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine();
             sb.AppendLine("{0}GlobalNamespace: {1}".Fmt(defaultValue("GlobalNamespace"), Config.GlobalNamespace));

--- a/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
+++ b/src/ServiceStack/NativeTypes/VbNet/VbNetGenerator.cs
@@ -90,6 +90,7 @@ namespace ServiceStack.NativeTypes.VbNet
             sb.AppendLine("' Options:");
             sb.AppendLine("'Date: {0}".Fmt(DateTime.Now.ToString("s").Replace("T", " ")));
             sb.AppendLine("'Version: {0}".Fmt(Env.ServiceStackVersion));
+            sb.AppendLine("'Tip: {0}".Fmt(HelpMessages.NativeTypesDtoOptionsTip.Fmt("''")));
             sb.AppendLine("'BaseUrl: {0}".Fmt(Config.BaseUrl));
             sb.AppendLine("'");
             sb.AppendLine("{0}GlobalNamespace: {1}".Fmt(defaultValue("GlobalNamespace"), Config.GlobalNamespace));


### PR DESCRIPTION
Added a `Tip` to generated native types to help devs with convention of overriding DTO options by removing comment prefix.

Idea from [SSVS raised issue](https://github.com/ServiceStack/ServiceStackVS/issues/21).

Thoughts?