### PR TITLE
Add Cloudflare IP

### DIFF
--- a/src/ServiceStack.Interfaces/Web/IRequest.cs
+++ b/src/ServiceStack.Interfaces/Web/IRequest.cs
@@ -128,6 +128,11 @@ namespace ServiceStack.Web
         /// The Remote Ip as reported by X-Forwarded-For, X-Real-IP or Request.UserHostAddress
         /// </summary>
         string RemoteIp { get; }
+        
+        /// <summary>
+        /// The Remote Ip as reported by CF-Connecting-IP
+        /// </summary>
+        string CloudflareIp { get { return Headers["CF-Connecting-IP"]; } }
 
         /// <summary>
         /// The value of the Authorization Header used to send the Api Key, null if not available


### PR DESCRIPTION
ServiceStack needs a way to get the real IP for Cloudflare visitors.
This may not be the right place to add it.. there's other classes where it may be appropriate. Feel free to close this request and submit your own if this is wrong.