### PR TITLE
Making ServiceController extensible.

### DIFF
--- a/src/ServiceStack/Host/ServiceController.cs
+++ b/src/ServiceStack/Host/ServiceController.cs
@@ -505,7 +505,7 @@ namespace ServiceStack.Host
             return Execute(requestDto, new BasicRequest());
         }
 
-        public object Execute(object requestDto, IRequest req)
+        public virtual object Execute(object requestDto, IRequest req)
         {
             req.Dto = requestDto;
             var requestType = requestDto.GetType();
@@ -608,7 +608,7 @@ namespace ServiceStack.Host
                 : response.AsTaskResult();
         }
 
-        public ServiceExecFn GetService(Type requestType)
+        public virtual ServiceExecFn GetService(Type requestType)
         {
             ServiceExecFn handlerFn;
             if (!requestExecMap.TryGetValue(requestType, out handlerFn))


### PR DESCRIPTION
Since `IAppHost` directly references to `ServiceController` instead of `IServiceController` for whatever reason I do not know? (Either extend the interface or remove it completly imo).

Usecase:
It like to add some fallback strategy for when Service cannot be found.

Btw i cant build the project because pfx key file is missing, and when i remove it it dies on DynamoDbv2/CodeAnalysis.dll is missing  (nuget package version wanted 2.3.1.5.3, though version 2.3.3.0 was installed)
