### PR TITLE
Change ResponseStatus type to ResponseStatus?

### DIFF
--- a/src/ServiceStack/NativeTypes/Kotlin/KotlinGenerator.cs
+++ b/src/ServiceStack/NativeTypes/Kotlin/KotlinGenerator.cs
@@ -433,7 +433,7 @@ namespace ServiceStack.NativeTypes.Kotlin
                 if (wasAdded) sb.AppendLine();
 
                 AppendDataMember(sb, null, dataMemberIndex++);
-                sb.AppendLine("var {0}:ResponseStatus{1}".Fmt(typeof(ResponseStatus).Name.PropertyStyle(), defaultValue));
+                sb.AppendLine("var {0}:ResponseStatus?{1}".Fmt(typeof(ResponseStatus).Name.PropertyStyle(), defaultValue));
             }
         }
         


### PR DESCRIPTION
For null assignment. Only affects classes without ResponseStatus already declared in response and `AddResponseStatus: True` in options.