### PR TITLE
Added public IHasDbTransaction interface similar to IHasDbConnection

### DIFF
--- a/src/ServiceStack.Common/Data/IHasDbConnection.cs
+++ b/src/ServiceStack.Common/Data/IHasDbConnection.cs
@@ -15,5 +15,10 @@ namespace ServiceStack.Data
     {
         IDbCommand DbCommand { get; }
     }
+
+    public interface IHasDbTransaction
+    {
+        IDbTransaction DbTransaction { get; }
+    }
 }
 #endif

--- a/src/ServiceStack.Common/MiniProfiler/Data/ProfiledCommand.cs
+++ b/src/ServiceStack.Common/MiniProfiler/Data/ProfiledCommand.cs
@@ -79,7 +79,8 @@ namespace ServiceStack.MiniProfiler.Data
             {
                 this._tran = value;
                 var awesomeTran = value as ProfiledDbTransaction;
-                _cmd.Transaction = awesomeTran?.DbTransaction as DbTransaction ?? value;
+                _cmd.Transaction = awesomeTran == null || !(awesomeTran.DbTransaction is DbTransaction) ?
+                    value : (DbTransaction)awesomeTran.DbTransaction;
             }
         }
 

--- a/src/ServiceStack.Common/MiniProfiler/Data/ProfiledCommand.cs
+++ b/src/ServiceStack.Common/MiniProfiler/Data/ProfiledCommand.cs
@@ -76,7 +76,7 @@ namespace ServiceStack.MiniProfiler.Data
             {
                 this._tran = value;
                 var awesomeTran = value as ProfiledDbTransaction;
-                _cmd.Transaction = awesomeTran == null ? value : awesomeTran.WrappedTransaction;
+                _cmd.Transaction = awesomeTran?.DbTransaction as DbTransaction ?? value;
             }
         }
 

--- a/src/ServiceStack.Common/MiniProfiler/Data/ProfiledDbTransaction.cs
+++ b/src/ServiceStack.Common/MiniProfiler/Data/ProfiledDbTransaction.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Data.Common;
 using System.Data;
+using ServiceStack.Data;
 
 #pragma warning disable 1591 // xml doc comments warnings
 
 namespace ServiceStack.MiniProfiler.Data
 {
-    public class ProfiledDbTransaction : DbTransaction
+    public class ProfiledDbTransaction : DbTransaction, IHasDbTransaction
     {
         private ProfiledConnection _conn;
         private DbTransaction _trans;
@@ -24,7 +25,7 @@ namespace ServiceStack.MiniProfiler.Data
             get { return _conn; }
         }
 
-        internal DbTransaction WrappedTransaction
+        public IDbTransaction DbTransaction
         {
             get { return _trans; }
         }


### PR DESCRIPTION
It allows getting the real transaction from a ProfiledDbTransaction in client code without Reflection hacks.

If this is OK I'll send a PR in ServiceStack.OrmLite to implement this interface in OrmLiteConnection and OrmLiteTransaction, too.