### PR TITLE
Add unit test to show issue with 'HasKeys' on netcore.

### DIFF
--- a/tests/NetCoreTests/ContainerTests.cs
+++ b/tests/NetCoreTests/ContainerTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using System.Net.Http;
+using System.Threading.Tasks;
 using Funq;
 using NUnit.Framework;
 using ServiceStack;
-using ServiceStack.Testing;
 
 namespace NetCoreTests
 {
@@ -17,6 +17,26 @@ namespace NetCoreTests
             }
         }
         
+        [Route("/haskeys")]
+        class HasQueryStringKeysTestDto {}
+        
+        [Route("/numberofkeys")]
+        class NumberOfKeysTestDto {}
+
+        class HasKeysService : Service
+        {
+            public string Get(HasQueryStringKeysTestDto request)
+            {
+                return this.Request.QueryString.HasKeys().ToString();
+            }
+            
+            public string Get(NumberOfKeysTestDto request)
+            {
+                return this.Request.QueryString.Count.ToString();
+            }
+        }
+        
+        
         [Test]
         public void Can_resolve_dependency_in_multiple_AppHosts()
         {
@@ -30,6 +50,28 @@ namespace NetCoreTests
             {
                 var logFactory = appHost.TryResolve<Microsoft.Extensions.Logging.ILoggerFactory>();
                 var log = logFactory.CreateLogger("categoryName");
+            }
+        }
+        
+        [Test]
+        public async Task Can_use_haskeys()
+        {
+            using (var appHost = new AppHost().Init().Start("http://localhost:2000/"))
+            {
+                var client = new HttpClient();
+                var result = await client.GetStringAsync("http://localhost:2000/haskeys?test=foo");
+                Assert.That(result, Is.EqualTo("true"));
+            }
+        }
+        
+        [Test]
+        public async Task Can_use_AllKeys()
+        {
+            using (var appHost = new AppHost().Init().Start("http://localhost:2000/"))
+            {
+                var client = new HttpClient();
+                var result = await client.GetStringAsync("http://localhost:2000/numberofkeys?test=foo");
+                Assert.That(result, Is.EqualTo("1"));
             }
         }
     }


### PR DESCRIPTION
This is an interesting case. On netcore, the `Request.QueryString.HasKeys()` in a service will return false even when keys are present and accessible from `Request.QueryString.AllKeys`.

This works fine if manually creating a `NetCoreQueryStringCollection` and using `HasKeys` but via the request pipeline, it doesn't.

This PR only adds the test to show it's a problem.