### PR TITLE
QueueNames<T> does not respect QueuePrefix

### DIFF
--- a/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
+++ b/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
@@ -13,15 +13,15 @@ namespace ServiceStack.Messaging
 		{
 			var utf8 = new UTF8Encoding(false);
 
-			Priority = "mq:" + typeof(T).Name + ".priorityq";
-			PriorityBytes = utf8.GetBytes(Priority);
-			In = "mq:" + typeof(T).Name + ".inq";
-			InBytes = utf8.GetBytes(In);
-			Out = "mq:" + typeof(T).Name + ".outq";
-			OutBytes = utf8.GetBytes(Out);
-			Dlq = "mq:" + typeof(T).Name + ".dlq";
-			DlqBytes = utf8.GetBytes(Dlq);
-		}
+            Priority = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".priorityq");
+            PriorityBytes = utf8.GetBytes(Priority);
+            In = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".inq");
+            InBytes = utf8.GetBytes(In);
+            Out = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".outq");
+            OutBytes = utf8.GetBytes(Out);
+            Dlq = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".dlq");
+            DlqBytes = utf8.GetBytes(Dlq);
+        }
 
 		public static string Priority { get; private set; }
 		public static byte[] PriorityBytes { get; private set; }
@@ -41,14 +41,22 @@ namespace ServiceStack.Messaging
 	/// </summary>
 	public class QueueNames
 	{
-		public static string TopicIn = "mq:topic:in";
-		public static string TopicOut = "mq:topic:out";
+		public static string MqPrefix = "mq:";
+        public static string TopicIn = MqPrefix + "topic:in";
+        public static string TopicOut = MqPrefix + "topic:out";
+
 		public static string QueuePrefix = "";
 
+        public static Func<string, string, string> ResolveQueueNameFn = ResolveQueueName;
+
+        public static string ResolveQueueName(string typeName, string queueSuffix)
+        {
+            return QueuePrefix + MqPrefix + typeName + queueSuffix;
+        }
 		public static void SetQueuePrefix(string prefix)
 		{
-			TopicIn = prefix + "mq:topic:in";
-			TopicOut = prefix + "mq:topic:out";
+            TopicIn = prefix + MqPrefix + "topic:in";
+            TopicOut = prefix + MqPrefix + "topic:out";
 			QueuePrefix = prefix;
 		}
 
@@ -59,25 +67,25 @@ namespace ServiceStack.Messaging
 			this.messageType = messageType;
 		}
 
-		public string Priority
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".priorityq"; }
-		}
+        public string Priority
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".priorityq"); }
+        }
 
-		public string In
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".inq"; }
-		}
+        public string In
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".inq"); }
+        }
 
-		public string Out
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".outq"; }
-		}
+        public string Out
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".outq"); }
+        }
 
-		public string Dlq
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".dlq"; }
-		}
+        public string Dlq
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".dlq"); }
+        }
 	}
 
 }

--- a/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
+++ b/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
@@ -3,103 +3,81 @@ using System.Text;
 
 namespace ServiceStack.Messaging
 {
-    /// <summary>
-    /// Util static generic class to create unique queue names for types
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public static class QueueNames<T>
-    {
-        static QueueNames()
-        {
-            var utf8 = new UTF8Encoding(false);
+	/// <summary>
+	/// Util static generic class to create unique queue names for types
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public static class QueueNames<T>
+	{
+		static QueueNames()
+		{
+			var utf8 = new UTF8Encoding(false);
 
-            Priority = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".priorityq");
-            PriorityBytes = utf8.GetBytes(Priority);
-            In = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".inq");
-            InBytes = utf8.GetBytes(In);
-            Out = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".outq");
-            OutBytes = utf8.GetBytes(Out);
-            Dlq = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".dlq");
-            DlqBytes = utf8.GetBytes(Dlq);
-        }
+			Priority = "mq:" + typeof(T).Name + ".priorityq";
+			PriorityBytes = utf8.GetBytes(Priority);
+			In = "mq:" + typeof(T).Name + ".inq";
+			InBytes = utf8.GetBytes(In);
+			Out = "mq:" + typeof(T).Name + ".outq";
+			OutBytes = utf8.GetBytes(Out);
+			Dlq = "mq:" + typeof(T).Name + ".dlq";
+			DlqBytes = utf8.GetBytes(Dlq);
+		}
 
