### PR TITLE
Update MockHttpResponse to give clue in testing

### DIFF
--- a/src/ServiceStack/Testing/MockHttpResponse.cs
+++ b/src/ServiceStack/Testing/MockHttpResponse.cs
@@ -16,8 +16,7 @@ namespace ServiceStack.Testing
             this.Headers = PclExportClient.Instance.NewNameValueCollection();
             this.OutputStream = new MemoryStream();
             this.TextWritten = new StringBuilder();
-            HostContext.AssertAppHost();
-            this.Cookies = HostContext.AppHost.GetCookies(this);
+            this.Cookies = HostContext.AssertAppHost().GetCookies(this);
             this.Items = new Dictionary<string, object>();
         }
 

--- a/src/ServiceStack/Testing/MockHttpResponse.cs
+++ b/src/ServiceStack/Testing/MockHttpResponse.cs
@@ -16,6 +16,8 @@ namespace ServiceStack.Testing
             this.Headers = PclExportClient.Instance.NewNameValueCollection();
             this.OutputStream = new MemoryStream();
             this.TextWritten = new StringBuilder();
+            if (HostContext.AppHost == null)
+                throw new NullReferenceException("A ServiceStackHost has not been initialised in the test.");
             this.Cookies = HostContext.AppHost.GetCookies(this);
             this.Items = new Dictionary<string, object>();
         }

--- a/src/ServiceStack/Testing/MockHttpResponse.cs
+++ b/src/ServiceStack/Testing/MockHttpResponse.cs
@@ -16,8 +16,7 @@ namespace ServiceStack.Testing
             this.Headers = PclExportClient.Instance.NewNameValueCollection();
             this.OutputStream = new MemoryStream();
             this.TextWritten = new StringBuilder();
-            if (HostContext.AppHost == null)
-                throw new NullReferenceException("A ServiceStackHost has not been initialised in the test.");
+            HostContext.AssertAppHost();
             this.Cookies = HostContext.AppHost.GetCookies(this);
             this.Items = new Dictionary<string, object>();
         }


### PR DESCRIPTION
When testing an using the `MockHttpRequest`, if you forget to initialise an AppHost in your tests (usually done once for all tests) you get the dreaded 'Object reference not set to an instance of an object.' NOT from `MockHttpRequest` but from `MockHttpResponse` with no clue as to the cause. 

This change ensures that you get a clue, that prompts you to initialise a ServiceStackHost in your tests first. It could even go further and point you to a page to demonstarte how to do that.
