### PR TITLE
Check for null ServiceRoutes

### DIFF
--- a/src/ServiceStack/Auth/JwtAuthProviderReader.cs
+++ b/src/ServiceStack/Auth/JwtAuthProviderReader.cs
@@ -549,10 +549,12 @@ namespace ServiceStack.Auth
 
             if (KeyId == null)
                 KeyId = GetKeyId();
-
-            foreach (var registerService in ServiceRoutes)
-            {
-                appHost.RegisterService(registerService.Key, registerService.Value);
+                
+            if(ServiceRoutes != null) {
+                foreach (var registerService in ServiceRoutes)
+                {
+                    appHost.RegisterService(registerService.Key, registerService.Value);
+                }
             }
 
             feature.AuthResponseDecorator = AuthenticateResponseDecorator;


### PR DESCRIPTION
ServiceRoutes is null by default and this was causing an exception to occur during application startup that was swallowed by the AppHost init procedure.