### PR TITLE
Fix RequestContext going out of scope in .NetCore

### DIFF
--- a/src/ServiceStack/AppHostBase.NetCore.cs
+++ b/src/ServiceStack/AppHostBase.NetCore.cs
@@ -89,7 +89,6 @@ namespace ServiceStack
         {
             //Keep in sync with Kestrel/AppSelfHostBase.cs
             var operationName = context.Request.GetOperationName().UrlDecode() ?? "Home";
-
             var pathInfo = context.Request.Path.HasValue
                 ? context.Request.Path.Value
                 : "/";
@@ -102,6 +101,13 @@ namespace ServiceStack
 
                 pathInfo = pathInfo.Substring(mode.Length + 1);
             }
+
+#if NETSTANDARD1_6
+            // This fixes problems if the RequestContext.Instance.Items was touched on startup or outside of request context.
+            // It would turn it into a static dictionary instead flooding request with each-others values.
+            // This can already happen if I register a Funq.Container Request Scope type and Resolve it on startup.
+            RequestContext.Instance.StartRequestContext();
+#endif
 
             var httpReq = new NetCoreRequest(context, operationName, RequestAttributes.None, pathInfo);
             httpReq.RequestAttributes = httpReq.GetAttributes();

--- a/src/ServiceStack/RequestContext.cs
+++ b/src/ServiceStack/RequestContext.cs
@@ -19,6 +19,7 @@ namespace ServiceStack
     {
         public static readonly RequestContext Instance = new RequestContext();
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Tell ServiceStack to use ThreadStatic Items Collection for RequestScoped items.
         /// Warning: ThreadStatic Items aren't pinned to the same request in async services which callback on different threads.
@@ -27,9 +28,16 @@ namespace ServiceStack
 
         [ThreadStatic]
         public static IDictionary RequestItems;
-
-#if NETSTANDARD1_6
+#else
         public static AsyncLocal<IDictionary> AsyncRequestItems = new AsyncLocal<IDictionary>();
+
+        /// <summary>
+        /// Start a new Request context, everything deeper in Async pipeline will get this new RequestContext dictionary.
+        /// </summary>
+        public void StartRequestContext()
+        {
+            CreateItems();
+        }
 #endif
 
         /// <summary>


### PR DESCRIPTION
Hey mythz, i posed some weird stackoverflow issue lately of getting weird redis errors.

I traced the bug to in our code but it i found the issue also lays in servicestack core. 
The requestContext can easily be turned into a static dictionary when touched directy & indirectly in startup. Or outside of a request. This would already create the AsyncLocal<Dictionary> and thus this dictionary would be given anywhere deeper in the pipeline: also every request gets this same Dictionary.

I solved it this way it now overrides this dictionary at the beginning over every request.

Another option, which wouldn't be water-thight but maybe a good addition: on `CreateItems` check if `ServiceStackHost.Instance.HasStarted` Otherwise throw an error, so people will see there bugs in code early on instead of getting weird errors when concurrent calls start happening.
