### PR TITLE
Minor Metadata Fixes

### DIFF
--- a/src/ServiceStack/Admin/RequestLogsService.cs
+++ b/src/ServiceStack/Admin/RequestLogsService.cs
@@ -48,6 +48,7 @@ namespace ServiceStack.Admin
     }
 
     [DefaultRequest(typeof(RequestLogs))]
+    [Restrict(VisibilityTo = RequestAttributes.None)]
     public class RequestLogsService : Service
     {
         private static readonly Dictionary<string, string> Usage = new Dictionary<string, string> {

--- a/src/ServiceStack/RequestLogsFeature.cs
+++ b/src/ServiceStack/RequestLogsFeature.cs
@@ -96,7 +96,7 @@ namespace ServiceStack
             }
 
             appHost.GetPlugin<MetadataFeature>()
-                .AddDebugLink(AtRestPath, "Request Logs");
+                .AddDebugLink(AtRestPath.TrimStart('/'), "Request Logs");
         }
     }
 }


### PR DESCRIPTION
- Restricted visibility of the Request Logs service to none. 
- Fixed a minor issue where the Request Logs debug link would not work when debugging on a local IIS server.
