### PR TITLE
Fix SSE client restart

### DIFF
--- a/src/ServiceStack.Client/ServerEventsClient.cs
+++ b/src/ServiceStack.Client/ServerEventsClient.cs
@@ -107,9 +107,7 @@ namespace ServiceStack
             this.EventStreamUri = baseUri.CombineWith("event-stream");
             this.Channels = channels;
 
-            if (Channels != null && Channels.Length > 0)
-                this.EventStreamUri = this.EventStreamUri
-                    .AddQueryParam("channel", string.Join(",", Channels));
+            this.InitializeEventStreamUri();
 
             this.ServiceClient = new JsonServiceClient(baseUri);
 
@@ -117,6 +115,13 @@ namespace ServiceStack
             this.ReceiverTypes = new List<Type>();
             this.Handlers = new Dictionary<string, ServerEventCallback>();
             this.NamedReceivers = new Dictionary<string, ServerEventCallback>();
+        }
+
+        public void InitializeEventStreamUri()
+        {
+            if (Channels != null && Channels.Length > 0)
+                this.EventStreamUri = this.EventStreamUri
+                    .AddQueryParam("channel", string.Join(",", Channels));
         }
 
         public ServerEventsClient Start()
@@ -336,6 +341,8 @@ namespace ServiceStack
                             return;
                         try
                         {
+                            //Channels may have changed
+                            InitializeEventStreamUri();
                             Start();
                         }
                         catch (Exception ex)

--- a/src/ServiceStack.Client/ServerEventsClient.cs
+++ b/src/ServiceStack.Client/ServerEventsClient.cs
@@ -117,7 +117,7 @@ namespace ServiceStack
             this.NamedReceivers = new Dictionary<string, ServerEventCallback>();
         }
 
-        public void InitializeEventStreamUri()
+        private void InitializeEventStreamUri()
         {
             if (Channels != null && Channels.Length > 0)
                 this.EventStreamUri = this.EventStreamUri

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
@@ -1117,6 +1117,28 @@ namespace ServiceStack.WebHost.Endpoints.Tests
                 Assert.That(chatMsg.Message, Is.EqualTo("msg2"));
             }
         }
+
+        [Test]
+        public async void Channels_updated_after_Restart()
+        {
+            using (var client = new ServerEventsClient(Conf.AbsoluteBaseUri, "home"))
+            {
+                Assert.That(client.EventStreamUri.EndsWith("home"));
+
+                await client.AuthenticateAsync(new Authenticate
+                {
+                    provider = CustomCredentialsAuthProvider.Name,
+                    UserName = "user",
+                    Password = "pass",
+                });
+
+                client.Start();
+                client.Channels = new[] {"Foo", "Bar"};
+                client.Restart();
+
+                Assert.That(client.EventStreamUri.EndsWith("Foo,Bar"));
+            }
+        }
     }
 
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServerEventTests.cs
@@ -1136,6 +1136,8 @@ namespace ServiceStack.WebHost.Endpoints.Tests
                 client.Channels = new[] {"Foo", "Bar"};
                 client.Restart();
 
+                Thread.Sleep(10); // Wait for SleepBackOffMultiplier to continue
+
                 Assert.That(client.EventStreamUri.EndsWith("Foo,Bar"));
             }
         }


### PR DESCRIPTION
Currently when updating `Channels` of an SSE client, restarting didn't update the `EventStreamUri`. Test and fix in PR.

I could be missing the expected flow, but fix was due to use case of:

```` csharp
var channels = new string[] { "home" };
var client = ServerEventsClient(baseUrl,channels);
client.Start();
client.Channels = new string[] { "new-channel" };
client.Restart();
// Excepted client to be listening on updated channels only.
````