### PR TITLE
Auto Batched Requests - share current req index with rest of pipeline part 2

### DIFF
--- a/src/ServiceStack/ServiceStackHost.Runtime.cs
+++ b/src/ServiceStack/ServiceStackHost.Runtime.cs
@@ -227,12 +227,20 @@ namespace ServiceStack
                     return;
                 }
 
+                var i = 0;
+
                 foreach (var dto in batchResponse)
                 {
+                    req.Items["AutoBatchIndex"] = i;
+
                     await ApplyResponseFiltersSingleAsync(req, res, dto);
                     if (res.IsClosed)
                         return;
+
+                    i++;
                 }
+
+                req.Items.Remove("AutoBatchIndex");
             }
         }
 

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Funq;
+using NUnit.Framework;
+
+namespace ServiceStack.WebHost.Endpoints.Tests
+{
+    public class AutoBatchAppHost : AppSelfHostBase
+    {
+        public AutoBatchAppHost()
+            : base(typeof(AutoBatchTests).Name, typeof(AutoBatchIndexServices).Assembly)
+        {
+        }
+
+        public override void Configure(Container container)
+        {
+            GlobalRequestFilters.Add((req, res, dto) =>
+            {
+                var autoBatchIndex = req.GetItem("AutoBatchIndex")?.ToString();
+                if (autoBatchIndex != null)
+                {
+                    res.RemoveHeader("GlobalRequestFilterAutoBatchIndex");
+                    res.AddHeader("GlobalRequestFilterAutoBatchIndex", autoBatchIndex);
+                }
+            });
+
+            GlobalResponseFilters.Add((req, res, dto) =>
+            {
+                var autoBatchIndex = req.GetItem("AutoBatchIndex")?.ToString();
+
+                if (autoBatchIndex != null)
+                {
+                    var response = dto as IMeta;
+                    if (response != null)
+                    {
+                        response.Meta = new Dictionary<string, string>
+                        {
+                            ["GlobalResponseFilterAutoBatchIndex"] = autoBatchIndex
+                        };
+                    }
+                }
+            });
+        }
+    }
+
+    public class GetAutoBatchIndex : IReturn<GetAutoBatchIndexResponse>
+    {
+    }
+
+    public class GetAutoBatchIndexResponse : IMeta
+    {
+        public string Index { get; set; }
+        public Dictionary<string, string> Meta { get; set; }
+    }
+
+    public class AutoBatchIndexServices : Service
+    {
+        public object Any(GetAutoBatchIndex request)
+        {
+            var autoBatchIndex = Request.GetItem("AutoBatchIndex")?.ToString();
+            return new GetAutoBatchIndexResponse
+            {
+                Index = autoBatchIndex
+            };
+        }
+    }
+
+    [TestFixture]
+    public class AutoBatchTests
+    {
+        private ServiceStackHost appHost;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetUp()
+        {
+            appHost = new AutoBatchAppHost()
+                .Init()
+                .Start(Config.AbsoluteBaseUri);
+        }
+
+        [OneTimeTearDown]
+        public void TestFixtureTearDown()
+        {
+            appHost.Dispose();
+        }
+
+        [Test]
+        public void Single_requests_dont_set_AutoBatchIndex()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            WebHeaderCollection responseHeaders = null;
+
+            client.ResponseFilter = resp => { responseHeaders = resp.Headers; };
+
+            var response = client.Send(new GetAutoBatchIndex());
+
+            Assert.Null(response.Index);
+            Assert.Null(response.Meta);
+            Assert.IsFalse(responseHeaders.AllKeys.Contains("GlobalRequestFilterAutoBatchIndex"));
+        }
+
+        [Test]
+        public void Multi_requests_set_AutoBatchIndex()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            WebHeaderCollection responseHeaders = null;
+
+            client.ResponseFilter = response => { responseHeaders = response.Headers; };
+
+            var responses = client.SendAll(new[]
+            {
+                new GetAutoBatchIndex(),
+                new GetAutoBatchIndex()
+            });
+
+            Assert.AreEqual("0", responses[0].Index);
+            Assert.AreEqual("0", responses[0].Meta["GlobalResponseFilterAutoBatchIndex"]);
+
+            Assert.AreEqual("1", responses[1].Index);
+            Assert.AreEqual("1", responses[1].Meta["GlobalResponseFilterAutoBatchIndex"]);
+
+            Assert.AreEqual("1", responseHeaders["GlobalRequestFilterAutoBatchIndex"]);
+        }
+    }
+}


### PR DESCRIPTION
Further to #1196 

* Add AutoBatchIndex for global response filters
* Add tests
