### PR TITLE
Add ext method for use in Custom Batched Requests Implementations

### DIFF
--- a/src/ServiceStack/HttpRequestExtensions.cs
+++ b/src/ServiceStack/HttpRequestExtensions.cs
@@ -1111,5 +1111,19 @@ namespace ServiceStack
                     throw new NotSupportedException($"Unknown IHttpRequest property '{name}'");
             }
         }
+
+        public static void EachRequest<T>(this IRequest httpReq, Action<T> action)
+        {
+            if (!(httpReq.Dto is IEnumerable<T> requests))
+                return;
+
+            requests.Each((i, dto) =>
+            {
+                httpReq.Items["AutoBatchIndex"] = i;
+                action(dto);
+            });
+
+            httpReq.Items.Remove("AutoBatchIndex");
+        }
     }
 }


### PR DESCRIPTION
Using this method to enumerate the requests batch ensures the same behaviour
as regular (non-custom) batch requests. Namely, the AutoBatchIndex item is
set correctly.

The new test shows usage with a custom batched request implementation. If the custom impl performs some kind of complex validation then performing this within the EachRequest "loop" will ensure the exceptions ResponseStatus.Meta is set as with non-customs.
