### PR TITLE
fix for getting bearer token when authorization header is empty

### DIFF
--- a/src/ServiceStack/Host/HttpRequestAuthentication.cs
+++ b/src/ServiceStack/Host/HttpRequestAuthentication.cs
@@ -15,6 +15,9 @@ namespace ServiceStack.Host
                 return null;
 
             var pos = auth.IndexOf(' ');
+            if (pos < 0)
+                return null;
+
             return auth.Substring(0, pos).EqualsIgnoreCase("Bearer") ? auth.Substring(pos + 1) : null;
         }
 

--- a/src/ServiceStack/Host/HttpRequestAuthentication.cs
+++ b/src/ServiceStack/Host/HttpRequestAuthentication.cs
@@ -11,7 +11,8 @@ namespace ServiceStack.Host
         public static string GetBearerToken(this IRequest httpReq)
         {
             var auth = httpReq.Headers[HttpHeaders.Authorization];
-            if (auth == null) return null;
+            if (string.IsNullOrEmpty(auth))
+                return null;
 
             var pos = auth.IndexOf(' ');
             return auth.Substring(0, pos).EqualsIgnoreCase("Bearer") ? auth.Substring(pos + 1) : null;

--- a/tests/ServiceStack.ServiceHost.Tests/HttpRequestAuthenticatonTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/HttpRequestAuthenticatonTests.cs
@@ -56,6 +56,22 @@ namespace ServiceStack.ServiceHost.Tests
         }
 
         [Test]
+        public void Should_Return_Null_As_Bearer_Token_When_Authorization_Header_Does_Not_Prefix()
+        {
+            // PREPARE
+            var sut = new Mock<IRequest>();
+            var headers = PclExportClient.Instance.NewNameValueCollection();
+            headers.Add("Authorization", "Blablabla");
+            sut.Setup(e => e.Headers).Returns(headers);
+
+            // RUN
+            var bearerToken = sut.Object.GetBearerToken();
+
+            // ASSERT
+            Assert.Null(bearerToken);
+        }
+
+        [Test]
         public void Should_Return_Null_As_Bearer_Token_When_Authorization_Header_Does_Not_Contain_Bearer()
         {
             // PREPARE
@@ -70,6 +86,8 @@ namespace ServiceStack.ServiceHost.Tests
             // ASSERT
             Assert.Null(bearerToken);
         }
+
+
 
         [Test]
         public void Can_Return_Bearer_Token()

--- a/tests/ServiceStack.ServiceHost.Tests/HttpRequestAuthenticatonTests.cs
+++ b/tests/ServiceStack.ServiceHost.Tests/HttpRequestAuthenticatonTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Specialized;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Moq;
 using ServiceStack.Host;
 using ServiceStack.Web;
@@ -22,6 +21,70 @@ namespace ServiceStack.ServiceHost.Tests
             var res = requestMock.Object.GetDigestAuth();
 
             Assert.NotNull(res);
+        }
+
+        [Test]
+        public void Should_Return_Null_When_Authorization_Header_Is_Missing()
+        {
+            // PREPARE
+            var sut = new Mock<IRequest>();
+            var headers = PclExportClient.Instance.NewNameValueCollection();
+            sut.Setup(e => e.Headers).Returns(headers);
+
+            // RUN
+            var bearerToken = sut.Object.GetBearerToken();
+
+            // ASSERT
+            Assert.Null(bearerToken);
+        }
+
+        [Test]
+        public void Should_Return_Null_As_Bearer_Token_When_Authorization_Header_Is_Empty()
+        {
+            // PREPARE
+            var sut = new Mock<IRequest>();
+            var headers = PclExportClient.Instance.NewNameValueCollection();
+            headers.Add("Authorization", string.Empty);
+
+            sut.Setup(e => e.Headers).Returns(headers);
+
+            // RUN
+            var bearerToken = sut.Object.GetBearerToken();
+
+            // ASSERT
+            Assert.Null(bearerToken);
+        }
+
+        [Test]
+        public void Should_Return_Null_As_Bearer_Token_When_Authorization_Header_Does_Not_Contain_Bearer()
+        {
+            // PREPARE
+            var sut = new Mock<IRequest>();
+            var headers = PclExportClient.Instance.NewNameValueCollection();
+            headers.Add("Authorization", "Basic blablabla");
+            sut.Setup(e => e.Headers).Returns(headers);
+
+            // RUN
+            var bearerToken = sut.Object.GetBearerToken();
+
+            // ASSERT
+            Assert.Null(bearerToken);
+        }
+
+        [Test]
+        public void Can_Return_Bearer_Token()
+        {
+            // PREPARE
+            var sut = new Mock<IRequest>();
+            var headers = PclExportClient.Instance.NewNameValueCollection();
+            headers.Add("Authorization", "Bearer blablabla");
+            sut.Setup(e => e.Headers).Returns(headers);
+
+            // RUN
+            var bearerToken = sut.Object.GetBearerToken();
+
+            // ASSERT
+            Assert.True("blablabla" == bearerToken);
         }
     }
 }


### PR DESCRIPTION
Fix for situation when authorization header is present but it is empty.