### PR TITLE
Fix memory leak: After disposing ServiceStackHost is kept in memory

### DIFF
--- a/src/ServiceStack/ServiceStackHost.cs
+++ b/src/ServiceStack/ServiceStackHost.cs
@@ -775,19 +775,21 @@ namespace ServiceStack
 
             if (config.LogUnobservedTaskExceptions)
             {
-                TaskScheduler.UnobservedTaskException += (sender, args) =>
-                {
-                    args.SetObserved();
-                    args.Exception.Handle(ex =>
-                    {
-                        lock (AsyncErrors)
-                        {
-                            AsyncErrors.Add(DtoUtils.CreateErrorResponse(null, ex).GetResponseStatus());
-                            return true;
-                        }
-                    });
-                };
+                TaskScheduler.UnobservedTaskException += this.HandleUnobservedTaskException;
             }
+        }
+
+        private void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs args)
+        {
+            args.SetObserved();
+            args.Exception.Handle(ex =>
+            {
+                lock (AsyncErrors)
+                {
+                    AsyncErrors.Add(DtoUtils.CreateErrorResponse(null, ex).GetResponseStatus());
+                    return true;
+                }
+            });
         }
 
         private void RunConfigureAppHosts(IEnumerable<Type> configureAppHosts)
@@ -1204,6 +1206,8 @@ namespace ServiceStack
 
                 JS.UnConfigure();
                 JsConfig.Reset(); //Clears Runtime Attributes
+
+                TaskScheduler.UnobservedTaskException -= this.HandleUnobservedTaskException;
 
                 Instance = null;
             }


### PR DESCRIPTION
Even after ServiceStackHost has been disposed, the static event TaskScheduler.UnobservedTaskException holds a reference to the object and thus it is kept in memory throughout the lifetime of the application. This creates a problem with systems that have "soft" restarts where the app domain is never disposed, and ServiceStack is reinitialized multiple times.