### PR TITLE
Fix invalid security requirement in generated api schema

### DIFF
--- a/src/ServiceStack.Api.OpenApi/Specification/OpenApiDeclaration.cs
+++ b/src/ServiceStack.Api.OpenApi/Specification/OpenApiDeclaration.cs
@@ -46,7 +46,7 @@ namespace ServiceStack.Api.OpenApi.Specification
         public Dictionary<string, OpenApiSecuritySchema> SecurityDefinitions { get; set; }
 
         [DataMember(Name = "security")]
-        public Dictionary<string, List<string>> Security { get; set; }
+        public List<Dictionary<string, List<string>>> Security { get; set; }
 
         [DataMember(Name = "tags")]
         public List<OpenApiTag> Tags { get; set; }


### PR DESCRIPTION
The security requirement for OpenApiDeclaration should be a List<Dictionary<string, List<string>>>, as it is for OpenApiOperation.