### PR TITLE
SSE - Skip broadcasting to expired subscriptions

### DIFF
--- a/src/ServiceStack/ServerEventsFeature.cs
+++ b/src/ServiceStack/ServerEventsFeature.cs
@@ -676,6 +676,7 @@ namespace ServiceStack
                                 string.Join(", ", sub.Channels));
 
                         expired.Add(sub);
+	                    continue;
                     }
 
                     if (Log.IsDebugEnabled)


### PR DESCRIPTION
If the subscription is expired or closed, then it shouldn't be receiving publications.