### PR TITLE
GatewayExecuteAsync: don't apply response filters when applyFilters is false

### DIFF
--- a/src/ServiceStack/Host/ServiceController.cs
+++ b/src/ServiceStack/Host/ServiceController.cs
@@ -687,12 +687,12 @@ namespace ServiceStack.Host
                         if (ret == null)
                             ret = (object[])Array.CreateInstance(tResult.GetType(), tasks.Length);
 
-                        ret[i] = await ApplyResponseFiltersAsync(tResult, req);
+                        ret[i] = applyFilters ? await ApplyResponseFiltersAsync(tResult, req) : tResult;
                     }
                     return ret;
                 }
 
-                return await ApplyResponseFiltersAsync(response, req);
+                return applyFilters ? await ApplyResponseFiltersAsync(response, req) : response;
             }
 
             return applyFilters

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/InProcessServiceGatewayRequestResponseFiltersTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/InProcessServiceGatewayRequestResponseFiltersTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Funq;
+using NUnit.Framework;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    public class SomeResponse
+    {
+        public string Info { get; set; }
+    }
+
+    public class InternalResponse : SomeResponse
+    {
+    }
+
+    public class RequestSync : IReturn<SomeResponse> { }
+    public class RequestAsync : IReturn<SomeResponse> { }
+    public class RequestInternal: IGet, IReturn<InternalResponse> { }
+
+    public class FooBarService: Service
+    {
+        public SomeResponse Get(RequestSync request)
+        {
+            var resp = Gateway.Send(new RequestInternal());
+            return new SomeResponse() {Info = resp.Info};
+        }
+
+        public async Task<SomeResponse> Get(RequestAsync req)
+        {
+            var resp = await Gateway.SendAsync(new RequestInternal());
+            return new SomeResponse() {Info = resp.Info};
+        }
+
+        public Task<InternalResponse> Get(RequestInternal req) => Task.FromResult(new InternalResponse() {Info = "yay"});
+    }
+
+    public class InProcessServiceGatewayRequestResponseFiltersTests
+    {
+        class InProcessAppHost : AppSelfHostBase
+        {
+            public InProcessAppHost() : base(typeof(InProcessServiceGatewayRequestResponseFiltersTests).Name, 
+                typeof(ServiceGatewayServices).Assembly) { }
+
+            public override void Configure(Container container)
+            {                
+            }
+        }
+
+        private readonly ServiceStackHost _appHost;        
+        private readonly List<string> _filterCallLog = new List<string>();
+        private readonly JsonServiceClient _client;
+
+        public InProcessServiceGatewayRequestResponseFiltersTests()
+        {
+            _appHost = new InProcessAppHost();
+            _appHost.GlobalRequestFilters.Add((req ,resp, dto) => _filterCallLog.Add(req.PathInfo));
+            _appHost.GlobalResponseFilters.Add((req, resp, dto) => _filterCallLog.Add(dto.GetType().Name));
+
+            _appHost.Init()
+                .Start(Config.ListeningOn);
+            _client = new JsonServiceClient(Config.ListeningOn);
+        }
+
+        [TearDown]
+        public void CleanAfterTest()
+        {
+            _filterCallLog.Clear();
+        }
+
+        [OneTimeTearDown]
+        public void TestFixtureTearDown()
+        {
+            _appHost.Dispose();
+        }
+
+        [Test]
+        public void Should_Not_Call_Filters_When_Using_SyncGateway()
+        {
+            var result = _client.Get(new RequestSync());
+            Assert.AreEqual("yay", result.Info);            
+            CollectionAssert.AreEqual(new []{ "/json/reply/RequestSync", "SomeResponse" }, _filterCallLog);
+        }
+
+        [Test]
+        public void Should_Not_Call_Filters_When_Using_AsyncGateway()
+        {
+            var result = _client.Get(new RequestAsync());
+            Assert.AreEqual("yay", result.Info);
+            CollectionAssert.AreEqual(new[] { "/json/reply/RequestAsync", "SomeResponse" }, _filterCallLog);
+        }
+    }
+}


### PR DESCRIPTION
this fixes a bug in ServiceController.ExecAsync - when instructed not to apply filters, Respone filters are applied anyway (but not Request filters, making it even worse in my case).

I've discovered it when using Service Gateway (Sync and Async), that's why the tests are using Gateway and not comparing Exec/ExecAsync directly. I suppose they could be made shorter but I believe they still show the point.

without the fix, the second test (using Gateway.SendAsync) fails as the list contains 3 elements (ResponseFilter is called for Internal Request made through Gateway)