### PR TITLE
session.UserName -> session.UserAuthName

### DIFF
--- a/src/ServiceStack/Auth/AuthProvider.cs
+++ b/src/ServiceStack/Auth/AuthProvider.cs
@@ -294,7 +294,7 @@ namespace ServiceStack.Auth
             }
             else
             {
-                if (!userName.EqualsIgnoreCase(session.UserName))
+                if (!userName.EqualsIgnoreCase(session.UserAuthName))
                     return false;
             }
             return true;


### PR DESCRIPTION
public override bool IsAuthorized(IAuthSession session, IAuthTokens tokens, Authenticate request = null)
contains : return !StringExtensions.IsNullOrEmpty(session.UserAuthName);
(before in callstack)
So, we have to compare UserAuthName in this method, cause sometimes session.UserName is null.