### PR TITLE
Instagram profile image is empty

### DIFF
--- a/src/ServiceStack.Authentication.OAuth2/InstagramOAuth2Provider.cs
+++ b/src/ServiceStack.Authentication.OAuth2/InstagramOAuth2Provider.cs
@@ -50,6 +50,7 @@ namespace ServiceStack.Authentication.OAuth2
                 { "username", data["username"] }, 
                 { "name", data["full_name"] }, 
                 { "picture", data["profile_picture"] },
+                { AuthMetadataProvider.ProfileUrlKey, data["profile_picture"] },
             };
 
             return authInfo;


### PR DESCRIPTION
When you authenticate using Instagram, the profile image is not showing up. Fixing code so that the profileUrl field gets added to items collection thereby causing the image to show up.