### PR TITLE
Change cast of ServiceClient in SSE client

### DIFF
--- a/src/ServiceStack.Client/ServerEventsClient.cs
+++ b/src/ServiceStack.Client/ServerEventsClient.cs
@@ -131,7 +131,8 @@ namespace ServiceStack
 
             stopped = false;
             httpReq = (HttpWebRequest)WebRequest.Create(EventStreamUri);
-            httpReq.CookieContainer = ((ServiceClientBase)ServiceClient).CookieContainer; //share auth cookies
+            //share auth cookies
+            httpReq.CookieContainer = ((IHasCookieContainer) ServiceClient).CookieContainer;
             //httpReq.AllowReadStreamBuffering = false; //.NET v4.5
 
             if (EventStreamRequestFilter != null)


### PR DESCRIPTION
To support other IServiceClients that implement IHasCookieContainer, eg
JsonHttpClient.