### PR TITLE
Swagger Bootstrap: Show required request DTO properties

### DIFF
--- a/src/ServiceStack.Api.Swagger/swagger-ui-bootstrap/swagger-like-template.html
+++ b/src/ServiceStack.Api.Swagger/swagger-ui-bootstrap/swagger-like-template.html
@@ -224,6 +224,7 @@ function notUndefinedNullOrZeroLength(obj) {
     <thead>
         <tr>
             <th width="12%">Parameter</th>
+            <th width="5%">Required</th>
             <th width="7%">Parameter Type</th>
             <th width="7%">Data Type</th>
             <th>Description</th>
@@ -233,6 +234,7 @@ function notUndefinedNullOrZeroLength(obj) {
         % a.parameters.forEach(function(param) {
         <tr>
             <td>${ param.name !== undefined && param.name !== null ? param.name : param.type }</td>
+            <td>${ param.required ? "yes" : "" }</td>
             <td>${ param.paramType }</td>
             <td>${ param.name === undefined || param.name === null ? '' : param.type }</td>
             <td>${ param.description }</td>
@@ -289,7 +291,6 @@ function notUndefinedNullOrZeroLength(obj) {
         <thead>
             <tr>
                 <th width="12%">Field</th>
-                <th width="5%">Required</th>
                 <th width="9%">Data Type</th>
                 <th>Description</th>
             </tr>
@@ -298,7 +299,6 @@ function notUndefinedNullOrZeroLength(obj) {
             % _.each(a.properties, function(prop, key) {
             <tr>
                 <td>${ key }</td>
-                <td>${ _.contains(a.required, key) ? "yes" : "" }</td>
                 <td>${ toSwaggerType(prop) }</td>
                 <td>${ prop.description }</td>
             </tr>


### PR DESCRIPTION
Added a "Required" column to the Parameters table.
Removed the "Required" column from the Response Model table.

The logic was simply in the wrong place.

Before the change:
![image](https://cloud.githubusercontent.com/assets/54773/20448845/dd82925a-ad9a-11e6-9be4-d63261e4ca14.png)

After the change:
![image](https://cloud.githubusercontent.com/assets/54773/20448852/e83688be-ad9a-11e6-9916-f47047466838.png)
