### PR TITLE
Add a flag to relax treating warnings/info as errors

### DIFF
--- a/src/ServiceStack/IAppHost.cs
+++ b/src/ServiceStack/IAppHost.cs
@@ -115,6 +115,11 @@ namespace ServiceStack
         /// Add Response Filters for MQ/TCP Responses
         /// </summary>
         List<Action<IRequest, IResponse, object>> GlobalMessageResponseFilters { get; }
+        
+        /// <summary>
+        /// Add Async Response Filters for MQ/TCP Responses
+        /// </summary>
+        List<Func<IRequest, IResponse, object, Task>> GlobalMessageResponseFiltersAsync { get; }
 
         /// <summary>
         /// Add Request Filter for a specific Request DTO Type

--- a/src/ServiceStack/Validation/ValidationFeature.cs
+++ b/src/ServiceStack/Validation/ValidationFeature.cs
@@ -14,7 +14,8 @@ namespace ServiceStack.Validation
         public Func<ValidationResult, object, object> ErrorResponseFilter { get; set; }
 
         public bool ScanAppHostAssemblies { get; set; } = true;
-
+        public bool TreatInfoAndWarningsAsErrors { get; set; } = true;
+        
         /// <summary>
         /// Activate the validation mechanism, so every request DTO with an existing validator
         /// will be validated.
@@ -22,14 +23,39 @@ namespace ServiceStack.Validation
         /// <param name="appHost">The app host</param>
         public void Register(IAppHost appHost)
         {
-            if (!appHost.GlobalRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsync))
+            if (TreatInfoAndWarningsAsErrors)
             {
-                appHost.GlobalRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsync);
-            }
+                if (!appHost.GlobalRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsync))
+                {
+                    appHost.GlobalRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsync);
+                }
 
-            if (!appHost.GlobalMessageRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsync))
+                if (!appHost.GlobalMessageRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsync))
+                {
+                    appHost.GlobalMessageRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsync);
+                }
+            }
+            else
             {
-                appHost.GlobalMessageRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsync);
+                if (!appHost.GlobalRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsyncIgnoreWarningsInfo))
+                {
+                    appHost.GlobalRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsyncIgnoreWarningsInfo);
+                }
+
+                if (!appHost.GlobalMessageRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsyncIgnoreWarningsInfo))
+                {
+                    appHost.GlobalMessageRequestFiltersAsync.Add(ValidationFilters.RequestFilterAsyncIgnoreWarningsInfo);
+                }
+                
+                if (!appHost.GlobalResponseFiltersAsync.Contains(ValidationFilters.ResponseFilterAsync))
+                {
+                    appHost.GlobalResponseFiltersAsync.Add(ValidationFilters.ResponseFilterAsync);
+                }
+
+                if (!appHost.GlobalMessageResponseFiltersAsync.Contains(ValidationFilters.ResponseFilterAsync))
+                {
+                    appHost.GlobalMessageResponseFiltersAsync.Add(ValidationFilters.ResponseFilterAsync);
+                }
             }
 
             if (ScanAppHostAssemblies)

--- a/src/ServiceStack/Validation/ValidationFilters.cs
+++ b/src/ServiceStack/Validation/ValidationFilters.cs
@@ -104,35 +104,28 @@ namespace ServiceStack.Validation
         {
             var ruleSet = req.Verb;
 
-            try
-            {
-                ValidationResult validationResult;
+            ValidationResult validationResult;
 
-                if (validator.HasAsyncValidators(ruleSet))
-                {
-                    validationResult = await validator.ValidateAsync(
-                        new ValidationContext(requestDto, null, new MultiRuleSetValidatorSelector(ruleSet))
-                        {
-                            Request = req
-                        });
-                }
-                else
-                {
-                    validationResult = validator.Validate(
-                        new ValidationContext(requestDto, null, new MultiRuleSetValidatorSelector(ruleSet))
-                        {
-                            Request = req
-                        });
-                }
-
-                return validationResult;
-            }
-            finally
+            if (validator.HasAsyncValidators(ruleSet))
             {
-                using (validator as IDisposable)
-                {
-                }
+                validationResult = await validator.ValidateAsync(
+                    new ValidationContext(requestDto, null, new MultiRuleSetValidatorSelector(ruleSet))
+                    {
+                        Request = req
+                    });
             }
+            else
+            {
+                validationResult = validator.Validate(
+                    new ValidationContext(requestDto, null, new MultiRuleSetValidatorSelector(ruleSet))
+                    {
+                        Request = req
+                    });
+            }
+
+            using (validator as IDisposable) { }
+            
+            return validationResult;
         }
     }
 }

