### PR TITLE
Make the container behaviour in AppHost extensible

### DIFF
--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -264,7 +264,7 @@ namespace ServiceStack
         /// <summary>
         /// The AppHost.Container. Note: it is not thread safe to register dependencies after AppStart.
         /// </summary>
-        public Container Container { get; private set; }
+        public virtual Container Container { get; private set; }
 
         public IServiceRoutes Routes { get; set; }
 


### PR DESCRIPTION
I would like to make the container getter extensible in the appHost.

I was overwriting all the resolve, tryResolve, register, etc methods to add to the child container after startup. But Sometimes some code references to the AppHost.Container directly. Since this method is public why not make it overrideable. then with one override i can solve all my problems.

Usecase: Supply a childContainer (to plugins) per request or per customer  (depending on performance/memory usage)