### PR TITLE
Add AutoBatchIndex to ResponseStatus.Meta for auto batched requests

### DIFF
--- a/src/ServiceStack/Host/ServiceRunner.cs
+++ b/src/ServiceStack/Host/ServiceRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,6 +57,22 @@ namespace ServiceStack.Host
 
         public virtual object AfterEachRequest(IRequest req, TRequest request, object response)
         {
+            if (response.IsErrorResponse())
+            {
+                var autoBatchIndex = req.GetItem("AutoBatchIndex")?.ToString();
+                if (autoBatchIndex != null)
+                {
+                    var responseStatus = response.GetResponseStatus();
+                    if (responseStatus != null)
+                    {
+                        if (responseStatus.Meta == null)
+                            responseStatus.Meta = new Dictionary<string, string>();
+
+                        responseStatus.Meta["AutoBatchIndex"] = autoBatchIndex;
+                    }
+                }
+            }
+
             //only call OnAfterExecute if no exception occured
             return response.IsErrorResponse() ? response : OnAfterExecute(req, response);
         }

--- a/src/ServiceStack/Validation/ValidationFilters.cs
+++ b/src/ServiceStack/Validation/ValidationFilters.cs
@@ -46,6 +46,19 @@ namespace ServiceStack.Validation
                     await HostContext.RaiseServiceException(req, requestDto, validationResult.ToException())
                     ?? DtoUtils.CreateErrorResponse(requestDto, validationResult.ToErrorResult());
 
+                var autoBatchIndex = req.GetItem("AutoBatchIndex")?.ToString();
+                if (autoBatchIndex != null)
+                {
+                    var responseStatus = errorResponse.GetResponseStatus();
+                    if (responseStatus != null)
+                    {
+                        if (responseStatus.Meta == null)
+                            responseStatus.Meta = new Dictionary<string, string>();
+
+                        responseStatus.Meta["AutoBatchIndex"] = autoBatchIndex;
+                    }
+                }
+
                 var validationFeature = HostContext.GetPlugin<ValidationFeature>();
                 if (validationFeature?.ErrorResponseFilter != null)
                 {


### PR DESCRIPTION
This allows the client to relate the error to the request which caused the error.