--- a/tests/ServiceStack.Common.Tests/FluentValidation/UserSeverityTests.cs
+++ b/tests/ServiceStack.Common.Tests/FluentValidation/UserSeverityTests.cs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/. 
 
+using Funq;
 using ServiceStack.FluentValidation;
+using ServiceStack.Testing;
+using ServiceStack.Validation;
 
 namespace ServiceStack.Common.Tests.FluentValidation
 {
@@ -15,6 +18,8 @@ namespace ServiceStack.Common.Tests.FluentValidation
 
         public class UserSeverityTests
         {
+            private const string Urlbase = "http://localhost:2001/";
+            
             [Test]
             public void Stores_user_severity_against_validation_failure()
             {
@@ -39,6 +44,103 @@ namespace ServiceStack.Common.Tests.FluentValidation
                 {
                 }
             }
+
+            [Test]
+            public void Response_returned_when_valid()
+            {
+                using (var appHost = new TestAppHost())
+                {
+                    appHost.Plugins.Add(new ValidationFeature());
+                    appHost.Init();
+                    appHost.Start(Urlbase);
+
+                    var sc = new JsonServiceClient(Urlbase);
+
+                    var response = sc.Get(new EchoRequest {Day = "Monday", Word = "Word"});
+
+                    Assert.That(response.Day, Is.EqualTo("Monday"));
+                    Assert.That(response.Word, Is.EqualTo("Word"));
+                }
+            }
+
+            [Test]
+            public void Can_treat_warnings_and_info_as_errors()
+            {
+                using (var appHost = new TestAppHost())
+                {
+                    appHost.Plugins.Add(new ValidationFeature {TreatInfoAndWarningsAsErrors = true});
+                    appHost.Init();
+                    appHost.Start(Urlbase);
+
+                    var sc = new JsonServiceClient(Urlbase);
+
+                    Assert.Throws<WebServiceException>(() => sc.Get(new EchoRequest {Day = "Monday", Word = ""}),
+                        "'Word' should not be empty.");
+                }
+            }
+
+            [Test]
+            public void Can_ignore_warnings_and_info_as_errors()
+            {
+                using (var appHost = new TestAppHost())
+                {
+                    appHost.Plugins.Add(new ValidationFeature {TreatInfoAndWarningsAsErrors = false});
+                    appHost.Init();
+                    appHost.Start(Urlbase);
+
+                    var sc = new JsonServiceClient(Urlbase);
+
+                    var response = sc.Get(new EchoRequest {Day = "", Word = ""});
+
+                    Assert.That(response.ResponseStatus, Is.Not.Null);
+                    Assert.That(response.ResponseStatus.Errors, Is.Not.Empty);
+                    Assert.That(response.ResponseStatus.Errors.First().Meta["Severity"], Is.EqualTo("Info"));
+                    Assert.That(response.ResponseStatus.Errors[1].Meta["Severity"], Is.EqualTo("Warning"));
+                }
+            }
+
+            internal class TestAppHost : AppSelfHostBase
+            {
+                public Action<Container> ConfigureContainer { get; set; }
+
+                public TestAppHost()
+                    : base("AppHost for ValidationFeature SeverityTests", typeof(EchoService).Assembly)
+                {
+                }
+
+                public override void Configure(Container container)
+                {
+                    if (ConfigureContainer != null)
+                        this.ConfigureContainer(container);
+                }
+            }
+        }
+
+        public class EchoService : Service
+        {
+            public object Any(EchoRequest request) => new EchoResponse {Day = request.Day, Word = request.Word};
+        }
+
+        public class EchoRequestValidator : AbstractValidator<EchoRequest>
+        {
+            public EchoRequestValidator()
+            {
+                RuleFor(e => e.Word).NotEmpty().WithSeverity(Severity.Info);
+                RuleFor(e => e.Day).NotEmpty().WithSeverity(Severity.Warning);
+            }
+        }
+
+        public class EchoRequest : IReturn<EchoResponse>
+        {
+            public string Word { get; set; }
+            public string Day { get; set; }
+        }
+
+        public class EchoResponse : IHasResponseStatus
+        {
+            public string Word { get; set; }
+            public string Day { get; set; }
+            public ResponseStatus ResponseStatus { get; set; }
         }
     }
 }


### PR DESCRIPTION
With FluentValidation you can set the Severity level to Info, Warning or Error using the WithSeverity extensions method.

The ValidationFeature does not distinguish between the different severity levels and will return an error response back to the caller regardless of the severity set.

This PR adds a flag to disable this behavior. 

Instead of getting an error response returned, if the response DTO inherits from IHasResponseStatus, the response status property will be populated with the failed validations and the meta dictionary property will contain the severity.