### PR TITLE
Mixed case after wildcard path causes "Index was outside the bounds of the array." error

### DIFF
--- a/src/ServiceStack/ServiceHost/RestPath.cs
+++ b/src/ServiceStack/ServiceHost/RestPath.cs
@@ -421,11 +421,11 @@ namespace ServiceStack.ServiceHost
                         // hits a match for the next element in the definition (which must be a literal)
                         // It may consume 0 or more path parts
                         var stopLiteral = i == this.TotalComponentsCount - 1 ? null : this.literalsToMatch[i + 1];
-                        if (requestComponents[pathIx] != stopLiteral)
+                        if (string.Compare(requestComponents[pathIx], stopLiteral, StringComparison.OrdinalIgnoreCase) != 0)
                         {
                             var sb = new StringBuilder(value);
                             pathIx++;
-                            while (requestComponents[pathIx] != stopLiteral)
+                            while (string.Compare(requestComponents[pathIx], stopLiteral, StringComparison.OrdinalIgnoreCase) != 0)
                             {
                                 sb.Append(PathSeperatorChar + requestComponents[pathIx++]);
                             }

--- a/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/RestPathTests.cs
@@ -17,6 +17,16 @@ namespace ServiceStack.ServiceHost.Tests
         }
 
         [Test]
+        public void Can_deserialize_SimpleType_wildcard_in_middle_of_path_mixed_case()
+        {
+            var restPath = new RestPath(typeof(SimpleType), "/simple/{Name*}/MixedCase");
+            var request = restPath.CreateRequest("/simple/Hello/World/MixedCase") as SimpleType;
+
+            Assert.That(request, Is.Not.Null);
+            Assert.That(request.Name, Is.EqualTo("Hello/World"));
+        }
+
+        [Test]
         public void Can_deserialize_SimpleType_path()
         {
             var restPath = new RestPath(typeof(SimpleType), "/simple/{Name}");


### PR DESCRIPTION
The following error happens if a literal after a route wildcard is not lower case. I've changed these two sections to be case insensitive.

Example:  
Fails: /api/Sample/{Path*}/Literal
Success: /api/Sample/{Path*}/literal

Index was outside the bounds of the array.

at ServiceStack.ServiceHost.RestPath.CreateRequest(String pathInfo, Dictionary`2 queryStringAndFormData, Object fromInstance) in C:\Source\ServiceStack\src\ServiceStack\ServiceHost\RestPath.cs:line 429
   at ServiceStack.WebHost.Endpoints.RestHandler.GetRequest(IHttpRequest httpReq, IRestPath restPath) in C:\Source\ServiceStack\src\ServiceStack\WebHost.Endpoints\RestHandler.cs:line 143
   at ServiceStack.WebHost.Endpoints.RestHandler.ProcessRequest(IHttpRequest httpReq, IHttpResponse httpRes, String operationName) in C:\Source\ServiceStack\src\ServiceStack\WebHost.Endpoints\RestHandler.cs:line 93