-        public static string Priority { get; private set; }
-        public static byte[] PriorityBytes { get; private set; }
+		public static string Priority { get; private set; }
+		public static byte[] PriorityBytes { get; private set; }
 
-        public static string In { get; private set; }
-        public static byte[] InBytes { get; private set; }
+		public static string In { get; private set; }
+		public static byte[] InBytes { get; private set; }
 
-        public static string Out { get; private set; }
-        public static byte[] OutBytes { get; private set; }
+		public static string Out { get; private set; }
+		public static byte[] OutBytes { get; private set; }
 
-        public static string Dlq { get; private set; }
-        public static byte[] DlqBytes { get; private set; }
+		public static string Dlq { get; private set; }
+		public static byte[] DlqBytes { get; private set; }
+	}
 
-        public static string[] AllQueueNames
-        {
-            get
-            {
-                return new[] {
-                    In,
-                    Priority,
-                    Out,
-                    Dlq,
-                };
-            }
-        }
-    }
+	/// <summary>
+	/// Util class to create unique queue names for runtime types
+	/// </summary>
+	public class QueueNames
+	{
+		public static string TopicIn = "mq:topic:in";
+		public static string TopicOut = "mq:topic:out";
+		public static string QueuePrefix = "";
 
-    /// <summary>
-    /// Util class to create unique queue names for runtime types
-    /// </summary>
-    public class QueueNames
-    {
-        public static string MqPrefix = "mq:";
+		public static void SetQueuePrefix(string prefix)
+		{
+			TopicIn = prefix + "mq:topic:in";
+			TopicOut = prefix + "mq:topic:out";
+			QueuePrefix = prefix;
+		}
 
-        public static string QueuePrefix = "";
-        public static string TopicIn = MqPrefix + "topic:in";
-        public static string TopicOut = MqPrefix + "topic:out";
+		private readonly Type messageType;
 
-        public static Func<string, string, string> ResolveQueueNameFn = ResolveQueueName;
+		public QueueNames(Type messageType)
+		{
+			this.messageType = messageType;
+		}
 
-        public static string ResolveQueueName(string typeName, string queueSuffix)
-        {
-            return QueuePrefix + MqPrefix + typeName + queueSuffix;
-        }
+		public string Priority
+		{
+			get { return QueuePrefix + "mq:" + messageType.Name + ".priorityq"; }
+		}
 
-        public static void SetQueuePrefix(string prefix)
-        {
-            TopicIn = prefix + MqPrefix + "topic:in";
-            TopicOut = prefix + MqPrefix + "topic:out";
-            QueuePrefix = prefix;
-        }
+		public string In
+		{
+			get { return QueuePrefix + "mq:" + messageType.Name + ".inq"; }
+		}
 
-        private readonly Type messageType;
+		public string Out
+		{
+			get { return QueuePrefix + "mq:" + messageType.Name + ".outq"; }
+		}
 
-        public QueueNames(Type messageType)
-        {
-            this.messageType = messageType;
-        }
-
-        public string Priority
-        {
-            get { return ResolveQueueNameFn(messageType.Name, ".priorityq"); }
-        }
-
-        public string In
-        {
-            get { return ResolveQueueNameFn(messageType.Name, ".inq"); }
-        }
-
-        public string Out
-        {
-            get { return ResolveQueueNameFn(messageType.Name, ".outq"); }
-        }
-
-        public string Dlq
-        {
-            get { return ResolveQueueNameFn(messageType.Name, ".dlq"); }
-        }
-    }
+		public string Dlq
+		{
+			get { return QueuePrefix + "mq:" + messageType.Name + ".dlq"; }
+		}
+	}
 
 }

