### PR TITLE
Implements support for log4Net in Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ requestlogs/
 
 *.DS_Store
 
-NuGet/
 NuGet.Pcl/
 NuGet.Signed/
 

--- a/NuGet/NuGetPack.cmd
+++ b/NuGet/NuGetPack.cmd
@@ -26,6 +26,7 @@ SET NUGET=..\src\.nuget\nuget
 %NUGET% pack ServiceStack.Logging.EntLib5\servicestack.logging.entlib5.nuspec -symbols
 %NUGET% pack ServiceStack.Logging.EventLog\servicestack.logging.eventlog.nuspec -symbols
 %NUGET% pack ServiceStack.Logging.Log4Net\servicestack.logging.log4net.nuspec -symbols
+%NUGET% pack ServiceStack.Logging.Log4Net\servicestack.logging.log4net.core.nuspec -symbols
 %NUGET% pack ServiceStack.Logging.NLog\servicestack.logging.nlog.nuspec -symbols
 %NUGET% pack ServiceStack.Logging.Serilog\servicestack.logging.serilog.nuspec -symbols
 

--- a/NuGet/ServiceStack.Logging.Log4Net.Core/servicestack.logging.log4net.core.nuspec
+++ b/NuGet/ServiceStack.Logging.Log4Net.Core/servicestack.logging.log4net.core.nuspec
@@ -19,10 +19,9 @@
     <copyright>ServiceStack and contributors</copyright>
     <dependencies>
       <group targetFramework=".netstandard2.0">
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0" />
         <dependency id="log4net" version="[2.0.8, )" />
         <dependency id="ServiceStack.Interfaces.Core" version="5.0.0" />
-		<dependency id="Microsoft.Extensions.Logging" version="[2.0.8, )" />
+		    <dependency id="Microsoft.Extensions.Logging" version="1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/NuGet/ServiceStack.Logging.Log4Net.Core/servicestack.logging.log4net.core.nuspec
+++ b/NuGet/ServiceStack.Logging.Log4Net.Core/servicestack.logging.log4net.core.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>ServiceStack.Logging.Log4Net.Core</id>
+    <version>5.0.0</version>
+    <title>ServiceStack.Logging.Log4Net.Core</title>
+    <authors>ServiceStack</authors>
+    <owners>ServiceStack</owners>
+    <summary>log4Net logging integration for ServiceStack, the Opensource .NET and Mono REST Web Services Framework</summary>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      Provides log4net logging integration for other ServiceStack projects
+    </description>
+    <projectUrl>https://github.com/ServiceStack/ServiceStack</projectUrl>
+    <licenseUrl>https://servicestack.net/terms</licenseUrl>
+    <iconUrl>https://servicestack.net/img/logo-32.png</iconUrl>
+    <tags>servicestack log logging log4net</tags>
+    <language>en-US</language>
+    <copyright>ServiceStack and contributors</copyright>
+    <dependencies>
+      <group targetFramework=".netstandard2.0">
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0" />
+        <dependency id="log4net" version="[2.0.8, )" />
+        <dependency id="ServiceStack.Interfaces.Core" version="5.0.0" />
+		<dependency id="Microsoft.Extensions.Logging" version="[2.0.8, )" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\**\*.*" target="lib" />
+    <file src="..\..\src\ServiceStack.Logging.Log4Net.Core\**\*.cs" target="src" />
+  </files>
+</package>

--- a/build/build.proj
+++ b/build/build.proj
@@ -330,6 +330,18 @@
     <Exec Command="&quot;$(NuGetPath)&quot; pack &quot;$(NuGetPackageDir)/ServiceStack.Logging.Log4Net/servicestack.logging.log4net.nuspec&quot; -OutputDirectory &quot;$(NuGetPackageDir)&quot; -Version $(PackageVersion) -Symbols"
             LogStandardErrorAsError="true" />
 
