### PR TITLE
Address spiral-of-death in event-subscription Dispose path

### DIFF
--- a/src/ServiceStack/Internal/IServiceStackAsyncDisposable.cs
+++ b/src/ServiceStack/Internal/IServiceStackAsyncDisposable.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ServiceStack.Internal
+{
+    // intent: like IAsyncDisposable, but usable on net45 TFM
+    internal interface IServiceStackAsyncDisposable
+    {
+        Task DisposeAsync();
+    }
+
+    internal static class DisposableExtensions
+    {
+        internal static Task DisposeAsync(this IDisposable disposable)
+        {   // note: if a type clearly implements IServiceStackAsyncDisposable, overload
+            // resolution will prefer IServiceStackAsyncDisposable over an extension method,
+            // so we lose nothing by doing this
+            if (disposable is IServiceStackAsyncDisposable)
+                return disposable.DisposeAsync();
+            else
+            {
+                disposable?.Dispose();
+                return TypeConstants.EmptyTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
event-subscriptions `Dispose` path appears to be manifesting spiral-off-death (https://blog.marcgravell.com/2019/02/fun-with-spiral-of-death.html)

- introduce an internal `DisposeAsync` API (not public due to net45 TFM)
- use this API whenever disposing on async path
- implementation is virtually the same as sync `Dispose`, but using `Task.Delay` instead of `Thread.Sleep`

Additional observations for future consideration:
- `IAsyncDisposable.DisposeAsync` is an official API now down to net461 (via https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/)
- may want to consider when/if `ConfigureAwait(false)` is appropriate on the async code generally
- I've used [`MutexSlim`](https://github.com/mgravell/Pipelines.Sockets.Unofficial/tree/master/src/Pipelines.Sockets.Unofficial/Threading) in this scenario before - avoids a wait loop (whether hot or cold), with the "release" prodding the sync/async awaiters
- important: *do not* use `SempahoreSlim` for this unless you know you're targeting .NET Core 3 or above (see blog; conceptually it is fine, but a "feature" makes it susceptible to the same spiral)