### PR TITLE
jQuery 3.x Compatibility

### DIFF
--- a/src/ServiceStack/js/ss-utils.js
+++ b/src/ServiceStack/js/ss-utils.js
@@ -537,7 +537,7 @@
                         }, parseInt(opt.heartbeatIntervalMs) || 10000);
                     }
                     if (opt.unRegisterUrl) {
-                        $(window).unload(function () {
+                        $(window).on("unload", function () {
                             $.post(opt.unRegisterUrl, null, function (r) { });
                         });
                     }


### PR DESCRIPTION
Changed $(window).unload() to $(window).on("unload", ) for compatibility with jQuery 3.x (they've removed methods deprecated since 1.8): https://github.com/jquery/jquery/issues/2286