### PR TITLE
Non-session optimized implementation of wire serializer

### DIFF
--- a/src/ServiceStack.Wire/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Wire/Properties/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Service Stack LLC")]
+[assembly: AssemblyProduct("ServiceStack")]
+[assembly: AssemblyCopyright("Copyright (c) ServiceStack 2016")]
+[assembly: AssemblyTrademark("Service Stack")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0428d353-cd67-481f-877a-676e3bbcf903")]
+
+[assembly: AssemblyVersion("4.0.0.0")]

--- a/src/ServiceStack.Wire/ServiceStack.Wire.csproj
+++ b/src/ServiceStack.Wire/ServiceStack.Wire.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0428D353-CD67-481F-877A-676E3BBCF903}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceStack.Wire</RootNamespace>
+    <AssemblyName>ServiceStack.Wire</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\lib\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Wire.0.8.1\lib\net45\Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WireExtensions.cs" />
+    <Compile Include="WireFormat.cs" />
+    <Compile Include="WireServiceClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceStack.Client\ServiceStack.Client.csproj">
+      <Project>{C43F583F-ABDE-4DD4-BBE3-66322817A6AD}</Project>
+      <Name>ServiceStack.Client</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceStack\ServiceStack.csproj">
+      <Project>{680A1709-25EB-4D52-A87F-EE03FFD94BAA}</Project>
+      <Name>ServiceStack</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceStack.Wire/WireExtensions.cs
+++ b/src/ServiceStack.Wire/WireExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Service Stack LLC. All Rights Reserved.
+// License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt
+
+namespace ServiceStack.Wire
+{
+    using global::Wire;
+    using ServiceStack.Text;
+
+    public static class WireExtensions
+    {
+        private static readonly Serializer serializer = new Serializer();
+
+        public static byte[] ToWire<T>(this T obj)
+        {
+            using (var ms = MemoryStreamFactory.GetStream())
+            {
+                serializer.Serialize(obj, ms);
+                var bytes = ms.ToArray();
+                return bytes;
+            }
+        }
+
+        public static T FromWire<T>(this byte[] bytes)
+        {
+            using (var ms = MemoryStreamFactory.GetStream(bytes))
+            {
+                return serializer.Deserialize<T>(ms);
+            }
+        }
+    }
+}

--- a/src/ServiceStack.Wire/WireFormat.cs
+++ b/src/ServiceStack.Wire/WireFormat.cs
@@ -1,0 +1,71 @@
+﻿namespace ServiceStack.Wire
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using global::Wire;
+    using ServiceStack.Web;
+
+    public class WireFormat : IPlugin, IWirePlugin
+    {
+        public WireFormat()
+        {
+            serializer = new Serializer(new SerializerOptions(true, false, null, null, null));
+        }
+
+        public void Register(IAppHost appHost)
+        {
+            appHost.ContentTypes.Register(MimeTypes.Wire,
+                Serialize,
+                Deserialize);
+        }
+
+        private static Serializer serializer;
+
+        public static void Serialize(IRequest requestContext, object dto, Stream outputStream)
+        {
+            Serialize(dto, outputStream);
+        }
+
+        public static void Serialize(object dto, Stream outputStream)
+        {
+            if (dto == null) return;
+            try
+            {
+                serializer.Serialize(dto, outputStream);
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex, dto.GetType());
+            }
+        }
+
+        public static object Deserialize(Type type, Stream fromStream)
+        {
+            try
+            {
+                return serializer.Deserialize(fromStream);
+            }
+            catch (Exception ex)
+            {
+                return HandleException(ex, type);
+            }
+        }
+
+        /// <summary>
+        /// MsgPack throws an exception for empty DTO's - normalizing the behavior to 
+        /// follow other types and return an empty instance.
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static object HandleException(Exception ex, Type type)
+        {
+            if (ex is SerializationException
+                && ex.Message.Contains("does not have any serializable fields nor properties"))
+                return type.CreateInstance();
+
+            throw ex;
+        }
+    }
+}

--- a/src/ServiceStack.Wire/WireServiceClient.cs
+++ b/src/ServiceStack.Wire/WireServiceClient.cs
@@ -1,0 +1,49 @@
+namespace ServiceStack.Wire
+{
+    using System;
+    using System.IO;
+    using ServiceStack.Web;
+
+    public class WireServiceClient : ServiceClientBase
+    {
+        public override string Format => "x-wire";
+
+        public WireServiceClient(string baseUri)
+        {
+            SetBaseUri(baseUri);
+        }
+
+        public WireServiceClient(string syncReplyBaseUri, string asyncOneWayBaseUri)
+            : base(syncReplyBaseUri, asyncOneWayBaseUri) { }
+
+        public override void SerializeToStream(IRequest requestContext, object request, Stream stream)
+        {
+            if (request == null) return;
+            try
+            {
+                WireFormat.Serialize(requestContext, request, stream);
+            }
+            catch (Exception ex)
+            {
+                WireFormat.HandleException(ex, request.GetType());
+            }
+        }
+
+        public override T DeserializeFromStream<T>(Stream stream)
+        {
+            try
+            {
+                return (T)WireFormat.Deserialize(typeof(T), stream);
+
+            }
+            catch (Exception ex)
+            {
+                return (T)WireFormat.HandleException(ex, typeof(T));
+            }
+        }
+
+        public override string ContentType => MimeTypes.Wire;
+
+        public override StreamDeserializerDelegate StreamDeserializer => WireFormat.Deserialize;
+    }
+}

