### PR TITLE
Issues found by PVS-Studio

### DIFF
--- a/src/ServiceStack/Auth/AuthProvider.cs
+++ b/src/ServiceStack/Auth/AuthProvider.cs
@@ -86,7 +86,7 @@ namespace ServiceStack.Auth
 
             var session = service.GetSession();
             var referrerUrl = request?.Continue
-                ?? (feature.HtmlLogoutRedirect != null ? service.Request.ResolveAbsoluteUrl(feature.HtmlLogoutRedirect) : null)
+                ?? (feature?.HtmlLogoutRedirect != null ? service.Request.ResolveAbsoluteUrl(feature.HtmlLogoutRedirect) : null)
                 ?? session.ReferrerUrl
                 ?? service.Request.GetHeader("Referer").NotLogoutUrl()
                 ?? this.RedirectUrl;

--- a/src/ServiceStack/NativeTypes/Kotlin/KotlinGenerator.cs
+++ b/src/ServiceStack/NativeTypes/Kotlin/KotlinGenerator.cs
@@ -283,7 +283,7 @@ namespace ServiceStack.NativeTypes.Kotlin
 
             if (type.IsEnum.GetValueOrDefault())
             {
-                var hasIntValue = type.EnumNames.Count == (type.EnumValues?.Count ?? 0);
+                var hasIntValue = (type.EnumNames?.Count ?? 0) == (type.EnumValues?.Count ?? 0);
                 var enumConstructor = hasIntValue ? "(val value:Int)" : "";
 
                 sb.AppendLine($"enum class {typeName}{enumConstructor}");

--- a/src/ServiceStack/ServerEventsFeature.cs
+++ b/src/ServiceStack/ServerEventsFeature.cs
@@ -119,7 +119,7 @@ namespace ServiceStack
             var feature = HostContext.GetPlugin<ServerEventsFeature>();
 
             var session = req.GetSession();
-            if (feature.LimitToAuthenticatedUsers && !session.IsAuthenticated)
+            if (feature.LimitToAuthenticatedUsers && session != null && !session.IsAuthenticated)
             {
                 session.ReturnFailedAuthentication(req);
                 return TypeConstants.EmptyTask;
@@ -176,7 +176,7 @@ namespace ServiceStack
                     { "isAuthenticated", session != null && session.IsAuthenticated ? "true": "false" },
                     { "displayName", displayName },
                     { "channels", string.Join(",", channels) },
-                    { AuthMetadataProvider.ProfileUrlKey, session.GetProfileUrl() ?? AuthMetadataProvider.DefaultNoProfileImgUrl },
+                    { AuthMetadataProvider.ProfileUrlKey, session?.GetProfileUrl() ?? AuthMetadataProvider.DefaultNoProfileImgUrl },
                 }
             };
 


### PR DESCRIPTION
Hello,
I have found a few bugs using PVS-Studio analyzer. PVS-Studio is a static code analyzer for C, C++ and C#: [https://www.viva64.com/en/pvs-studio/](https://www.viva64.com/en/pvs-studio/)

Analyzer warnings:

- [V3095](https://www.viva64.com/en/w/V3095/) The 'feature' object was used before it was verified against null. Check lines: 89, 99. ServiceStack AuthProvider.cs 89

- [V3095](https://www.viva64.com/en/w/V3095/) The 'type.EnumNames' object was used before it was verified against null. Check lines: 286, 294. ServiceStack KotlinGenerator.cs 286

- [V3095](https://www.viva64.com/en/w/V3095/) The 'session' object was used before it was verified against null. Check lines: 122, 170. ServiceStack ServerEventsFeature.cs 122

- [V3042](https://www.viva64.com/en/w/V3042/) Possible NullReferenceException. The '?.' and '.' operators are used for accessing members of the 'session' object ServiceStack ServerEventsFeature.cs 179

In addition, I suggest having a look at the emails, sent from @pvs-studio.com.

Best regards,
Sergey Hrenov,
PVS-Studio Team