### PR TITLE
Fix NRE for TypeScript generation

### DIFF
--- a/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -58,7 +58,7 @@ namespace ServiceStack.NativeTypes.TypeScript
 
             // Look first for shortest Namespace ending with `ServiceModel` convention, else shortest ns
             var globalNamespace = Config.GlobalNamespace
-                ?? typeNamespaces.Where(x => x.EndsWith("ServiceModel"))
+                ?? typeNamespaces.Where(x => x != null && x.EndsWith("ServiceModel"))
                     .OrderBy(x => x).FirstOrDefault()
                 ?? typeNamespaces.OrderBy(x => x).First();
 


### PR DESCRIPTION
Classes declared outside of a namespace causing an NRE when trying to generate native types.