### PR TITLE
Update OrderedDictionary.cs

### DIFF
--- a/src/ServiceStack.Api.Swagger/Support/OrderedDictionary.cs
+++ b/src/ServiceStack.Api.Swagger/Support/OrderedDictionary.cs
@@ -403,7 +403,7 @@ namespace ServiceStack.Api.Swagger.Support
         /// <remarks>This method performs a linear search; therefore it has a cost of O(n) at worst.</remarks>
         public int IndexOfKey(TKey key)
         {
-            if (null == key)
+            if (EqualityComparer<TKey>.Default.Equals(key, default(TKey)))
                 throw new ArgumentNullException("key");
 
             for (int index = 0; index < List.Count; index++)
@@ -433,7 +433,7 @@ namespace ServiceStack.Api.Swagger.Support
         /// <returns><see langword="true"/> if the key was found and the corresponding element was removed; otherwise, <see langword="false"/></returns>
         public bool Remove(TKey key)
         {
-            if (null == key)
+            if (EqualityComparer<TKey>.Default.Equals(key, default(TKey)))
                 throw new ArgumentNullException("key");
 
             int index = IndexOfKey(key);


### PR DESCRIPTION
We are enforcing SonarQube static code analysis against our code.  It has recommended changes to the two lines I altered.  

Here is the rule we are trying to satisfy with the change.
When constraints have not been applied to restrict a generic type parameter to be a reference type, then a value type, such as a struct, could also be passed. In such cases, comparing the type parameter to null would always be false, because a struct can be empty, but never null. If a value type is truly what's expected, then the comparison should use default(). If it's not, then constraints should be added so that no value type can be passed.