### PR TITLE
Updated ContentFormat.IsBinary() logic for Wire format

### DIFF
--- a/src/ServiceStack.Client/ContentFormat.cs
+++ b/src/ServiceStack.Client/ContentFormat.cs
@@ -69,6 +69,7 @@ namespace ServiceStack
                 case MimeTypes.MsgPack:
                 case MimeTypes.Binary:
                 case MimeTypes.Bson:
+                case MimeTypes.Wire:
                     return true;
             }
 


### PR DESCRIPTION
Added Wire MimeType to IsBinary() check as I was getting an exception when trying to cache Wire formatted content without this.

I also noticed there currently isn't support for Wire format in `[Restrict(RequestAttributes.Wire)]`. I had a shot at doing this locally but it meant touching ServiceStack.Interfaces project (to update RequestAttributes and Feature classes) which resulted in a few issues relating to needing to update ServiceStack.Interfaces for other projects while I'm unable to sign it.

If Restrictions for Wire is something you think should be supported I can add the changes I've made to this P.R. (albeit they may be incomplete).