### PR TITLE
Fixes NLog bug introduced when adding support for async PushProperty

### DIFF
--- a/src/ServiceStack.Logging.NLog/NLogLogger.cs
+++ b/src/ServiceStack.Logging.NLog/NLogLogger.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.Logging.NLogger
 
         public NLogLogger(string typeName)
         {
-            log = NLog.LogManager.GetLogger(typeName, typeof(NLogLogger));
+            log = NLog.LogManager.GetLogger(typeName);
         }
 
         /// <summary>
@@ -21,7 +21,7 @@ namespace ServiceStack.Logging.NLogger
         /// <param name="type">The type.</param>
         public NLogLogger(Type type)
         {
-            log = NLog.LogManager.GetLogger(UseFullTypeNames ? type.FullName : type.Name, typeof(NLogLogger));
+            log = NLog.LogManager.GetLogger(UseFullTypeNames ? type.FullName : type.Name);
         }
 
         public static bool UseFullTypeNames { get; set; }

--- a/tests/ServiceStack.Logging.Tests/UnitTests/NLogTests.cs
+++ b/tests/ServiceStack.Logging.Tests/UnitTests/NLogTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NUnit.Framework;
-using ServiceStack.Logging;
 
 namespace ServiceStack.Logging.Tests.UnitTests
 {
@@ -10,23 +9,52 @@ namespace ServiceStack.Logging.Tests.UnitTests
         [Test]
         public void Does_maintain_callsite()
         {
-            Logging.LogManager.LogFactory = new NLogger.NLogFactory();
-
-            var log = ServiceStack.Logging.LogManager.LogFactory.GetLogger(GetType());
-            log.InfoFormat("Message");
-            log.InfoFormat("Message with Args {0}", "Foo");
-            log.Info("Message with Exception", new Exception("Foo Exception"));
+            try
+            {
+                var target = new NLog.Targets.MemoryTarget();
+                NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+                Logging.LogManager.LogFactory = new NLogger.NLogFactory();
+                var stringWriter = new System.IO.StringWriter();
+                NLog.Common.InternalLogger.LogLevel = NLog.LogLevel.Warn;
+                NLog.Common.InternalLogger.LogWriter = stringWriter;
+                var log = ServiceStack.Logging.LogManager.LogFactory.GetLogger(GetType());
+                log.InfoFormat("Message");
+                log.InfoFormat("Message with Args {0}", "Foo");
+                log.Info("Message with Exception", new Exception("Foo Exception"));
+                Assert.AreEqual(0, stringWriter.GetStringBuilder().Length);
+                Assert.AreEqual(3, target.Logs.Count);
+            }
+            finally
+            {
+                NLog.Common.InternalLogger.Reset();
+                NLog.LogManager.Configuration = null;
+            }
         }
 
         [Test]
         public void PushPropertyTest()
         {
-            Logging.LogManager.LogFactory = new NLogger.NLogFactory();
-
-            var log = Logging.LogManager.LogFactory.GetLogger(GetType());
-            using (log.PushProperty("Hello", "World"))
+            try
             {
-                log.InfoFormat("Message");
+                var target = new NLog.Targets.MemoryTarget();
+                NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target);
+                Logging.LogManager.LogFactory = new NLogger.NLogFactory();
+                var stringWriter = new System.IO.StringWriter();
+                NLog.Common.InternalLogger.LogLevel = NLog.LogLevel.Warn;
+                NLog.Common.InternalLogger.LogWriter = stringWriter;
+                var log = Logging.LogManager.LogFactory.GetLogger(GetType());
+                using (log.PushProperty("Hello", "World"))
+                {
+                    log.InfoFormat("Message");
+                }
+                Assert.AreEqual(0, stringWriter.GetStringBuilder().Length);
+                Assert.AreEqual(0, stringWriter.GetStringBuilder().Length);
+                Assert.AreEqual(1, target.Logs.Count);
+            }
+            finally
+            {
+                NLog.Common.InternalLogger.Reset();
+                NLog.LogManager.Configuration = null;
             }
         }
     }


### PR DESCRIPTION
Fixes bug introduced with #1171 

See also https://forums.servicestack.net/t/wierd-error-trying-to-instantiate-nlogger-with-servicestack/5115