--- a/src/ServiceStack.Wire/packages.config
+++ b/src/ServiceStack.Wire/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Wire" version="0.8.1" targetFramework="net452" />
+</packages>

--- a/src/ServiceStack.sln
+++ b/src/ServiceStack.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.25302.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}"
 EndProject
@@ -156,6 +156,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorRockstars.Web.Tests", "..\tests\RazorRockstars.Web.Tests\RazorRockstars.Web.Tests.csproj", "{1AD83DAD-3C69-4343-983E-074F0374EE80}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CheckMvc", "..\tests\CheckMvc\CheckMvc.csproj", "{50971470-179A-45D1-92C9-748DEFCBD9E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Wire", "ServiceStack.Wire\ServiceStack.Wire.csproj", "{0428D353-CD67-481F-877A-676E3BBCF903}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -767,6 +769,24 @@ Global
 		{50971470-179A-45D1-92C9-748DEFCBD9E5}.Signed|Mixed Platforms.Build.0 = Release|Any CPU
 		{50971470-179A-45D1-92C9-748DEFCBD9E5}.Signed|x86.ActiveCfg = Release|Any CPU
 		{50971470-179A-45D1-92C9-748DEFCBD9E5}.Signed|x86.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Debug|x86.Build.0 = Debug|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|x86.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Release|x86.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|Any CPU.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|Mixed Platforms.Build.0 = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|x86.ActiveCfg = Release|Any CPU
+		{0428D353-CD67-481F-877A-676E3BBCF903}.Signed|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -801,6 +821,7 @@ Global
 		{213EF4BA-786A-432F-B147-5702B18DE3CC} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{1AD83DAD-3C69-4343-983E-074F0374EE80} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
 		{50971470-179A-45D1-92C9-748DEFCBD9E5} = {4EBD29DD-21A1-47B5-80DB-F9D58C91BED5}
+		{0428D353-CD67-481F-877A-676E3BBCF903} = {CBDE0575-D09B-4B4D-8C62-5E03E54F6BE8}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = ..\tests\RazorRockstars.Console\RazorRockstars.Console.csproj

--- a/src/ServiceStack/IPlugin.cs
+++ b/src/ServiceStack/IPlugin.cs
@@ -34,6 +34,7 @@
 
     public interface IProtoBufPlugin { }        //Marker for ProtoBuf plugin
     public interface IMsgPackPlugin { }         //Marker for MsgPack plugin
+    public interface IWirePlugin { }            //Marker for Wire plugin
     public interface INetSerializerPlugin { }   //Marker for NetSerialize plugin
     public interface IRazorPlugin { }           //Marker for MVC Razor plugin
 }

--- a/tests/RazorRockstars.Console.Files/MsgPackServiceTests.cs
+++ b/tests/RazorRockstars.Console.Files/MsgPackServiceTests.cs
@@ -10,6 +10,8 @@ using ServiceStack.Text;
 
 namespace RazorRockstars.Console.Files
 {
+    using ServiceStack.Wire;
+
     public class MsgPackEmail
     {
         public string ToAddress { get; set; }
@@ -153,6 +155,76 @@ namespace RazorRockstars.Console.Files
                 Assert.That(response.Equals(request));
             }
         }
+    }
 
