### PR TITLE
Implemented named registration for various IoC container overloads

### DIFF
--- a/src/ServiceStack/ContainerTypeExtensions.cs
+++ b/src/ServiceStack/ContainerTypeExtensions.cs
@@ -28,6 +28,25 @@ namespace ServiceStack
         }
 
         /// <summary>
+        /// Registers a named instance of type in the IoC container and
+        /// adds auto-wiring to the specified type.
+        /// </summary>
+        /// <param name="serviceType"></param>
+        /// <param name="inFunqAsType"></param>
+        public static void RegisterAutoWiredType(this Container container, string name, Type serviceType, Type inFunqAsType,
+            ReuseScope scope = ReuseScope.None)
+        {
+            if (serviceType.IsAbstract || serviceType.ContainsGenericParameters)
+                return;
+
+            var methodInfo = typeof(Container).GetMethod("RegisterAutoWiredAs", new[] { typeof(string) });
+            var registerMethodInfo = methodInfo.MakeGenericMethod(new[] { serviceType, inFunqAsType });
+
+            var registration = registerMethodInfo.Invoke(container, new[] { name }) as IRegistration;
+            registration.ReusedWithin(scope);
+        }
+
+        /// <summary>
         /// Registers the type in the IoC container and
         /// adds auto-wiring to the specified type.
         /// The reuse scope is set to none (transient).
@@ -44,6 +63,26 @@ namespace ServiceStack
             var registerMethodInfo = methodInfo.MakeGenericMethod(new[] { serviceType });
 
             var registration = registerMethodInfo.Invoke(container, TypeConstants.EmptyObjectArray) as IRegistration;
+            registration.ReusedWithin(scope);
+        }
+
+        /// <summary>
+        /// Registers the type in the IoC container and
+        /// adds auto-wiring to the specified type.
+        /// The reuse scope is set to none (transient).
+        /// </summary>
+        /// <param name="serviceTypes"></param>
+        public static void RegisterAutoWiredType(this Container container, string name, Type serviceType,
+            ReuseScope scope = ReuseScope.None)
+        {
+            //Don't try to register base service classes
+            if (serviceType.IsAbstract || serviceType.ContainsGenericParameters)
+                return;
+
+            var methodInfo = typeof(Container).GetMethod("RegisterAutoWired", new[] { typeof(string) });
+            var registerMethodInfo = methodInfo.MakeGenericMethod(new[] { serviceType });
+
+            var registration = registerMethodInfo.Invoke(container, new[] { name }) as IRegistration;
             registration.ReusedWithin(scope);
         }
 

--- a/src/ServiceStack/Funq/Container.Adapter.cs
+++ b/src/ServiceStack/Funq/Container.Adapter.cs
@@ -26,6 +26,17 @@ namespace Funq
         }
 
         /// <summary>
+        /// Register an autowired dependency
+        /// </summary>
+        /// <param name="name">Name of dependency</param>
+        /// <typeparam name="T"></typeparam>
+        public IRegistration<T> RegisterAutoWired<T>(string name)
+        {
+            var serviceFactory = GenerateAutoWireFn<T>();
+            return this.Register(name, serviceFactory);
+        }
+
+        /// <summary>
         /// Register an autowired dependency as a separate type
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -38,6 +49,18 @@ namespace Funq
         }
 
         /// <summary>
+        /// Register an autowired dependency as a separate type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public IRegistration<TAs> RegisterAutoWiredAs<T, TAs>(string name)
+            where T : TAs
+        {
+            var serviceFactory = GenerateAutoWireFn<T>();
+            Func<Container, TAs> fn = c => serviceFactory(c);
+            return this.Register(name, fn);
+        }
+
+        /// <summary>
         /// Alias for RegisterAutoWiredAs
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -45,6 +68,16 @@ namespace Funq
             where T : TAs
         {
             return this.RegisterAutoWiredAs<T, TAs>();
+        }
+
+        /// <summary>
+        /// Alias for RegisterAutoWiredAs
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public IRegistration<TAs> RegisterAs<T, TAs>(string name)
+            where T : TAs
+        {
+            return this.RegisterAutoWiredAs<T, TAs>(name);
         }
 
         /// <summary>

