### PR TITLE
Restore IsAccountLocked to protected from internal

### DIFF
--- a/src/ServiceStack/Auth/AuthProvider.cs
+++ b/src/ServiceStack/Auth/AuthProvider.cs
@@ -335,7 +335,7 @@ namespace ServiceStack.Auth
             return session.ReferrerUrl;
         }
 
-        internal virtual bool IsAccountLocked(IAuthRepository authRepo, IUserAuth userAuth, IAuthTokens tokens=null)
+        protected virtual bool IsAccountLocked(IAuthRepository authRepo, IUserAuth userAuth, IAuthTokens tokens=null)
         {
             return userAuth?.LockedDate != null;
         }


### PR DESCRIPTION
This was previously protected (was using 4.0.40, updated to 4.5.14 today) and we had overridden this function and now can't because it's marked internal.