### PR TITLE
Make prefetch configurable

### DIFF
--- a/src/ServiceStack.RabbitMq/RabbitMqBasicConsumer.cs
+++ b/src/ServiceStack.RabbitMq/RabbitMqBasicConsumer.cs
@@ -1,5 +1,4 @@
-﻿
-using RabbitMQ.Client;
+﻿using RabbitMQ.Client;
 using RabbitMQ.Util;
 
 namespace ServiceStack.RabbitMq
@@ -8,7 +7,7 @@ namespace ServiceStack.RabbitMq
     {
         readonly SharedQueue<BasicGetResult> queue;
 
-        public RabbitMqBasicConsumer(IModel model) 
+        public RabbitMqBasicConsumer(IModel model)
             : this(model, new SharedQueue<BasicGetResult>()) { }
 
         public RabbitMqBasicConsumer(IModel model, SharedQueue<BasicGetResult> queue)


### PR DESCRIPTION
This pull request allows consumers to set the prefetch count but still defaults to the most optimal as described in:
http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
http://www.rabbitmq.com/amqp-0-9-1-reference.html