--- a/tests/ServiceStack.ServiceHost.Tests/IoCTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/IoCTests.cs
@@ -259,5 +259,90 @@ namespace ServiceStack.ServiceHost.Tests
             Assert.That(container.TryResolve<IFoo>(), Is.Not.Null);
             Assert.That(container.TryResolve<IBar>(), Is.Not.Null);
         }
+
+        [Test]
+        public void Can_autowire_named_instances()
+        {
+            var container = new Container();
+            container.Register<IFoo>(c => new Foo());
+            container.Register<IBar>(c => new Bar());
+            container.Register<int>(c => 100);
+
+            container.RegisterAutoWired<AutoWireService>("one");
+            container.RegisterAutoWired<AutoWireService>("two");
+
+            var one = container.ResolveNamed<AutoWireService>("one");
+            var two = container.ResolveNamed<AutoWireService>("two");
+            Assert.That(one, Is.Not.Null);
+            Assert.AreNotSame(one, two);
+        }
+        
+        [Test]
+        public void Can_autowireAs_named_instances()
+        {
+            var container = new Container();
+            container.Register<IFoo>(c => new Foo());
+            container.Register<IBar>(c => new Bar());
+            container.Register<int>(c => 100);
+
+            container.RegisterAutoWiredAs<AutoWireService, IService>("one");
+            container.RegisterAutoWiredAs<AutoWireService, IService>("two");
+
+            var one = container.ResolveNamed<IService>("one");
+            var two = container.ResolveNamed<IService>("two");
+            Assert.That(one, Is.Not.Null);
+            Assert.AreNotSame(one, two);
+        }
+
+        [Test]
+        public void Can_registerAs_named_instances()
+        {
+            var container = new Container();
+            container.Register<IFoo>(c => new Foo());
+            container.Register<IBar>(c => new Bar());
+            container.Register<int>(c => 100);
+
+            container.RegisterAs<AutoWireService, IService>("one");
+            container.RegisterAs<AutoWireService, IService>("two");
+
+            var one = container.ResolveNamed<IService>("one");
+            var two = container.ResolveNamed<IService>("two");
+            Assert.That(one, Is.Not.Null);
+            Assert.AreNotSame(one, two);
+        }
+
+        [Test]
+        public void Can_registerAutoWiredType_as_named_instance()
+        {
+            var container = new Container();
+            container.Register<IFoo>(c => new Foo());
+            container.Register<IBar>(c => new Bar());
+            container.Register<int>(c => 100);
+
+            container.RegisterAutoWiredType("one", typeof(AutoWireService), typeof(IService));
+            container.RegisterAutoWiredType("two", typeof(AutoWireService), typeof(IService));
+
+            var one = container.ResolveNamed<IService>("one");
+            var two = container.ResolveNamed<IService>("two");
+            Assert.That(one, Is.Not.Null);
+            Assert.AreNotSame(one, two);
+        }
+
+        [Test]
+        public void Can_registerAutoWiredType_named_instance()
+        {
+            var container = new Container();
+            container.Register<IFoo>(c => new Foo());
+            container.Register<IBar>(c => new Bar());
+            container.Register<int>(c => 100);
+
+            container.RegisterAutoWiredType("one", typeof(AutoWireService));
+            container.RegisterAutoWiredType("two", typeof(AutoWireService));
+
+            var one = container.ResolveNamed<AutoWireService>("one");
+            var two = container.ResolveNamed<AutoWireService>("two");
+            Assert.That(one, Is.Not.Null);
+            Assert.AreNotSame(one, two);
+        }
     }
 }


### PR DESCRIPTION
Added overloads of `RegisterAutoWiredType`, `RegisterAutoWired`, `RegisterAutoWiredAs` and `RegisterAs` to take `name` parameter to register named instance.
