### PR TITLE
Make ThrowResponseTypeException protected

### DIFF
--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -753,7 +753,7 @@ namespace ServiceStack
         readonly ConcurrentDictionary<Type, Action<Exception, string>> ResponseHandlers
             = new ConcurrentDictionary<Type, Action<Exception, string>>();
 
-        private void ThrowResponseTypeException<TResponse>(object request, Exception ex, string requestUri)
+        protected void ThrowResponseTypeException<TResponse>(object request, Exception ex, string requestUri)
         {
             var responseType = WebRequestUtils.GetErrorResponseDtoType<TResponse>(request);
             Action<Exception, string> responseHandler;


### PR DESCRIPTION
I'd like this method to be protected so we can override `ServiceClientBase.HandleResponseException` and provide minimal changes to it, but still keep the default behavior of it as is. (see [discussion](https://forums.servicestack.net/t/serviceclientbase-new-authentication-behaviour/4659/3))