### PR TITLE
Fix issue handling newline in CSS minifier

### DIFF
--- a/src/ServiceStack/Html/Minifiers.css.cs
+++ b/src/ServiceStack/Html/Minifiers.css.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.Html
         public static string MinifyCss(string css)
         {
             css = Regex.Replace(css, @"[a-zA-Z]+#", "#");
-            css = Regex.Replace(css, @"[\n\r]+\s*", String.Empty);
+            css = Regex.Replace(css, @"[\n\r]+\s*", " ");
             css = Regex.Replace(css, @"\s+", " ");
             css = Regex.Replace(css, @"\s?([:,;{}])\s?", "$1");
             css = css.Replace(";}", "}");


### PR DESCRIPTION
The regular expression in the CSS minifiy doesn't work properly for newlines.

For instance,

```
#id
div.test
{
	display: none;
}
```

gets minified to

```
#iddiv.test{display:none}
```

The whitespace is removed between the #id and div.

This regex

```
css = Regex.Replace(css, @"[\n\r]+\s*", String.Empty);
```

should replace to a single space instead.

The above then minifies to:

```
#id div.test{display:none}
```


