### PR TITLE
Unexpected end of Stream when uploading to aspnet core

### DIFF
--- a/src/ServiceStack/RequestLogsFeature.cs
+++ b/src/ServiceStack/RequestLogsFeature.cs
@@ -118,10 +118,27 @@ namespace ServiceStack
 
             if (EnableRequestBodyTracking)
             {
+#if NETSTANDARD2_0
+                appHost.PreRequestFilters.Insert(0, (httpReq, httpRes) =>
+                {
+                    if (httpReq.ContentType != null)
+                    {
+                        if (!(httpReq.ContentType.MatchesContentType(MimeTypes.MultiPartFormData)))
+                        {
+                            httpReq.UseBufferedStream = EnableRequestBodyTracking;
+                        }
+                    }
+                    else
+                    {
+                        httpReq.UseBufferedStream = EnableRequestBodyTracking;
+                    }
+                });
+#else
                 appHost.PreRequestFilters.Insert(0, (httpReq, httpRes) =>
                 {
                     httpReq.UseBufferedStream = EnableRequestBodyTracking;
                 });
+#endif
             }
 
             appHost.GetPlugin<MetadataFeature>()


### PR DESCRIPTION
At the time of RequestLogFeature Register, SS is attaching the Callback method for reading InputStream Buffer at HTTP listener level for all content type. That callback method creating the issue when the content type if multipart/form-data at least in .netcore 2.0

https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack/Host/HttpListener/ListenerRequest.cs  *line 221*

More Details about issue
https://forums.servicestack.net/t/unexpected-end-of-stream-when-uploading-to-aspnet-core/6478/2

Even the following commit will not solve the issue, because of InputStream already read before this GetRawBody call in InMemoryRollingRequestLogger.cs
https://github.com/ServiceStack/ServiceStack/commit/166e785b2dfce8a29ccfc30d2e172c69728cf6c3


