### PR TITLE
Added overloads for register typed filters

### DIFF
--- a/src/ServiceStack/Host/AppDelegates.cs
+++ b/src/ServiceStack/Host/AppDelegates.cs
@@ -20,6 +20,11 @@ namespace ServiceStack.Host
         void Invoke(IRequest req, IResponse res, object dto);
     }
 
+    public interface ITypedFilter<in T>
+    {
+        void Invoke(IRequest req, IResponse res, T dto);
+    }
+
     public class TypedFilter<T> : ITypedFilter
     {
         private readonly Action<IRequest, IResponse, T> action;

--- a/src/ServiceStack/IAppHost.cs
+++ b/src/ServiceStack/IAppHost.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
+using Funq;
 using ServiceStack.Configuration;
 using ServiceStack.Host;
 using ServiceStack.Host.Handlers;
@@ -111,9 +112,23 @@ namespace ServiceStack
         void RegisterTypedRequestFilter<T>(Action<IRequest, IResponse, T> filterFn);
 
         /// <summary>
+        /// Add <seealso cref="ITypedFilter{T}"/> as a Typed Request Filter for a specific Request DTO Type
+        /// </summary>
+        /// <typeparam name="T">The DTO Type.</typeparam>
+        /// <param name="filters">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
+        void RegisterTypedRequestFilter<T>(params Func<Container, ITypedFilter<T>>[] filters);
+
+        /// <summary>
         /// Add Request Filter for a specific Response DTO Type
         /// </summary>
         void RegisterTypedResponseFilter<T>(Action<IRequest, IResponse, T> filterFn);
+
+        /// <summary>
+        /// Add <seealso cref="ITypedFilter{T}"/> as a Typed Request Filter for a specific Request DTO Type
+        /// </summary>
+        /// <typeparam name="T">The DTO Type.</typeparam>
+        /// <param name="filters">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
+        void RegisterTypedResponseFilter<T>(params Func<Container, ITypedFilter<T>>[] filters);
 
         /// <summary>
         /// Add Request Filter for a specific MQ Request DTO Type

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/TypedFilterTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/TypedFilterTests.cs
@@ -1,0 +1,118 @@
+﻿using NUnit.Framework;
+using ServiceStack.Host;
+using ServiceStack.Testing;
+using ServiceStack.Web;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    [TestFixture]
+    public class TypedFilterTests
+    {
+        private class Dto : IReturn<Dto>
+        {
+            public bool RequestFilter { get; set; }
+            public bool ResponseFilter { get; set; }
+        }
+
+        private class DtoService : Service
+        {
+            public object Any(Dto r) => r;
+        }
+
+        private interface IDependency { }
+        private class Dependency : IDependency { }
+
+        private class TypedRequestFilter : ITypedFilter<Dto>
+        {
+            public TypedRequestFilter(IDependency dependency) => Dependency = dependency;
+
+            public IDependency Dependency { get; }
+
+            public void Invoke(IRequest req, IResponse res, Dto dto) => dto.RequestFilter = true;
+        }
+
+        private class TypedResponseFilter : ITypedFilter<Dto>
+        {
+            public TypedResponseFilter(IDependency dependency) => Dependency = dependency;
+
+            public IDependency Dependency { get; }
+
+            public void Invoke(IRequest req, IResponse res, Dto dto) => dto.ResponseFilter = true;
+        }
+
+        private ServiceStackHost appHost;
+
+        [OneTimeSetUp]
+        public void OnTestFixtureSetup()
+        {
+            appHost = new BasicAppHost(typeof(DtoService).GetAssembly())
+            {
+                ConfigureContainer = c =>
+                {
+                    c.RegisterAutoWiredAs<Dependency, IDependency>();
+                    c.RegisterAutoWired<TypedRequestFilter>();
+                    c.RegisterAutoWired<TypedResponseFilter>();
+                }
+            };
+            appHost.RegisterTypedRequestFilter(c => c.Resolve<TypedRequestFilter>());
+            appHost.RegisterTypedResponseFilter(c => c.Resolve<TypedResponseFilter>());
+            appHost.Init();
+        }
+
+        [OneTimeTearDown]
+        public void OnTestFixtureTearDown()
+        {
+            appHost.Dispose();
+        }
+
+        [Test]
+        public void Request_filter_auto_wired()
+        {
+            // Arrange
+            var filter = appHost.GetContainer().Resolve<TypedRequestFilter>();
+
+            // Assert
+            Assert.NotNull(filter.Dependency);
+        }
+
+        [Test]
+        public void Response_filter_auto_wired()
+        {
+            // Arrange
+            var filter = appHost.GetContainer().Resolve<TypedResponseFilter>();
+
+            // Assert
+            Assert.NotNull(filter.Dependency);
+        }
+
+        [Test]
+        public void Request_filter_executed()
+        {
+            // Arrange
+            var dto = new Dto();
+            var request = new BasicRequest(dto);
+
+            // Act
+            var response = appHost.ServiceController.Execute(dto, request, true) as Dto;
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.IsTrue(response.RequestFilter);
+        }
+
+        [Test]
+        public void Response_filter_executed()
+        {
+            // Arrange
+            var dto = new Dto();
+            var request = new BasicRequest(dto);
+
+            // Act
+            var response = appHost.ServiceController.Execute(dto, request, true) as Dto;
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.IsTrue(response.ResponseFilter);
+        }
+    }
+}


### PR DESCRIPTION
I added a couple of overloads to ServiceStackHost for convenience purposes.
The overloads allow you to use the container to resolve an ITypedFilter<T> service(s).
It will then delay the resolve until the filter is actually called, allowing the container to correctly auto-wire the dependencies.

`RegisterTypedRequestFilter(c => c.Resolve<MyTypedFilter>());`

Otherwise, the service(s) would be resolved during the initialization, and results in a "Cannot resolve service or one of its auto-wired dependencies" exception. 

`RegisterTypedRequestFilter(container.Resolve<MyTypedFilter>());`

_Note: If there is already a recommended way to do this let me know. I was not aware of any so this is what we did to resolve our problem._