+    <!-- ServiceStack.Logging.Log4Net.Core -->
+
+    <MSBuild Projects="$(SrcDir)/ServiceStack.Logging.Log4Net.Core/ServiceStack.Logging.Log4Net.Core.csproj"
+             Targets="Build"
+             Properties="Version=$(PackageVersion);Configuration=$(Configuration)" />
+
+    <MakeDir Directories="$(NuGetPackageDir)/ServiceStack.Logging.Log4Net.Core/lib/netstandard2.0" Condition="!Exists('$(NuGetPackageDir)/ServiceStack.Logging.Log4Net.Core/lib/netstandard2.0')" />
+    <Copy SourceFiles="%(Log4NetFiles.Identity)" DestinationFolder="$(NuGetPackageDir)/ServiceStack.Logging.Log4Net/lib/netstandard2.0" />
+
+    <Exec Command="&quot;$(NuGetPath)&quot; pack &quot;$(NuGetPackageDir)/ServiceStack.Logging.Log4Net.Core/servicestack.logging.log4net.core.nuspec&quot; -OutputDirectory &quot;$(NuGetPackageDir)&quot; -Version $(PackageVersion) -Symbols"
+            LogStandardErrorAsError="true" />
+
     <!-- ServiceStack.Logging.NLog -->
 
     <MSBuild Projects="$(SrcDir)/ServiceStack.Logging.NLog/ServiceStack.Logging.NLog.csproj"

