### PR TITLE
Exclude empty arrays in query string

### DIFF
--- a/src/ServiceStack.Client/UrlExtensions.cs
+++ b/src/ServiceStack.Client/UrlExtensions.cs
@@ -481,7 +481,7 @@ namespace ServiceStack
                     continue;
 
                 var value = queryProperty.Value.GetValue(request, true);
-                if (value == null)
+                if (value == null || (value is Array && value.ToJsv() == EmptyArray))
                     continue;
 
                 var qsName = Text.JsConfig.EmitLowercaseUnderscoreNames


### PR DESCRIPTION
Empty arrays pad out the query string length and will cause a 404.15 with ASP.NET projects if the query string exceeds the maximum configured length, this commit excludes empty arrays.