### PR TITLE
NLogLogger - Allow NLog to capture Exception-object when only parameter (unit test)

### DIFF
--- a/src/ServiceStack.Logging.NLog/ServiceStack.Logging.NLog.csproj
+++ b/src/ServiceStack.Logging.NLog/ServiceStack.Logging.NLog.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj" />
     <PackageReference Include="ServiceStack.Text" Version="$(Version)" />
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="NLog" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/tests/ServiceStack.Logging.Tests/UnitTests/NLogTests.cs
+++ b/tests/ServiceStack.Logging.Tests/UnitTests/NLogTests.cs
@@ -53,6 +53,34 @@ namespace ServiceStack.Logging.Tests.UnitTests
         }
 
         [Test]
+        public void CaptureSingleParameterExceptionTest()
+        {
+            try
+            {
+                NLog.LogManager.ThrowExceptions = true; // Only use this for unit-tests
+                var target = new NLog.Targets.DebugTarget() { Layout = "${exception:format=message}" };
+                NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+                Logging.LogManager.LogFactory = new NLogger.NLogFactory();
+                var log = Logging.LogManager.LogFactory.GetLogger(GetType());
+                log.Debug(new ApplicationException("Debug"));
+                Assert.AreEqual("Debug", target.LastMessage);
+                log.Info(new ApplicationException("Info"));
+                Assert.AreEqual("Info", target.LastMessage);
+                log.Warn(new ApplicationException("Warn"));
+                Assert.AreEqual("Warn", target.LastMessage);
+                log.Error(new ApplicationException("Error"));
+                Assert.AreEqual("Error", target.LastMessage);
+                log.Fatal(new ApplicationException("Fatal"));
+                Assert.AreEqual("Fatal", target.LastMessage);
+            }
+            finally
+            {
+                NLog.Common.InternalLogger.Reset();
+                NLog.LogManager.Configuration = null;
+            }
+        }
+
+        [Test]
         public void Can_call_method_using_NLog_concrete_providers()
         {
             Logging.LogManager.LogFactory = new NLogger.NLogFactory();


### PR DESCRIPTION
Unit test for #1210 (Requires NLog 4.5.4 that includes https://github.com/NLog/NLog/pull/2586)