### PR TITLE
Added ReturnAttribute for use in OrmLite

### DIFF
--- a/src/ServiceStack.Interfaces/DataAnnotations/ReturnAttribute.cs
+++ b/src/ServiceStack.Interfaces/DataAnnotations/ReturnAttribute.cs
@@ -1,0 +1,26 @@
+
+using System;
+
+namespace ServiceStack.DataAnnotations
+{
+
+    /// <summary>
+    /// ReturnAttribute
+    /// Use to indicate that a property should be included in the 
+    /// returning/output clause of INSERT and UPDATE sql sentences
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ReturnAttribute : AttributeBase {}
+
+    /// <summary>
+    /// Return this property in INSERT statements
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ReturnOnInsertAttribute : AttributeBase { }
+
+    /// <summary>
+    /// Return this property in UPDATE statements
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ReturnOnUpdateAttribute : AttributeBase { }
+}


### PR DESCRIPTION
Added the ReturnAttribute to implement in OrmLite.
Properties marked with this attribute will be included in the RETURNING (FireBird and PostgreSql) or OUTPUT (SqlServer) clause when building sql sentences for INSERT or UPDATE operations.

This allows to use SEQUENCES in SqlServer for Id columns instead of IDENTITY.
Also and not less useful, allows to get back field values that might be updated in database triggers when doing the same operations.