### PR TITLE
Fix unobserved AggregateException

### DIFF
--- a/src/ServiceStack.Client/AsyncUtils.cs
+++ b/src/ServiceStack.Client/AsyncUtils.cs
@@ -108,7 +108,7 @@ namespace ServiceStack
         {
             return token.IsCancellationRequested
                 ? TaskConstants<int>.Canceled
-                : Task<int>.Factory.FromAsync(stream.BeginRead, stream.EndRead, buffer, offset, count, null);
+                : Task<int>.Factory.FromAsync(stream.BeginRead, result => stream.CanRead ? stream.EndRead(result) : 0, buffer, offset, count, null);
         }
 
         public static Task WriteAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken token)


### PR DESCRIPTION
Usually after reconnecting, I get the following exception:

```
System.AggregateException
A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread.

Inner exception:
Message: Cannot access a disposed object.
Object name: 'System.Net.Sockets.NetworkStream'.

Stack Trace:
   at System.Net.ConnectStream.EndRead(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
```

I have tried to write the reproducible test case, if you need another example or detailed description just let me know.
