### PR TITLE
Marked addIndex field as volatile

### DIFF
--- a/src/ServiceStack.Common/Net30/ObjectPool.cs
+++ b/src/ServiceStack.Common/Net30/ObjectPool.cs
@@ -41,7 +41,7 @@ namespace ServiceStack.Net30.Collections.Concurrent
         const int bit = 0x8000000;
 
         readonly T[] buffer;
-        int addIndex;
+        volatile int addIndex;
         int removeIndex;
 
         public ObjectPool ()


### PR DESCRIPTION
Marked _addIndex_ field (accessed by multiple threads concurrently) as **volatile** to suppress just-in-time optimization around it performed by next generation of JIT (RyuJIT) and causing concurrency issues (endless loop in Take() method under high-load).