### PR TITLE
Return all request binding errors with serialization exception

### DIFF
--- a/src/ServiceStack.Client/Serialization/StringMapTypeDeserializer.cs
+++ b/src/ServiceStack.Client/Serialization/StringMapTypeDeserializer.cs
@@ -82,16 +82,18 @@ namespace ServiceStack.Serialization
 
         public object PopulateFromMap(object instance, IDictionary<string, string> keyValuePairs, List<string> ignoredWarningsOnPropertyNames = null)
         {
+            var errors = new List<RequestBindingError>();
+
             string propertyName = null;
             string propertyTextValue = null;
             PropertySerializerEntry propertySerializerEntry = null;
 
-            try
-            {
-                if (instance == null)
-                    instance = type.CreateInstance();
+            if (instance == null)
+                instance = type.CreateInstance();
 
-                foreach (var pair in keyValuePairs.Where(x => !string.IsNullOrEmpty(x.Value)))
+            foreach (var pair in keyValuePairs.Where(x => !string.IsNullOrEmpty(x.Value)))
+            {
+                try
                 {
                     propertyName = pair.Key;
                     propertyTextValue = pair.Value;
@@ -110,7 +112,8 @@ namespace ServiceStack.Serialization
                         }
 
                         var ignoredProperty = propertyName.ToLowerInvariant();
-                        if (ignoredWarningsOnPropertyNames == null || !ignoredWarningsOnPropertyNames.Contains(ignoredProperty))
+                        if (ignoredWarningsOnPropertyNames == null ||
+                            !ignoredWarningsOnPropertyNames.Contains(ignoredProperty))
                         {
                             Log.WarnFormat("Property '{0}' does not exist on type '{1}'", ignoredProperty, type.FullName);
                         }
@@ -119,11 +122,12 @@ namespace ServiceStack.Serialization
 
                     if (propertySerializerEntry.PropertySetFn == null)
                     {
-                        Log.WarnFormat("Could not set value of read-only property '{0}' on type '{1}'", propertyName, type.FullName);
+                        Log.WarnFormat("Could not set value of read-only property '{0}' on type '{1}'", propertyName,
+                                       type.FullName);
                         continue;
                     }
 
-                    if (propertySerializerEntry.PropertyType == typeof(bool))
+                    if (propertySerializerEntry.PropertyType == typeof (bool))
                     {
                         //InputExtensions.cs#530 MVC Checkbox helper emits extra hidden input field, generating 2 values, first is the real value
                         propertyTextValue = propertyTextValue.SplitOnFirst(',').First();
@@ -138,27 +142,43 @@ namespace ServiceStack.Serialization
                     }
                     propertySerializerEntry.PropertySetFn(instance, value);
                 }
-                return instance;
+                catch (Exception ex)
+                {
+                    var error = new RequestBindingError();
+
+                    if (propertyName != null)
+                        error.PropertyName = propertyName;
+
+                    if (propertyTextValue != null)
+                        error.PropertyValueString = propertyTextValue;
+
+                    if (propertySerializerEntry != null && propertySerializerEntry.PropertyType != null)
+                        error.PropertyType = propertySerializerEntry.PropertyType;
+
+                    errors.Add(error);
+                }
             }
-            catch (Exception ex)
+
+            if (errors.Count > 0)
             {
-                var serializationException = new SerializationException("Unable to bind to request '{0}': {1}".Fmt(type.Name, ex.Message), ex);
-                if (propertyName != null)
-                    serializationException.Data.Add("propertyName", propertyName);
-
-                if (propertyTextValue != null)
-                    serializationException.Data.Add("propertyValueString", propertyTextValue);
-
-                if (propertySerializerEntry != null && propertySerializerEntry.PropertyType != null)
-                    serializationException.Data.Add("propertyType", propertySerializerEntry.PropertyType);
-
+                var serializationException = new SerializationException("Unable to bind to request '{0}'".Fmt(type.Name));
+                serializationException.Data.Add("errors", errors);
                 throw serializationException;
             }
+
+            return instance;
         }
 
         public object CreateFromMap(IDictionary<string, string> keyValuePairs)
         {
             return PopulateFromMap(null, keyValuePairs, null);
         }
+    }
+
+    public class RequestBindingError
+    {
+        public string PropertyName { get; set; }
+        public string PropertyValueString { get; set; }
+        public Type PropertyType { get; set; }
     }
 }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/CustomValidationErrorTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/CustomValidationErrorTests.cs
@@ -63,6 +63,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
     public class ErrorRequestBinding : IReturn<ErrorRequestBinding>
     {
         public int Int { get; set; }
+        public decimal Decimal { get; set; }
     }
 
     public class TestRequestBindingService : Service