--- a/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
+++ b/src/ServiceStack.Interfaces/Messaging/QueueNames.cs
@@ -3,81 +3,103 @@ using System.Text;
 
 namespace ServiceStack.Messaging
 {
-	/// <summary>
-	/// Util static generic class to create unique queue names for types
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	public static class QueueNames<T>
-	{
-		static QueueNames()
-		{
-			var utf8 = new UTF8Encoding(false);
+    /// <summary>
+    /// Util static generic class to create unique queue names for types
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public static class QueueNames<T>
+    {
+        static QueueNames()
+        {
+            var utf8 = new UTF8Encoding(false);
 
-			Priority = "mq:" + typeof(T).Name + ".priorityq";
-			PriorityBytes = utf8.GetBytes(Priority);
-			In = "mq:" + typeof(T).Name + ".inq";
-			InBytes = utf8.GetBytes(In);
-			Out = "mq:" + typeof(T).Name + ".outq";
-			OutBytes = utf8.GetBytes(Out);
-			Dlq = "mq:" + typeof(T).Name + ".dlq";
-			DlqBytes = utf8.GetBytes(Dlq);
-		}
+            Priority = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".priorityq");
+            PriorityBytes = utf8.GetBytes(Priority);
+            In = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".inq");
+            InBytes = utf8.GetBytes(In);
+            Out = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".outq");
+            OutBytes = utf8.GetBytes(Out);
+            Dlq = QueueNames.ResolveQueueNameFn(typeof(T).Name, ".dlq");
+            DlqBytes = utf8.GetBytes(Dlq);
+        }
 
-		public static string Priority { get; private set; }
-		public static byte[] PriorityBytes { get; private set; }
+        public static string Priority { get; private set; }
+        public static byte[] PriorityBytes { get; private set; }
 
-		public static string In { get; private set; }
-		public static byte[] InBytes { get; private set; }
+        public static string In { get; private set; }
+        public static byte[] InBytes { get; private set; }
 
-		public static string Out { get; private set; }
-		public static byte[] OutBytes { get; private set; }
+        public static string Out { get; private set; }
+        public static byte[] OutBytes { get; private set; }
 
-		public static string Dlq { get; private set; }
-		public static byte[] DlqBytes { get; private set; }
-	}
+        public static string Dlq { get; private set; }
+        public static byte[] DlqBytes { get; private set; }
 
-	/// <summary>
-	/// Util class to create unique queue names for runtime types
-	/// </summary>
-	public class QueueNames
-	{
-		public static string TopicIn = "mq:topic:in";
-		public static string TopicOut = "mq:topic:out";
-		public static string QueuePrefix = "";
+        public static string[] AllQueueNames
+        {
+            get
+            {
+                return new[] {
+                    In,
+                    Priority,
+                    Out,
+                    Dlq,
+                };
+            }
+        }
+    }
 
-		public static void SetQueuePrefix(string prefix)
-		{
-			TopicIn = prefix + "mq:topic:in";
-			TopicOut = prefix + "mq:topic:out";
-			QueuePrefix = prefix;
-		}
+    /// <summary>
+    /// Util class to create unique queue names for runtime types
+    /// </summary>
+    public class QueueNames
+    {
+        public static string MqPrefix = "mq:";
 
-		private readonly Type messageType;
+        public static string QueuePrefix = "";
+        public static string TopicIn = MqPrefix + "topic:in";
+        public static string TopicOut = MqPrefix + "topic:out";
 
-		public QueueNames(Type messageType)
-		{
-			this.messageType = messageType;
-		}
+        public static Func<string, string, string> ResolveQueueNameFn = ResolveQueueName;
 
-		public string Priority
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".priorityq"; }
-		}
+        public static string ResolveQueueName(string typeName, string queueSuffix)
+        {
+            return QueuePrefix + MqPrefix + typeName + queueSuffix;
+        }
 
-		public string In
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".inq"; }
-		}
+        public static void SetQueuePrefix(string prefix)
+        {
+            TopicIn = prefix + MqPrefix + "topic:in";
+            TopicOut = prefix + MqPrefix + "topic:out";
+            QueuePrefix = prefix;
+        }
 
-		public string Out
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".outq"; }
-		}
+        private readonly Type messageType;
 
-		public string Dlq
-		{
-			get { return QueuePrefix + "mq:" + messageType.Name + ".dlq"; }
-		}
-	}
+        public QueueNames(Type messageType)
+        {
+            this.messageType = messageType;
+        }
+
+        public string Priority
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".priorityq"); }
+        }
+
+        public string In
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".inq"); }
+        }
+
+        public string Out
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".outq"); }
+        }
+
+        public string Dlq
+        {
+            get { return ResolveQueueNameFn(messageType.Name, ".dlq"); }
+        }
+    }
 
 }


### PR DESCRIPTION
Here are the changes again. For some reason it's still showing spacing differences which are coming from the v4 version. If this isn't acceptable I can manually put the changes in if needed. 