### PR TITLE
Auto Batched Requests - share current req index with rest of pipeline

### DIFF
--- a/src/ServiceStack/Host/ServiceController.cs
+++ b/src/ServiceStack/Host/ServiceController.cs
@@ -746,7 +746,7 @@ namespace ServiceStack.Host
 
                 var firstDto = dtosList[0];
 
-                req.Items["MultiRequestIndex"] = 0;
+                req.Items["AutoBatchIndex"] = 0;
 
                 var firstResponse = handlerFn(req, firstDto);
                 if (firstResponse is Exception)
@@ -766,7 +766,7 @@ namespace ServiceStack.Host
                     for (var i = 1; i < dtosList.Count; i++)
                     {
                         var dto = dtosList[i];
-                        req.Items["MultiRequestIndex"] = i;
+                        req.Items["AutoBatchIndex"] = i;
                         var response = handlerFn(req, dto);
                         //short-circuit on first error
                         if (response is Exception)
@@ -777,7 +777,7 @@ namespace ServiceStack.Host
 
                         ret[i] = response;
                     }
-                    req.Items.Remove("MultiRequestIndex");
+                    req.Items.Remove("AutoBatchIndex");
                     req.SetAutoBatchCompletedHeader(dtosList.Count);
                     return ret;
                 }
@@ -793,7 +793,7 @@ namespace ServiceStack.Host
                     if (firstAsyncError != null)
                         return firstAsyncError;
 
-                    req.Items["MultiRequestIndex"] = i;
+                    req.Items["AutoBatchIndex"] = i;
 
                     asyncResponses[i] = i == 0
                         ? asyncResponse //don't re-execute first request
@@ -810,7 +810,7 @@ namespace ServiceStack.Host
                 var batchResponse = HostContext.Async.ContinueWith(req, task, x => {
                     if (firstAsyncError != null)
                         return (object)firstAsyncError;
-                    req.Items.Remove("MultiRequestIndex");
+                    req.Items.Remove("AutoBatchIndex");
                     req.SetAutoBatchCompletedHeader(dtosList.Count);
                     return (object) asyncResponses;
                 }); //return error or completed responses

--- a/src/ServiceStack/ServiceStackHost.Runtime.cs
+++ b/src/ServiceStack/ServiceStackHost.Runtime.cs
@@ -138,7 +138,7 @@ namespace ServiceStack
 
                 foreach (var dto in dtos)
                 {
-                    req.Items["MultiRequestIndex"] = i;
+                    req.Items["AutoBatchIndex"] = i;
                     await ApplyRequestFiltersSingleAsync(req, res, dto);
                     if (res.IsClosed)
                         return;
@@ -146,7 +146,7 @@ namespace ServiceStack
                     i++;
                 }
 
-                req.Items.Remove("MultiRequestIndex");
+                req.Items.Remove("AutoBatchIndex");
             }
         }
 

--- a/src/ServiceStack/ServiceStackHost.Runtime.cs
+++ b/src/ServiceStack/ServiceStackHost.Runtime.cs
@@ -134,12 +134,19 @@ namespace ServiceStack
                 }
 
                 var dtos = (IEnumerable)requestDto;
+                var i = 0;
+
                 foreach (var dto in dtos)
                 {
+                    req.Items["MultiRequestIndex"] = i;
                     await ApplyRequestFiltersSingleAsync(req, res, dto);
                     if (res.IsClosed)
                         return;
+
+                    i++;
                 }
+
+                req.Items.Remove("MultiRequestIndex");
             }
         }
 


### PR DESCRIPTION
When a MultiRequest is being processed it would be useful for the rest of the pipeline to be able to obtain the index of the request within the batch. For example if an error occurs a `Meta` item could be added to the `ResponseStatus` which indicated the position that the error relates to.

This PR adds `MultiRequestIndex` as a req item that can be retrieved anywhere in the pipeline. If this is acceptable I'll add tests and refine the implementation.
