### PR TITLE
Register SaltedHash as a transient service.

### DIFF
--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -500,7 +500,7 @@ namespace ServiceStack
 
         public virtual void OnBeforeInit()
         {
-            Container.Register<IHashProvider>(c => new SaltedHash());
+            Container.Register<IHashProvider>(c => new SaltedHash()).ReusedWithin(ReuseScope.None);
         }
 
         //After configure called


### PR DESCRIPTION
SHA256 is not thread-safe  and concurrent use of ComputeHash can return an incorrect hash result.

This issue can be reproduced with a simple HelloWorld service and the following configuration:

```
public override void Configure(Container container)
        {
            var usersRepo = new InMemoryAuthRepository();
            usersRepo.CreateUserAuth(new UserAuth() { UserName = "admin1" }, "pass1");
            container.Register<IUserAuthRepository>(usersRepo);

            this.Plugins.Add(new AuthFeature(
                () => new AuthUserSession(),
                new[] { new BasicAuthProvider() }));

            // Uncomment the following to fix the concurrency issue
            //container.Register<IHashProvider>(c =>
            //{
            //    return new SaltedHash();
            //}).ReusedWithin(ReuseScope.None);
        }
```

I used the Apache Bench tool to stress test the service.

When the concurrency flag is set to 1, all the requests succeed.
`./ab -n 100 -c 1 -H 'Authorization: Basic YWRtaW4xOnBhc3Mx' http://localhost/TinySS/hello/Yann`

 The following returns a few 401 errors:
`./ab -n 100 -c 10 -H 'Authorization: Basic YWRtaW4xOnBhc3Mx' http://localhost/TinySS/hello/Yann`

The test above doesn't return any error when the `SaltedHash` is registered as transient. 




