### PR TITLE
RequestCompressionType is not considered when using AsyncServiceClient

### DIFF
--- a/src/ServiceStack.Client/AsyncServiceClient.cs
+++ b/src/ServiceStack.Client/AsyncServiceClient.cs
@@ -91,6 +91,8 @@ namespace ServiceStack
         public string BaseUri { get; set; }
         public bool DisableAutoCompression { get; set; }
 
+        public string RequestCompressionType { get; set; }
+
         public string UserName { get; set; }
 
         public string Password { get; set; }
@@ -220,6 +222,9 @@ namespace ServiceStack
                 if (HttpUtils.HasRequestBody(webReq.Method))
                 {
                     webReq.ContentType = ContentType;
+
+                   if (RequestCompressionType != null)
+                        webReq.Headers[HttpHeaders.ContentEncoding] = RequestCompressionType;
 
                     using (var requestStream = await webReq.GetRequestStreamAsync().ConfigureAwait(false))
                     {

--- a/src/ServiceStack.Client/ServiceClientBase.cs
+++ b/src/ServiceStack.Client/ServiceClientBase.cs
@@ -129,7 +129,18 @@ namespace ServiceStack
         }
         private bool disableAutoCompression;
 
-        public string RequestCompressionType { get; set; }
+
+        private string requestCompressionType;
+
+        public string RequestCompressionType
+        {
+            get => requestCompressionType;
+            set
+            {
+                requestCompressionType = value;
+                asyncClient.RequestCompressionType = value;
+            }
+        }
 
         /// <summary>
         /// The user name for basic authentication

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AsyncServiceClientTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AsyncServiceClientTests.cs
@@ -38,6 +38,20 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.That(response.Result, Is.EqualTo(GetFactorialService.GetFactorial(request.ForNumber)));
         }
 
+
+        [TestCase(CompressionTypes.Deflate)]
+        [TestCase(CompressionTypes.GZip)]
+        public async Task Can_call_SendAsync_with_compression_on_ServiceClient(string compressionType)
+        {
+            var jsonClient = new JsonServiceClient(ListeningOn) { RequestCompressionType = compressionType };
+
+            var request = new GetFactorial { ForNumber = 3 };
+            var response = await jsonClient.SendAsync<GetFactorialResponse>(request);
+
+            Assert.That(response, Is.Not.Null, "No response received");
+            Assert.That(response.Result, Is.EqualTo(GetFactorialService.GetFactorial(request.ForNumber)));
+        }
+
         [TestFixture]
         public class JsonAsyncServiceClientTests : AsyncServiceClientTests
         {

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ZipServiceClientTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ZipServiceClientTests.cs
@@ -162,5 +162,19 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             var response = client.Post(new HelloZip { Name = "GZIP" });
             Assert.That(response.Result, Is.EqualTo("Hello, GZIP"));
         }
+
+
+
+        [TestCase(CompressionTypes.Deflate)]
+        [TestCase(CompressionTypes.GZip)]
+        public async Task Can_send_async_compressed_client_request(string compressionType)
+        {
+            var client = new JsonServiceClient(Config.ListeningOn)
+            {
+                RequestCompressionType = compressionType,
+            };
+            var response = await client.PostAsync(new HelloZip { Name = compressionType });
+            Assert.That(response.Result, Is.EqualTo($"Hello, {compressionType}"));
+        }
     }
 }


### PR DESCRIPTION
**Problem:** When setting the RequestCompressionType on a JsonServiceClient and using the SendAsync-method a SerializationException occurs because the Content-Encoding header is not set in the WebRequest

**Proposed solution in this PR:**
I added the Property RequestCompressionType to the AsyncServiceClient and set it when setting the Property in the ServiceClientBase. The RequestCompressionType is then (anologous to the ServiceClientBase) added as a header before sending the WebRequest. I added tests to the AsyncServiceClientTests and the ZipServiceClientTests