@@ -113,18 +114,23 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             var client = new JsonServiceClient(Config.ServiceStackBaseUri);
             try
             {
-                var response = client.Get<ErrorRequestBinding>("/errorrequestbinding?Int=string");
+                var response = client.Get<ErrorRequestBinding>("/errorrequestbinding?Int=string&Decimal=string");
                 Assert.Fail("Should throw");
             }
             catch (WebServiceException ex)
             {
                 Assert.That(ex.ResponseStatus.Message,
-                    Is.EqualTo("Unable to bind to request 'ErrorRequestBinding': Input string was not in a correct format."));
+                    Is.EqualTo("Unable to bind to request 'ErrorRequestBinding'"));
 
-                var fieldError = ex.GetFieldErrors()[0];
-                Assert.That(fieldError.FieldName, Is.EqualTo("Int"));
-                Assert.That(fieldError.ErrorCode, Is.EqualTo(typeof(SerializationException).Name));
-                Assert.That(fieldError.Message, Is.EqualTo("'string' is an Invalid value for 'Int'"));
+                var intFieldError = ex.GetFieldErrors()[0];
+                Assert.That(intFieldError.FieldName, Is.EqualTo("Int"));
+                Assert.That(intFieldError.ErrorCode, Is.EqualTo(typeof(SerializationException).Name));
+                Assert.That(intFieldError.Message, Is.EqualTo("'string' is an Invalid value for 'Int'"));
+
+                var decimalFieldError = ex.GetFieldErrors()[1];
+                Assert.That(decimalFieldError.FieldName, Is.EqualTo("Decimal"));
+                Assert.That(decimalFieldError.ErrorCode, Is.EqualTo(typeof(SerializationException).Name));
+                Assert.That(decimalFieldError.Message, Is.EqualTo("'string' is an Invalid value for 'Decimal'"));
             }
         }
 
@@ -133,7 +139,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         {
             try
             {
-                var response = Config.ServiceStackBaseUri.CombineWith("/json/reply/ErrorRequestBinding?Int=string")
+                var response = Config.ServiceStackBaseUri.CombineWith("/json/reply/ErrorRequestBinding?Int=string&Decimal=string")
                     .GetJsonFromUrl();
                 Assert.Fail("Should throw");
             }
@@ -149,7 +155,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             try
             {
                 var response = Config.ServiceStackBaseUri.CombineWith("errorrequestbinding")
-                    .PostStringToUrl("Int=string", contentType: MimeTypes.FormUrlEncoded, accept: MimeTypes.Json);
+                    .PostStringToUrl("Int=string&Decimal=string", contentType: MimeTypes.FormUrlEncoded, accept: MimeTypes.Json);
                 Assert.Fail("Should throw");
             }
             catch (WebException ex)
@@ -164,7 +170,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             try
             {
                 var response = Config.ServiceStackBaseUri.CombineWith("/json/reply/ErrorRequestBinding")
-                    .PostStringToUrl("Int=string", contentType: MimeTypes.FormUrlEncoded, accept: MimeTypes.Json);
+                    .PostStringToUrl("Int=string&Decimal=string", contentType: MimeTypes.FormUrlEncoded, accept: MimeTypes.Json);
                 Assert.Fail("Should throw");
             }
             catch (WebException ex)
@@ -179,12 +185,17 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             var status = responseBody.FromJson<ErrorResponse>().ResponseStatus;
 
             Assert.That(status.Message,
-                Is.EqualTo("Unable to bind to request 'ErrorRequestBinding': Input string was not in a correct format."));
+                Is.EqualTo("Unable to bind to request 'ErrorRequestBinding'"));
 
             var fieldError = status.Errors[0];
             Assert.That(fieldError.FieldName, Is.EqualTo("Int"));
             Assert.That(fieldError.ErrorCode, Is.EqualTo(typeof (SerializationException).Name));
             Assert.That(fieldError.Message, Is.EqualTo("'string' is an Invalid value for 'Int'"));
+
+            var fieldError2 = status.Errors[1];
+            Assert.That(fieldError2.FieldName, Is.EqualTo("Decimal"));
+            Assert.That(fieldError2.ErrorCode, Is.EqualTo(typeof(SerializationException).Name));
+            Assert.That(fieldError2.Message, Is.EqualTo("'string' is an Invalid value for 'Decimal'"));
         }
     }
 


### PR DESCRIPTION
As details of the request binding error are now returned, I've extended this to return all binding errors, rather than just the first one. So if a field fails to bind the process continues to try to bind the other fields, rather than throwing. The end result is that all binding errors should be returned to the client in one go, which is particularly desirable if the errors are indicated to an interactive user for correction.

Related: https://forums.servicestack.net/t/different-binding-behavior-based-on-content-type/1681
