### PR TITLE
[netcore] System.Threading.ThreadPool package downgrade warning

### DIFF
--- a/NuGet.Core/ServiceStack.Core/ServiceStack.Core.nuspec
+++ b/NuGet.Core/ServiceStack.Core/ServiceStack.Core.nuspec
@@ -43,7 +43,7 @@
         <dependency id="System.Runtime.Serialization.Primitives" version="[4.1.1, )" />
         <dependency id="System.Collections.Specialized" version="[4.0.1, )" />
         <dependency id="System.Linq.Queryable" version="[4.0.1, )" />
-        <dependency id="System.Threading.ThreadPool" version="[4.0.1, )" />
+        <dependency id="System.Threading.ThreadPool" version="[4.0.10, )" />
         <dependency id="ServiceStack.Interfaces.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Text.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Client.Core" version="[1.0.0, )" />


### PR DESCRIPTION
When I run `dotnet restore` on **ServiceStack.Core**, I get the following warning:

_warn : Detected package downgrade: System.Threading.ThreadPool from 4.0.10 to 4.0.1_ 

So, this PR is to bump the version. I didn't investigate whether or not there was a reason for picking 4.0.1, but this was the only dependency throwing the warning, so I assumed it was a typo.