### PR TITLE
Use proper directory for embedded resources

### DIFF
--- a/src/ServiceStack.Api.OpenApi/project.json
+++ b/src/ServiceStack.Api.OpenApi/project.json
@@ -2,8 +2,7 @@
   "buildOptions": {
     "embed": {
       "include": [
-          "openapi-ui/**/*.*",
-          "openapi-ui-bootstrap/**/*.*"
+          "swagger-ui/**/*.*"
       ]
     }
   },


### PR DESCRIPTION
Currently it's including `openapi-ui`; however, the services looks for them at `swagger-ui` and this is not able to resolve the ui in .net core apps