+    [TestFixture]
+    public class WireServiceTests
+    {
+        protected const string ListeningOn = "http://localhost:1337/";
+
+        AppHost appHost;
+
+        [TestFixtureSetUp]
+        public void OnTestFixtureSetUp()
+        {
+            LogManager.LogFactory = new ConsoleLogFactory();
+
+            appHost = new AppHost { EnableRazor = false };
+            appHost.Plugins.Add(new WireFormat());
+            appHost.Init();
+            appHost.Start(ListeningOn);
+        }
+
+        [TestFixtureTearDown]
+        public void OnTestFixtureTearDown()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            appHost?.Dispose();
+        }
+
+        MsgPackEmail request = new MsgPackEmail
+        {
+            ToAddress = "to@email.com",
+            FromAddress = "from@email.com",
+            Subject = "Subject",
+            Body = "Body",
+            AttachmentData = Encoding.UTF8.GetBytes("AttachmentData"),
+        };
+
+        [Test]
+        public void Can_Send_Wire_request()
+        {
+            var client = new WireServiceClient(ListeningOn);
+
+            try
+            {
+                var response = client.Send<MsgPackEmail>(request);
+
+                Assert.That(response.Equals(request));
+            }
+            catch (WebServiceException webEx)
+            {
+                Assert.Fail(webEx.Message);
+            }
+        }
+
+        [Test]
+        public void Can_serialize_email_dto()
+        {
+            using (var ms = new MemoryStream())
+            {
+                WireFormat.Serialize(request, ms);
+
+                ms.Position = 0;
+
+                var response = WireFormat.Deserialize(request.GetType(), ms);
+
+                Assert.That(response.Equals(request));
+            }
+        }
     }
 }

--- a/tests/RazorRockstars.Console.Files/RazorRockstars.Console.Files.csproj
+++ b/tests/RazorRockstars.Console.Files/RazorRockstars.Console.Files.csproj
@@ -132,6 +132,10 @@
       <HintPath>..\..\lib\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
+    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Wire.0.8.1\lib\net45\Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppHost.cs" />
@@ -411,6 +415,10 @@
     <ProjectReference Include="..\..\src\ServiceStack.Server\ServiceStack.Server.csproj">
       <Project>{5a315f92-80d2-4c60-a5a4-22e027ac7e7e}</Project>
       <Name>ServiceStack.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\ServiceStack.Wire\ServiceStack.Wire.csproj">
+      <Project>{0428d353-cd67-481f-877a-676e3bbcf903}</Project>
+      <Name>ServiceStack.Wire</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\ServiceStack\ServiceStack.csproj">
       <Project>{680A1709-25EB-4D52-A87F-EE03FFD94BAA}</Project>

--- a/tests/RazorRockstars.Console.Files/packages.config
+++ b/tests/RazorRockstars.Console.Files/packages.config
@@ -11,4 +11,5 @@
   <package id="System.Data.SQLite.EF6" version="1.0.102.0" targetFramework="net45" />
   <package id="System.Data.SQLite.Linq" version="1.0.102.0" targetFramework="net45" />
   <package id="System.Data.SQLite.x64" version="1.0.102.0" targetFramework="net45" />
+  <package id="Wire" version="0.8.1" targetFramework="net45" />
 </packages>

--- a/tests/ServiceStack.Common.Tests/FormatTests.cs
+++ b/tests/ServiceStack.Common.Tests/FormatTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using NUnit.Framework;
 using ServiceStack.MsgPack;
 using ServiceStack.ProtoBuf;
+using ServiceStack.Wire;
 
 namespace ServiceStack.Common.Tests
 {
@@ -43,6 +44,19 @@ namespace ServiceStack.Common.Tests
             var bytes = dto.ToMsgPack();
 
             var fromBytes = bytes.FromMsgPack<TestModel>();
+
+            Assert.That(fromBytes.Id, Is.EqualTo(dto.Id));
+            Assert.That(fromBytes.Name, Is.EqualTo(dto.Name));
+        }
+
+        [Test]
+        public void Can_seraialize_Wire()
+        {
+            var dto = new TestModel { Id = 1, Name = "Name" };
+
+            var bytes = dto.ToWire();
+
+            var fromBytes = bytes.FromWire<TestModel>();
 
             Assert.That(fromBytes.Id, Is.EqualTo(dto.Id));
             Assert.That(fromBytes.Name, Is.EqualTo(dto.Name));

--- a/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
+++ b/tests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.csproj
@@ -278,6 +278,10 @@
       <Project>{5a315f92-80d2-4c60-a5a4-22e027ac7e7e}</Project>
       <Name>ServiceStack.Server</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\ServiceStack.Wire\ServiceStack.Wire.csproj">
+      <Project>{0428D353-CD67-481F-877A-676E3BBCF903}</Project>
+      <Name>ServiceStack.Wire</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\ServiceStack\ServiceStack.csproj">
       <Project>{680A1709-25EB-4D52-A87F-EE03FFD94BAA}</Project>
       <Name>ServiceStack</Name>


### PR DESCRIPTION
Adding new format "wire". a fast Binary serializer for POCO objects
https://github.com/AsynkronIT/Wire

I am using the most tolerant Versioned mode which from the docs says

"Versioned, in this mode, Wire will emit both type names and field information in the output stream. This allows systems to have slightly different versions of the contract types where some fields may have been added or removed."

In this mode is isn't required to register the types for serializing in advance as it will as stated above emit the type and field info to the output stream so AFAIK you do not need to hold a dictionary of types as MsgPackFormat does.

I am also not sure of the lifecycle of serialization sessions so am using a single static instance of the serializer in the client.