### PR TITLE
Fix hard-coded buffer size

### DIFF
--- a/src/ServiceStack.Client/AsyncUtils.cs
+++ b/src/ServiceStack.Client/AsyncUtils.cs
@@ -108,7 +108,7 @@ namespace ServiceStack
         {
             return token.IsCancellationRequested
                 ? TaskConstants<int>.Canceled
-                : Task<int>.Factory.FromAsync(stream.BeginRead, stream.EndRead, buffer, offset, count, null);
+                : Task<int>.Factory.FromAsync(stream.BeginRead, result => stream.CanRead ? stream.EndRead(result) : 0, buffer, offset, count, null);
         }
 
         public static Task WriteAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken token)

--- a/src/ServiceStack.Client/ServerEventsClient.cs
+++ b/src/ServiceStack.Client/ServerEventsClient.cs
@@ -411,7 +411,7 @@ namespace ServiceStack
         {
             if (!stream.CanRead) return;
 
-            var task = stream.ReadAsync(buffer, 0, 2048, cancel.Token);
+            var task = stream.ReadAsync(buffer, 0, BufferSize, cancel.Token);
             task.ContinueWith(t =>
             {
                 if (cancel.IsCancellationRequested || t.IsCanceled)


### PR DESCRIPTION
The initial buffer size is 8192, but only 2048 is used because of this mistake.
The error is not critical, but need to be fixed.