### PR TITLE
Typescript type generator does not properly output a default value for the C# bool type.

### DIFF
--- a/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -54,6 +54,7 @@ namespace ServiceStack.NativeTypes.TypeScript
             {"String", declaredEmptyString},
             {"string", declaredEmptyString},
             {"Boolean", "false"},
+            {"boolean", "false"},
             {"DateTime", declaredEmptyString},
             {"DateTimeOffset", declaredEmptyString},
             {"TimeSpan", declaredEmptyString},


### PR DESCRIPTION
Given the following route:
![image](https://user-images.githubusercontent.com/2873559/30349285-66cd0662-980a-11e7-8f3a-ba5f84d4ee9e.png)

generating native types for typescript produces the following output:
![image](https://user-images.githubusercontent.com/2873559/30349254-3d532f28-980a-11e7-93bf-7efd5895ad23.png)

the `createResponse ` return value should be `false`, not `new boolean()`
