### PR TITLE
Updated username to reflect changes per FB Graph API

### DIFF
--- a/src/ServiceStack/Auth/FacebookAuthProvider.cs
+++ b/src/ServiceStack/Auth/FacebookAuthProvider.cs
@@ -93,7 +93,7 @@ namespace ServiceStack.Auth
                 var json = AuthHttpGateway.DownloadFacebookUserInfo(tokens.AccessTokenSecret, Fields);
                 var obj = JsonObject.Parse(json);
                 tokens.UserId = obj.Get("id");
-                tokens.UserName = obj.Get("username");
+                tokens.UserName = obj.Get("id");
                 tokens.DisplayName = obj.Get("name");
                 tokens.FirstName = obj.Get("first_name");
                 tokens.LastName = obj.Get("last_name");


### PR DESCRIPTION
With Graph API 2.0 Facebook has removed the "username" field from the user data as retrieved from "/me". The url facebook.com/id will redirect to facebook.com/username
https://developers.facebook.com/docs/apps/upgrading#upgrading_v2_0_graph_api