### PR TITLE
add overwriteable method on authProvider for session value persistance.

### DIFF
--- a/src/ServiceStack/Auth/CredentialsAuthProvider.cs
+++ b/src/ServiceStack/Auth/CredentialsAuthProvider.cs
@@ -93,14 +93,20 @@ namespace ServiceStack.Auth
             return Authenticate(authService, session, userName, password, string.Empty);
         }
 
-        protected object Authenticate(IServiceBase authService, IAuthSession session, string userName, string password, string referrerUrl)
+        protected virtual IAuthSession ResetSessionBeforeLogin(IServiceBase authService, IAuthSession session, string userName)
         {
             if (!LoginMatchesSession(session, userName))
             {
                 authService.RemoveSession();
-                session = authService.GetSession();
+                return authService.GetSession();
             }
+            return session;
+        }
 
+        protected object Authenticate(IServiceBase authService, IAuthSession session, string userName, string password, string referrerUrl)
+        {
+            session = ResetSessionBeforeLogin(authService, session, userName);
+            
             if (TryAuthenticate(authService, userName, password))
             {
                 session.IsAuthenticated = true;


### PR DESCRIPTION
Im trying to persist an Cart Id (eCommerce platform) on user log-in.

The requirement is that the user keeps his cart when he logs in.

I save the cartId i the session when the user logs in.

But in my subclass of the CredentialsAuthProvider onAuthenticated the CartId is gone.