### PR TITLE
Create generated code with predictable [ApiMember] property ordering.

### DIFF
--- a/src/ServiceStack/NativeTypes/NativeTypesMetadata.cs
+++ b/src/ServiceStack/NativeTypes/NativeTypesMetadata.cs
@@ -552,6 +552,7 @@ namespace ServiceStack.NativeTypes
                 .Select(pi => ToProperty(pi, attr))
                 .Where(property => property.Name != "TypeId"
                     && property.Value != null)
+                .OrderBy(property => property.Name)
                 .ToList();
         }
 

--- a/tests/ServiceStack.Common.Tests/NativeTypesTests.cs
+++ b/tests/ServiceStack.Common.Tests/NativeTypesTests.cs
@@ -75,6 +75,20 @@ namespace ServiceStack.Common.Tests
         }
 
         [Test]
+        public void AnnotatedDtoTypes_ApiMemberNonDefaultProperties_AreSorted()
+        {
+            var result = appHost.ExecuteService(new TypesCSharp
+            {
+                IncludeTypes = new List<string> { "DtoResponse" }
+            });
+
+            var stringResult = result.ToString();
+
+            StringAssert.Contains("class DtoResponse", stringResult);
+            StringAssert.Contains("[ApiMember(Description=\"ShouldBeFirstInGeneratedCode\", IsRequired=true, Name=\"ShouldBeLastInGeneratedCode\")]", stringResult);
+        }
+
+        [Test]
         public void IncludeTypes_DoesNotReturnReferenceTypes_If_IncludeTypes_NoWildcard_Fsharp()
         {
             var result = appHost.ExecuteService(new TypesFSharp
@@ -306,6 +320,7 @@ namespace ServiceStack.Common.Tests
 
     public class DtoResponse
     {
+        [ApiMember(Name = "ShouldBeLastInGeneratedCode", Description = "ShouldBeFirstInGeneratedCode", IsRequired = true)]
         public EmbeddedRequest ReferencedType { get; set; }
     }
 


### PR DESCRIPTION
Generated code for annotated DTOs was creating [ApiMember] with random property ordering. (I suspect the order of the `PropertyInfo` collection is not guaranteed by the CLR.

Each time we regenerated a client library from an endpoint using the built-in `/types/csharp` endpoint on an annotated DTO, the resulting diff was massive, even though the DTO shapes had not changed.

Given an annotated DTO of:
```C#
public class Item
{
    [ApiMember(Description = "The ID of the item", IsRequired = true)]
    public int Id { get; set; }
}
```

One run of the type generator would yield:
```C#
public class Item
{
    [ApiMember(Description="The ID of the item", IsRequired=true)]
    public int Id { get; set; }
}
```

After the next daily build, with no code changes, a subsequent run of the type generator would yield:
```C#
public class Item
{
    [ApiMember(IsRequired=true, Description="The ID of the item")]
    public int Id { get; set; }
}
```

A quick solution was to simply sort the property collection by name to yield a deterministic output from the code generators.
