### PR TITLE
Add number to primitiveDefaultValues

### DIFF
--- a/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -68,6 +68,7 @@ namespace ServiceStack.NativeTypes.TypeScript
             {"Single", "0"},
             {"Double", "0"},
             {"Decimal", "0"},
+            {"number", 0},
             {"List", "[]"}
         };
 

--- a/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -68,7 +68,7 @@ namespace ServiceStack.NativeTypes.TypeScript
             {"Single", "0"},
             {"Double", "0"},
             {"Decimal", "0"},
-            {"number", 0},
+            {"number", "0"},
             {"List", "[]"}
         };
 


### PR DESCRIPTION
Added "number" to primitiveDefaultValues because:
1. AppendType calls options.ImplementsFn to get type info for generating the responseTypeExpression (`createResponse() { return x; }`).
2. ImplementsFn calls Type(...) to get the type name of the return object
3. `string Type(string type, string[] genericArgs)` returns from TypeAlias

When generating the type definition for IReturn<int> from the above workflow, the result was the following (invalid) syntax: `createResponse() { return new number(); }`
The result will now be this: `createResponse() { return 0; }`