### PR TITLE
Request Logging: Ensure that an ErrorResponse is logged as an error.

### DIFF
--- a/src/ServiceStack/Host/InMemoryRollingRequestLogger.cs
+++ b/src/ServiceStack/Host/InMemoryRollingRequestLogger.cs
@@ -191,6 +191,8 @@ namespace ServiceStack.Host
         {
             if (response is IHttpResult errorResult)
                 return errorResult.Response;
+            else if (response is ErrorResponse errorResponse)
+                return errorResponse.GetResponseDto();
 
             var ex = response as Exception;
             return ex?.ToResponseStatus();

--- a/src/ServiceStack/HttpExtensions.cs
+++ b/src/ServiceStack/HttpExtensions.cs
@@ -99,7 +99,7 @@ namespace ServiceStack
             var req = httpRes.Request;
             if (req != null && !req.Items.ContainsKey(Keywords.HasLogged))
             {
-                HostContext.TryResolve<IRequestLogger>()?.Log(req, req.Dto, null, TimeSpan.Zero);
+                HostContext.TryResolve<IRequestLogger>()?.Log(req, req.Dto, httpRes.Dto, TimeSpan.Zero);
             }
 
             if (!skipClose && !httpRes.IsClosed) 
@@ -120,7 +120,7 @@ namespace ServiceStack
             var req = httpRes.Request;
             if (req != null && !req.Items.ContainsKey(Keywords.HasLogged))
             {
-                HostContext.TryResolve<IRequestLogger>()?.Log(req, req.Dto, null, TimeSpan.Zero);
+                HostContext.TryResolve<IRequestLogger>()?.Log(req, req.Dto, httpRes.Dto, TimeSpan.Zero);
             }
 
             if (!skipClose && !httpRes.IsClosed) 

--- a/src/ServiceStack/HttpResultUtils.cs
+++ b/src/ServiceStack/HttpResultUtils.cs
@@ -66,11 +66,11 @@ namespace ServiceStack
         }
 
         /// <summary>
-        /// Whether the response is an IHttpError or Exception
+        /// Whether the response is an IHttpError or Exception or ErrorResponse
         /// </summary>
         public static bool IsErrorResponse(this object response)
         {
-            return response != null && (response is IHttpError || response is Exception);
+            return response != null && (response is IHttpError || response is Exception || response is ErrorResponse  );
         }
 
         /// <summary>


### PR DESCRIPTION
Responses of type ErrorResponse are not logged to the error log.

1. **HttpExtensions.EndHttpHandlerRequest** and **EndHttpHandlerRequestAsync** do not include the response in the call to **IRequestLogger.Log**, thus downstream handlers see the response as null (this also appears to prevent non-error responses from being logged when EnableResponseTracking is true),
2. **HttpResultUtils.IsErrorResponse** only considers **IHttpError** or **Exception** to be an error response, and thus
3. **InMemoryRollingRequestLogger.ToSerializableErrorResponse** does not serialize an ErrorResponse as an error.

Added tests fail in pre-PR code.

First PR, so comments/changes/criticisms welcome.