### PR TITLE
Re-instantiate HttpClient instance after Clear

### DIFF
--- a/src/ServiceStack.HttpClient/JsonHttpClient.cs
+++ b/src/ServiceStack.HttpClient/JsonHttpClient.cs
@@ -641,7 +641,7 @@ namespace ServiceStack
         {
             CookieContainer = new CookieContainer();
             HttpClient = null;
-            GetHttpClient();
+            HttpClient = GetHttpClient();
         }
 
         public Dictionary<string, string> GetCookieValues()

--- a/src/ServiceStack.HttpClient/JsonHttpClient.cs
+++ b/src/ServiceStack.HttpClient/JsonHttpClient.cs
@@ -651,7 +651,7 @@ namespace ServiceStack
 
         public void SetCookie(string name, string value, TimeSpan? expiresIn = null)
         {
-            this.SetCookie(HttpClient.BaseAddress, name, value,
+            this.SetCookie(GetHttpClient().BaseAddress, name, value,
                 expiresIn != null ? DateTime.UtcNow.Add(expiresIn.Value) : (DateTime?)null);
         }
 


### PR DESCRIPTION
Otherwise SetCookie null refs on `HttpClient.BaseAddress`.