### PR TITLE
Changed overloads for register typed filters

### DIFF
--- a/src/ServiceStack/IAppHost.cs
+++ b/src/ServiceStack/IAppHost.cs
@@ -115,8 +115,8 @@ namespace ServiceStack
         /// Add <seealso cref="ITypedFilter{T}"/> as a Typed Request Filter for a specific Request DTO Type
         /// </summary>
         /// <typeparam name="T">The DTO Type.</typeparam>
-        /// <param name="filters">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
-        void RegisterTypedRequestFilter<T>(params Func<Container, ITypedFilter<T>>[] filters);
+        /// <param name="filter">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
+        void RegisterTypedRequestFilter<T>(Func<Container, ITypedFilter<T>> filter);
 
         /// <summary>
         /// Add Request Filter for a specific Response DTO Type
@@ -127,8 +127,8 @@ namespace ServiceStack
         /// Add <seealso cref="ITypedFilter{T}"/> as a Typed Request Filter for a specific Request DTO Type
         /// </summary>
         /// <typeparam name="T">The DTO Type.</typeparam>
-        /// <param name="filters">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
-        void RegisterTypedResponseFilter<T>(params Func<Container, ITypedFilter<T>>[] filters);
+        /// <param name="filter">The <seealso cref="Container"/> methods to resolve the <seealso cref="ITypedFilter{T}"/>.</param>
+        void RegisterTypedResponseFilter<T>(Func<Container, ITypedFilter<T>> filter);
 
         /// <summary>
         /// Add Request Filter for a specific MQ Request DTO Type

--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -966,9 +966,9 @@ namespace ServiceStack
             GlobalTypedRequestFilters[typeof(T)] = new TypedFilter<T>(filterFn);
         }
 
-        public void RegisterTypedRequestFilter<T>(params Func<Container, ITypedFilter<T>>[] filters)
+        public void RegisterTypedRequestFilter<T>(Func<Container, ITypedFilter<T>> filter)
         {
-            RegisterTypedFilter(RegisterTypedRequestFilter, filters);
+            RegisterTypedFilter(RegisterTypedRequestFilter, filter);
         }
 
         public void RegisterTypedResponseFilter<T>(Action<IRequest, IResponse, T> filterFn)
@@ -976,21 +976,20 @@ namespace ServiceStack
             GlobalTypedResponseFilters[typeof(T)] = new TypedFilter<T>(filterFn);
         }
 
-        public void RegisterTypedResponseFilter<T>(params Func<Container, ITypedFilter<T>>[] filters)
+        public void RegisterTypedResponseFilter<T>(Func<Container, ITypedFilter<T>> filter)
         {
-            RegisterTypedFilter(RegisterTypedResponseFilter, filters);
+            RegisterTypedFilter(RegisterTypedResponseFilter, filter);
         }
 
-        private void RegisterTypedFilter<T>(Action<Action<IRequest, IResponse, T>> registerTypedFilter, Func<Container, ITypedFilter<T>>[] filters)
+        private void RegisterTypedFilter<T>(Action<Action<IRequest, IResponse, T>> registerTypedFilter, Func<Container, ITypedFilter<T>> filter)
         {
             registerTypedFilter.Invoke((request, response, dto) =>
             {
-                // The filters MUST be resolved inside the RegisterTypedFilter call.
+                // The filter MUST be resolved inside the RegisterTypedFilter call.
                 // Otherwise, the container will not be able to resolve some auto-wired dependencies.
-                foreach (var filter in filters)
-                    filter
-                        .Invoke(Container)
-                        .Invoke(request, response, dto);
+                filter
+                    .Invoke(Container)
+                    .Invoke(request, response, dto);
             });
         }
 


### PR DESCRIPTION
Changed overloads for register typed filters to remove params keyword.

Original: #1155 