### PR TITLE
Added generic and string ThrowIfNull so that it can be used as part of an inline…

### DIFF
--- a/src/ServiceStack.Common/AssertExtensions.cs
+++ b/src/ServiceStack.Common/AssertExtensions.cs
@@ -25,23 +25,35 @@ namespace ServiceStack
                 throw new ArgumentNullException(varName ?? "object");
         }
 
-        public static void ThrowIfNullOrEmpty(this string strValue)
+        public static T ThrowIfNull<T>(this T obj, string varName)
         {
-            ThrowIfNullOrEmpty(strValue, null);
+            if (obj == null)
+                throw new ArgumentNullException(varName ?? "object");
+
+            return obj;
         }
 
-        public static void ThrowIfNullOrEmpty(this string strValue, string varName)
+        public static string ThrowIfNullOrEmpty(this string strValue)
+        {
+            return ThrowIfNullOrEmpty(strValue, null);
+        }
+
+        public static string ThrowIfNullOrEmpty(this string strValue, string varName)
         {
             if (string.IsNullOrEmpty(strValue))
                 throw new ArgumentNullException(varName ?? "string");
+
+            return strValue;
         }
 
-        public static void ThrowIfNullOrEmpty(this ICollection collection)
+        public static ICollection ThrowIfNullOrEmpty(this ICollection collection)
         {
             ThrowIfNullOrEmpty(collection, null);
+
+            return collection;
         }
 
-        public static void ThrowIfNullOrEmpty(this ICollection collection, string varName)
+        public static ICollection ThrowIfNullOrEmpty(this ICollection collection, string varName)
         {
             var fieldName = varName ?? "collection";
 
@@ -50,14 +62,18 @@ namespace ServiceStack
 
             if (collection.Count == 0)
                 throw new ArgumentException(fieldName + " is empty");
+
+            return collection;
         }
 
-        public static void ThrowIfNullOrEmpty<T>(this ICollection<T> collection)
+        public static ICollection<T> ThrowIfNullOrEmpty<T>(this ICollection<T> collection)
         {
             ThrowIfNullOrEmpty(collection, null);
+
+            return collection;
         }
 
-        public static void ThrowIfNullOrEmpty<T>(this ICollection<T> collection, string varName)
+        public static ICollection<T> ThrowIfNullOrEmpty<T>(this ICollection<T> collection, string varName)
         {
             var fieldName = varName ?? "collection";
 
@@ -66,8 +82,8 @@ namespace ServiceStack
 
             if (collection.Count == 0)
                 throw new ArgumentException(fieldName + " is empty");
-        }
 
+            return collection;
+        }
     }
-
 }


### PR DESCRIPTION
… assignment rather than having to take 2 lines.  This just allows a null check to take place on the same line as an assignment operator.

E.g.

```C#
class SomeClass
{
   private readonly string internalValue;

   public SomeClass(string externalValue)
   {
       this.internalValue = externalValue.ThrowIfNullOrEmpty(nameof(externalValue));
      
      // instead of:
      // externalValue.ThrowIfNullOrEmpty(nameof(externalValue));
      // this.internalValue = externalValue;
   }
}
```