--- a/src/ServiceStack.Logging.Log4Net.Core/AssemblyInfo.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/AssemblyInfo.cs
@@ -1,0 +1,40 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack.Logging.Log4Net.Core")]
+[assembly: AssemblyDescription(@"Provides log4net logging integration for other ServiceStack projects
+        Includes: 
+            - ServiceStack.Logging.Log4Net.dll
+        Dependencies:
+            - ServiceStack.Interfaces.dll")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Demis Bellot")]
+[assembly: AssemblyProduct("ServiceStack.Logging.Log4Net.Core")]
+[assembly: AssemblyCopyright("Copyright � ServiceStack 2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d575bdba-a6db-464c-8c41-bd0694b79b02")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/ServiceStack.Logging.Log4Net.Core/Log4NetFactory.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/Log4NetFactory.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace ServiceStack.Logging.Log4Net.Core
+{
+    /// <summary>
+    /// ILogFactory that creates an Log4Net ILog logger
+    /// </summary>
+    public class Log4NetFactory : ILogFactory
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetFactory"/> class.
+        /// </summary>
+        public Log4NetFactory() : this(false) { }
+        private log4net.Repository.ILoggerRepository _rootRepository;
+
+        public log4net.Repository.ILoggerRepository RootRepository
+        {
+            get
+            {
+                if (_rootRepository == null)
+                {
+                    _rootRepository = log4net.LogManager.GetRepository(Assembly.GetEntryAssembly());
+                }
+                return _rootRepository;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetFactory"/> class.
+        /// </summary>
+        /// <param name="configureLog4Net">if set to <c>true</c> [will use the xml definition in App.Config to configure log4 net].</param>
+        public Log4NetFactory(bool configureLog4Net)
+        {
+            if (configureLog4Net)
+            {
+                log4net.Config.XmlConfigurator.Configure(RootRepository);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetFactory"/> class.
+        /// </summary>
+        /// <param name="log4NetConfigurationFile">The log4 net configuration file to load and watch. If not found configures from App.Config.</param>
+        public Log4NetFactory(string log4NetConfigurationFile)
+        {
+            if (File.Exists(log4NetConfigurationFile))
+                log4net.Config.XmlConfigurator.ConfigureAndWatch(RootRepository, new FileInfo(log4NetConfigurationFile));
+            else
+                log4net.Config.XmlConfigurator.Configure(RootRepository);
+        }
+
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
+        public ILog GetLogger(Type type)
+        {
+            return new Log4NetLogger(type);
+        }
+
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        /// <param name="typeName">Name of the type.</param>
+        /// <returns></returns>
+        public ILog GetLogger(string typeName)
+        {
+            return new Log4NetLogger(typeName);
+        }
+    }
+}

--- a/src/ServiceStack.Logging.Log4Net.Core/Log4NetLogger.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/Log4NetLogger.cs
@@ -312,20 +312,20 @@ namespace ServiceStack.Logging.Log4Net.Core
                 switch (logLevel)
                 {
                     case LogLevel.Critical:
-                        _log.Fatal(message);
+                        _log.Fatal(message, exception);
                         break;
                     case LogLevel.Debug:
                     case LogLevel.Trace:
-                        _log.Debug(message);
+                        _log.Debug(message, exception);
                         break;
                     case LogLevel.Error:
-                        _log.Error(message);
+                        _log.Error(message, exception);
                         break;
                     case LogLevel.Information:
-                        _log.Info(message);
+                        _log.Info(message, exception);
                         break;
                     case LogLevel.Warning:
-                        _log.Warn(message);
+                        _log.Warn(message, exception);
                         break;
                     default:
                         _log.Warn($"Encountered unknown log level {logLevel}, writing out as Info.");

--- a/src/ServiceStack.Logging.Log4Net.Core/Log4NetLogger.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/Log4NetLogger.cs
@@ -1,0 +1,353 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Reflection;
+
+namespace ServiceStack.Logging.Log4Net.Core
+{
+    public class Log4NetLogger : ILogWithContext, ILogger
+    {
+        private readonly log4net.ILog _log;
+        private Assembly _mainAssembly = Assembly.GetEntryAssembly();
+
+        public Log4NetLogger(string name)
+        {
+            _log = log4net.LogManager.GetLogger(_mainAssembly, name);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public Log4NetLogger(Type type)
+        {
+            _log = log4net.LogManager.GetLogger(type);
+        }
+
+        public bool IsDebugEnabled => _log.IsDebugEnabled;
+
+        /// <summary>
+        /// Logs a Debug message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Debug(object message)
+        {
+            if (_log.IsDebugEnabled)
+                _log.Debug(message);
+        }
+
+        /// <summary>
+        /// Logs a Debug message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Debug(object message, Exception exception)
+        {
+            if (_log.IsDebugEnabled)
+                _log.Debug(message, exception);
+        }
+
+        /// <summary>
+        /// Logs a Debug format message and exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void Debug(Exception exception, string format, params object[] args)
+        {
+            if (_log.IsDebugEnabled)
+                _log.Debug(string.Format(format, args), exception);
+        }
+
+        /// <summary>
+        /// Logs a Debug format message.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void DebugFormat(string format, params object[] args)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat(format, args);
+        }
+
+        /// <summary>
+        /// Logs a Error message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Error(object message)
+        {
+            if (_log.IsErrorEnabled)
+                _log.Error(message);
+        }
+
+        /// <summary>
+        /// Logs a Error message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Error(object message, Exception exception)
+        {
+            if (_log.IsErrorEnabled)
+                _log.Error(message, exception);
+        }
+
+        /// <summary>
+        /// Logs an Error format message and exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void Error(Exception exception, string format, params object[] args)
+        {
+            if (_log.IsErrorEnabled)
+                _log.Error(string.Format(format, args), exception);
+        }
+
+        /// <summary>
+        /// Logs a Error format message.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void ErrorFormat(string format, params object[] args)
+        {
+            if (_log.IsErrorEnabled)
+                _log.ErrorFormat(format, args);
+        }
+
+        /// <summary>
+        /// Logs a Fatal message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Fatal(object message)
+        {
+            if (_log.IsFatalEnabled)
+                _log.Fatal(message);
+        }
+
+        /// <summary>
+        /// Logs a Fatal message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Fatal(object message, Exception exception)
+        {
+            if (_log.IsFatalEnabled)
+                _log.Fatal(message, exception);
+        }
+
+        /// <summary>
+        /// Logs a Fatal format message and exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void Fatal(Exception exception, string format, params object[] args)
+        {
+            if (_log.IsFatalEnabled)
+                _log.Fatal(string.Format(format, args), exception);
+        }
+
+        /// <summary>
+        /// Logs a Error format message.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void FatalFormat(string format, params object[] args)
+        {
+            if (_log.IsFatalEnabled)
+                _log.FatalFormat(format, args);
+        }
+
+        /// <summary>
+        /// Logs an Info message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Info(object message)
+        {
+            if (_log.IsInfoEnabled)
+                _log.Info(message);
+        }
+
+        /// <summary>
+        /// Logs an Info message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Info(object message, Exception exception)
+        {
+            if (_log.IsInfoEnabled)
+                _log.Info(message, exception);
+        }
+
+        /// <summary>
+        /// Logs an Info format message and exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void Info(Exception exception, string format, params object[] args)
+        {
+            if (_log.IsInfoEnabled)
+                _log.Info(string.Format(format, args), exception);
+        }
+
+        /// <summary>
+        /// Logs an Info format message.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void InfoFormat(string format, params object[] args)
+        {
+            if (_log.IsInfoEnabled)
+                _log.InfoFormat(format, args);
+        }
+
+        public IDisposable PushProperty(string key, object value)
+        {
+            log4net.LogicalThreadContext.Properties[key] = value;
+            return new RemovePropertyOnDispose(key);
+        }
+
+        /// <summary>
+        /// Logs a Warning message.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void Warn(object message)
+        {
+            if (_log.IsWarnEnabled)
+                _log.Warn(message);
+        }
+
+        /// <summary>
+        /// Logs a Warning message and exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">The exception.</param>
+        public void Warn(object message, Exception exception)
+        {
+            if (_log.IsWarnEnabled)
+                _log.Warn(message, exception);
+        }
+
+        /// <summary>
+        /// Logs a Warn format message and exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void Warn(Exception exception, string format, params object[] args)
+        {
+            if (_log.IsWarnEnabled)
+                _log.Warn(string.Format(format, args), exception);
+        }
+
+        /// <summary>
+        /// Logs a Warning format message.
+        /// </summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The args.</param>
+        public void WarnFormat(string format, params object[] args)
+        {
+            if (_log.IsWarnEnabled)
+                _log.WarnFormat(format, args);
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Check is a logLevel is enabled.
+        /// </summary>
+        /// <param name="logLevel">the level.</param>
+        /// <returns></returns>
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return _log.IsFatalEnabled;
+                case LogLevel.Debug:
+                case LogLevel.Trace:
+                    return _log.IsDebugEnabled;
+                case LogLevel.Error:
+                    return _log.IsErrorEnabled;
+                case LogLevel.Information:
+                    return _log.IsInfoEnabled;
+                case LogLevel.Warning:
+                    return _log.IsWarnEnabled;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        /// <summary>
+        /// Logs a message from Logging into Log4Net.
+        /// </summary>
+        /// <typeparam name="TState"></typeparam>
+        /// <param name="logLevel">The level.</param>
+        /// <param name="eventId">The eventId.</param>
+        /// <param name="state">The state.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="formatter">The formatter.</param>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (formatter == null)
+            {
+                throw new ArgumentNullException(nameof(formatter));
+            }
+            string message = null;
+            if (null != formatter)
+            {
+                message = formatter(state, exception);
+            }
+            if (!string.IsNullOrEmpty(message) || exception != null)
+            {
+                switch (logLevel)
+                {
+                    case LogLevel.Critical:
+                        _log.Fatal(message);
+                        break;
+                    case LogLevel.Debug:
+                    case LogLevel.Trace:
+                        _log.Debug(message);
+                        break;
+                    case LogLevel.Error:
+                        _log.Error(message);
+                        break;
+                    case LogLevel.Information:
+                        _log.Info(message);
+                        break;
+                    case LogLevel.Warning:
+                        _log.Warn(message);
+                        break;
+                    default:
+                        _log.Warn($"Encountered unknown log level {logLevel}, writing out as Info.");
+                        _log.Info(message, exception);
+                        break;
+                }
+            }
+        }
+
+        private class RemovePropertyOnDispose : IDisposable
+        {
+            private readonly string removeKey;
+
+            public RemovePropertyOnDispose(string removeKey)
+            {
+                this.removeKey = removeKey;
+            }
+
+            public void Dispose()
+            {
+                log4net.LogicalThreadContext.Properties.Remove(removeKey);
+            }
+        }
+    }
+}

--- a/src/ServiceStack.Logging.Log4Net.Core/Log4NetProvider.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/Log4NetProvider.cs
@@ -15,6 +15,10 @@ namespace ServiceStack.Logging.Log4Net.Core
         private readonly ConcurrentDictionary<string, Log4NetLogger> _loggers =
             new ConcurrentDictionary<string, Log4NetLogger>();
 
+        public Log4NetProvider()
+        {
+        }
+
         public Log4NetProvider(string log4NetConfigFile)
         {
             Parselog4NetConfigFile(log4NetConfigFile);
@@ -82,7 +86,7 @@ namespace ServiceStack.Logging.Log4Net.Core
 
         public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
         {
-            factory.AddProvider(new Log4NetProvider("log4net.config"));
+            factory.AddProvider(new Log4NetProvider());
             return factory;
         }
     }

--- a/src/ServiceStack.Logging.Log4Net.Core/Log4NetProvider.cs
+++ b/src/ServiceStack.Logging.Log4Net.Core/Log4NetProvider.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+using System.Xml;
+using log4net.Repository;
+using Microsoft.Extensions.Logging;
+
+namespace ServiceStack.Logging.Log4Net.Core
+{
+    public class Log4NetProvider : ILoggerProvider
+    {
+        /// <summary>
+        /// The Dictionary containing the associated logger implementations of each category
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Log4NetLogger> _loggers =
+            new ConcurrentDictionary<string, Log4NetLogger>();
+
+        public Log4NetProvider(string log4NetConfigFile)
+        {
+            Parselog4NetConfigFile(log4NetConfigFile);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="ILogger"/> implementation for a category
+        /// </summary>
+        /// <param name="categoryName">the category name.</param>
+        /// <returns></returns>
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="ILogger"/> implementation.
+        /// </summary>
+        /// <param name="name">the name.</param>
+        /// <returns></returns>
+        private Log4NetLogger CreateLoggerImplementation(string name)
+        {
+            return new Log4NetLogger(name);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="ILogger"/> implementation with a configuration file.
+        /// </summary>
+        /// <param name="name">the name.</param>
+        /// <param name="log4NetConfigFile">the file uri.</param>
+        /// <returns></returns>
+        private Log4NetLogger CreateLoggerImplementation(string name, string log4NetConfigFile)
+        {
+            Parselog4NetConfigFile(log4NetConfigFile);
+            return new Log4NetLogger(name);
+        }
+
+        /// <summary>
+        /// Parse a configuration file given his uri
+        /// </summary>
+        /// <param name="log4NetConfigFile">the file uri.</param>
+        private static void Parselog4NetConfigFile(string log4NetConfigFile)
+        {
+            ILoggerRepository rootRepository = log4net.LogManager.GetRepository(Assembly.GetEntryAssembly());
+
+            if (File.Exists(log4NetConfigFile))
+                log4net.Config.XmlConfigurator.ConfigureAndWatch(rootRepository, new FileInfo(log4NetConfigFile));
+            else
+                log4net.Config.XmlConfigurator.Configure(rootRepository);
+        }
+
+        public void Dispose()
+        {
+            _loggers.Clear();
+        }
+    }
+
+    public static class Log4netExtensions
+    {
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile)
+        {
+            factory.AddProvider(new Log4NetProvider(log4NetConfigFile));
+            return factory;
+        }
+
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
+        {
+            factory.AddProvider(new Log4NetProvider("log4net.config"));
+            return factory;
+        }
+    }
+}

--- a/src/ServiceStack.Logging.Log4Net.Core/ServiceStack.Logging.Log4Net.Core.csproj
+++ b/src/ServiceStack.Logging.Log4Net.Core/ServiceStack.Logging.Log4Net.Core.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>ServiceStack.Logging.Log4Net.Core</AssemblyName>
+    <PackageId>ServiceStack.Logging.Log4Net.Core</PackageId>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' != 'Debug' ">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Reference Include="..\..\lib\netstandard2.0\ServiceStack.Text.dll" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Reference Include="System">
+      <HintPath>System</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/ServiceStack.Logging.sln
+++ b/src/ServiceStack.Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceStack.Logging.EventLog", "ServiceStack.Logging.EventLog\ServiceStack.Logging.EventLog.csproj", "{D920BA88-E394-4C75-94E3-78D7298A8457}"
 EndProject
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{CA7CF53F
 		..\NuGet\ServiceStack.Logging.Elmah\servicestack.logging.elmah.nuspec = ..\NuGet\ServiceStack.Logging.Elmah\servicestack.logging.elmah.nuspec
 		..\NuGet\ServiceStack.Logging.EntLib5\servicestack.logging.entlib5.nuspec = ..\NuGet\ServiceStack.Logging.EntLib5\servicestack.logging.entlib5.nuspec
 		..\NuGet\ServiceStack.Logging.EventLog\servicestack.logging.eventlog.nuspec = ..\NuGet\ServiceStack.Logging.EventLog\servicestack.logging.eventlog.nuspec
+		..\NuGet\ServiceStack.Logging.Log4Net.Core\servicestack.logging.log4net.core.nuspec = ..\NuGet\ServiceStack.Logging.Log4Net.Core\servicestack.logging.log4net.core.nuspec
 		..\NuGet\ServiceStack.Logging.Log4Net\servicestack.logging.log4net.nuspec = ..\NuGet\ServiceStack.Logging.Log4Net\servicestack.logging.log4net.nuspec
 		..\NuGet\ServiceStack.Logging.NLog\servicestack.logging.nlog.nuspec = ..\NuGet\ServiceStack.Logging.NLog\servicestack.logging.nlog.nuspec
 		..\NuGet\ServiceStack.Logging.Serilog\servicestack.logging.serilog.nuspec = ..\NuGet\ServiceStack.Logging.Serilog\servicestack.logging.serilog.nuspec
@@ -38,6 +39,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceStack.Logging.Slack", "ServiceStack.Logging.Slack\ServiceStack.Logging.Slack.csproj", "{11E70C3D-D27A-4370-98D7-FE4F69F3C70A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceStack.Logging.Serilog", "ServiceStack.Logging.Serilog\ServiceStack.Logging.Serilog.csproj", "{D13C55F2-2688-41E1-B4D1-6B6609851844}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Logging.Log4Net.Core", "ServiceStack.Logging.Log4Net.Core\ServiceStack.Logging.Log4Net.Core.csproj", "{302CE57E-97EF-4A45-ACB3-B20174A92D07}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -148,6 +151,16 @@ Global
 		{D13C55F2-2688-41E1-B4D1-6B6609851844}.Signed|Any CPU.Build.0 = Release|Any CPU
 		{D13C55F2-2688-41E1-B4D1-6B6609851844}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.ActiveCfg = Release|Any CPU
 		{D13C55F2-2688-41E1-B4D1-6B6609851844}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.Build.0 = Release|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.MonoTouch|Any CPU.ActiveCfg = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.MonoTouch|Any CPU.Build.0 = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Signed|Any CPU.ActiveCfg = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.Signed|Any CPU.Build.0 = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.ActiveCfg = Debug|Any CPU
+		{302CE57E-97EF-4A45-ACB3-B20174A92D07}.STATIC_ONLY NO_EXPRESSIONS|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,9 +170,9 @@ Global
 		{55942102-033A-4DA8-A6AF-1DB7B2F34A2D} = {671EE5B0-9B6E-4307-912E-C3E003AA04CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35;packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35
 		SolutionGuid = {866E4EA2-3A17-4BE4-B756-5FBFFD93ABCF}
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35;packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = ServiceStack.Logging.EventLog\ServiceStack.Logging.EventLog.csproj


### PR DESCRIPTION
Support for ServiceStack.Core netstandard2.0 and include provider to works with ASP.net Core.

You can reuse the log classes to implement both systems:
LogManager.LogFactory = new Log4NetFactory("log4net.config");
loggerFactory.AddProvider(new Log4NetProvider());
or
loggerFactory.AddLog4Net();
