### PR TITLE
Fix auth session extends on second authentication

### DIFF
--- a/src/ServiceStack/Auth/AuthenticateService.cs
+++ b/src/ServiceStack/Auth/AuthenticateService.cs
@@ -278,7 +278,7 @@ namespace ServiceStack.Auth
                 if (generateNewCookies)
                 {
                     this.Request.GenerateNewSessionCookies(session);
-                    oAuthConfig.SaveSession(this, session);
+                    oAuthConfig.SaveSession(this, session, (oAuthConfig as AuthProvider)?.SessionExpiry);
                 }
             }
             return response;


### PR DESCRIPTION
This commit makes saving session with SessionExpiry when user authenticated second time while session is active. Possible IAuthProvider should have `SessionExpiry` property to access it without casting to abstract class. 

https://forums.servicestack.net/t/session-never-expires/2906