### PR TITLE
Change applyErrors to default to `name` attribute

### DIFF
--- a/src/ServiceStack/js/ss-utils.js
+++ b/src/ServiceStack/js/ss-utils.js
@@ -303,7 +303,7 @@
                 var $el = $(this);
                 var $prev = $el.prev(), $next = $el.next();
                 var isCheck = this.type === "radio" || this.type === "checkbox";
-                var fieldId = (!isCheck ? this.id : null) || $el.attr("name");
+                var fieldId = $el.attr("name") || this.id;
                 if (!fieldId) return;
 
                 var key = (fieldId).toLowerCase();


### PR DESCRIPTION
There can be multiple forms on a single webpage. Form data is submitted via key value pairs where the key is based upon the input `name` attribute and not the `id` attribute since html entity id's need to be unique. The proposed change defaults to apply errors via the input `name` attribute rather than the `id` as that will correlate back to the ServiceStack Service's request DTO, which will then correctly find the correct fieldId to apply the errors. This would then also avoid the issue with check and radio inputs where there can be multiple of them.

Example: 
If there are two forms on a webpage and they both have an email input, only one can have an `id` of 'email'. The current way `applyErrors()` works defaults to the `id` attribute and not the `name` attribute, so only one form can have an input with an id of email, this can cause issues when you have razor partials loading multiple forms on the page that happen to have the same input id.