### PR TITLE
Flatten query DTOs into the request DTO (caution: changes DTO shape; requires major)

### DIFF
--- a/src/ServiceStack.Extensions/ServiceStack.Extensions.csproj
+++ b/src/ServiceStack.Extensions/ServiceStack.Extensions.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Grpc.AspNetCore.Server" Version="2.26.0" />
         <PackageReference Include="Grpc.Core.Api" Version="2.26.0" />
         <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
-        <PackageReference Include="protobuf-net" Version="2.4.4" />
+        <PackageReference Include="protobuf-net" Version="2.4.5" />
         
         <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj" />
         <ProjectReference Include="..\ServiceStack.Client\ServiceStack.Client.csproj" />

--- a/src/ServiceStack.GrpcClient/GrpcConfig.cs
+++ b/src/ServiceStack.GrpcClient/GrpcConfig.cs
@@ -7,7 +7,7 @@ namespace ServiceStack
 {
     public static class GrpcConfig
     {
-        public static RuntimeTypeModel TypeModel { get; } = ProtoBuf.Meta.TypeModel.Create();
+        public static RuntimeTypeModel TypeModel { get; } = ProtoBuf.Meta.RuntimeTypeModel.Create();
 
         public static Func<Type, bool> IgnoreTypeModel { get; set; } = DefaultIgnoreTypes;
 

--- a/src/ServiceStack.GrpcClient/GrpcServiceClient.cs
+++ b/src/ServiceStack.GrpcClient/GrpcServiceClient.cs
@@ -727,14 +727,13 @@ namespace ServiceStack
                 x => x == typeof(IReturnVoid)
                 || x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IReturn<>));
 
+            var mt = GrpcConfig.TypeModel.Add(typeof(T), applyDefaultBehaviour: true);
             if (!isRequest)
             {
                 // regular type; let the serializer worry about the details
-                return GrpcConfig.TypeModel.Add(typeof(T), applyDefaultBehaviour: true);
+                mt.ApplyFieldOffset(42);
             }
-            // query type; flatten
-            var mt = GrpcConfig.TypeModel.Add(typeof(T), applyDefaultBehaviour: false);
-
+            
             return mt;
 
         }

--- a/src/ServiceStack.GrpcClient/ServiceStack.GrpcClient.csproj
+++ b/src/ServiceStack.GrpcClient/ServiceStack.GrpcClient.csproj
@@ -12,6 +12,8 @@
         <PackageReference Include="Grpc.Net.Client" Version="2.26.0" />
         <PackageReference Include="Grpc.Core" Version="2.26.0" />
         <PackageReference Include="protobuf-net.Grpc" Version="1.0.22" />
+        <!-- the transitive import of protobuf-net is lower; we need at least this -->
+        <PackageReference Include="protobuf-net" Version="2.4.5" />
         <PackageReference Include="ServiceStack.Text" Version="$(Version)" />
 
         <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj" />

--- a/src/ServiceStack.Interfaces/IQuery.cs
+++ b/src/ServiceStack.Interfaces/IQuery.cs
@@ -140,6 +140,9 @@ namespace ServiceStack
 
         [DataMember(Order = 7)]
         public virtual Dictionary<string, string> Meta { get; set; }
+
+        // note: the number of fields here must fit inside the reserved chunk
+        // from GrpcServiceClient; see CreateMetaType
     }
 
     public abstract class QueryDb<T> : QueryBase, IQueryDb<T>, IReturn<QueryResponse<T>> { }

--- a/src/ServiceStack.ProtoBuf/ProtoBufFormat.cs
+++ b/src/ServiceStack.ProtoBuf/ProtoBufFormat.cs
@@ -13,7 +13,7 @@ namespace ServiceStack.ProtoBuf
         }
 
         private static RuntimeTypeModel model;
-        public static RuntimeTypeModel Model => model ?? (model = TypeModel.Create());
+        public static RuntimeTypeModel Model => model ?? (model = RuntimeTypeModel.Create());
 
         public static void Serialize(IRequest requestContext, object dto, Stream outputStream)
         {

--- a/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.Core.csproj
+++ b/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.Core.csproj
@@ -16,6 +16,6 @@
     <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.Core.csproj" />
     <ProjectReference Include="..\ServiceStack\ServiceStack.Core.csproj" />
     <PackageReference Include="ServiceStack.Text.Core" Version="$(Version)" />
-    <PackageReference Include="protobuf-net" Version="2.3.17" />
+    <PackageReference Include="protobuf-net" Version="2.4.5" />
   </ItemGroup>
 </Project>

--- a/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.csproj
+++ b/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.csproj" />
     <ProjectReference Include="..\ServiceStack\ServiceStack.csproj" />
     <PackageReference Include="ServiceStack.Text" Version="$(Version)" />
-    <PackageReference Include="protobuf-net" Version="2.4.4" />
+    <PackageReference Include="protobuf-net" Version="2.4.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />

--- a/tests/ServiceStack.Extensions.Tests/GrpcTests.cs
+++ b/tests/ServiceStack.Extensions.Tests/GrpcTests.cs
@@ -820,10 +820,13 @@ namespace ServiceStack.Extensions.Tests
             AssertFiles(files);
         }
 
+        static string GetServiceProto<T>()
+            => GrpcConfig.TypeModel.GetSchema(GrpcMarshaller<T>.GetMetaType().Type, ProtoBuf.Meta.ProtoSyntax.Proto3);
+
         [Test]
         public void CheckServiceProto_BaseType()
         {
-            var schema = GrpcConfig.TypeModel.GetSchema(GrpcMarshaller<Foo>.GetMetaType().Type, ProtoBuf.Meta.ProtoSyntax.Proto3);
+            var schema = GetServiceProto<Foo>();
             Assert.AreEqual(@"syntax = ""proto3"";
 package ServiceStack.Extensions.Tests;
 
@@ -831,13 +834,13 @@ message Foo {
    string X = 1;
 }
 ", schema);
-        }
-
-        [Test]
-        public void CheckServiceProto_DerivedType()
-        {
-            var schema = GrpcConfig.TypeModel.GetSchema(GrpcMarshaller<Bar>.GetMetaType().Type, ProtoBuf.Meta.ProtoSyntax.Proto3);
-            Assert.AreEqual(@"syntax = ""proto3"";
+         }
+ 
+         [Test]
+         public void CheckServiceProto_DerivedType()
+         {
+             var schema = GetServiceProto<Bar>();
+             Assert.AreEqual(@"syntax = ""proto3"";
 package ServiceStack.Extensions.Tests;
 
 message Bar {
@@ -848,6 +851,26 @@ message Foo {
    oneof subtype {
       Bar Bar = 210304982;
    }
+}
+", schema);
+         }
+ 
+        [Test]
+        public void CheckServiceProto_QueryDb_ShouldBeOffset()
+        {
+            var schema = GetServiceProto<QueryFoos>();
+            Assert.AreEqual(@"syntax = ""proto3"";
+package ServiceStack.Extensions.Tests;
+
+message QueryFoos {
+   int32 Skip = 1;
+   int32 Take = 2;
+   string OrderBy = 3;
+   string OrderByDesc = 4;
+   string Include = 5;
+   string Fields = 6;
+   map<string,string> Meta = 7;
+   string X = 33;
 }
 ", schema);
         }
@@ -864,6 +887,14 @@ message Foo {
         {
             [DataMember(Order = 2)]
             public string Y { get; set; }
+        }
+
+        [Route("/query/foos")]
+        [DataContract]
+        public class QueryFoos : QueryDb<Foo>
+        {
+            [DataMember(Order = 1)]
+            public string X { get; set; }
         }
     }
 }

--- a/tests/ServiceStack.Extensions.Tests/GrpcTests.cs
+++ b/tests/ServiceStack.Extensions.Tests/GrpcTests.cs
@@ -819,5 +819,51 @@ namespace ServiceStack.Extensions.Tests
             files = files.Where(x => x.ResponseStatus == null).ToList();
             AssertFiles(files);
         }
+
+        [Test]
+        public void CheckServiceProto_BaseType()
+        {
+            var schema = GrpcConfig.TypeModel.GetSchema(GrpcMarshaller<Foo>.GetMetaType().Type, ProtoBuf.Meta.ProtoSyntax.Proto3);
+            Assert.AreEqual(@"syntax = ""proto3"";
+package ServiceStack.Extensions.Tests;
+
+message Foo {
+   string X = 1;
+}
+", schema);
+        }
+
+        [Test]
+        public void CheckServiceProto_DerivedType()
+        {
+            var schema = GrpcConfig.TypeModel.GetSchema(GrpcMarshaller<Bar>.GetMetaType().Type, ProtoBuf.Meta.ProtoSyntax.Proto3);
+            Assert.AreEqual(@"syntax = ""proto3"";
+package ServiceStack.Extensions.Tests;
+
+message Bar {
+   string Y = 2;
+}
+message Foo {
+   string X = 1;
+   oneof subtype {
+      Bar Bar = 210304982;
+   }
+}
+", schema);
+        }
+
+        [DataContract]
+        public class Foo
+        {
+            [DataMember(Order = 1)]
+            public string X { get; set; }
+        }
+
+        [DataContract]
+        public class Bar : Foo
+        {
+            [DataMember(Order = 2)]
+            public string Y { get; set; }
+        }
     }
 }

--- a/tests/ServiceStack.Extensions.Tests/ProtobufTests.cs
+++ b/tests/ServiceStack.Extensions.Tests/ProtobufTests.cs
@@ -72,7 +72,7 @@ namespace ServiceStack.Extensions.Tests
         [Test]
         public void Can_Serialize_QueryRockstars_TypeModel()
         {
-            var model = TypeModel.Create();
+            var model = RuntimeTypeModel.Create();
             
             //var metaType = model.Add(typeof(QueryBase), true);
             model[typeof(QueryBase)].AddSubType(101, typeof(QueryDb<Rockstar>));

--- a/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
+++ b/tests/ServiceStack.WebHost.IntegrationTests/ServiceStack.WebHost.IntegrationTests.csproj
@@ -81,7 +81,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67">
-      <HintPath>..\..\src\packages\protobuf-net.2.4.4\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\..\src\packages\protobuf-net.2.4.5\lib\net40\protobuf-net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587">

--- a/tests/ServiceStack.WebHost.IntegrationTests/packages.config
+++ b/tests/ServiceStack.WebHost.IntegrationTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net472" />
-  <package id="protobuf-net" version="2.4.4" targetFramework="net472" />
+  <package id="protobuf-net" version="2.4.5" targetFramework="net472" />
   <package id="ServiceStack" version="5.8.0" targetFramework="net472" />
   <package id="ServiceStack.Api.OpenApi" version="5.8.0" targetFramework="net472" />
   <package id="ServiceStack.Client" version="5.8.0" targetFramework="net472" />


### PR DESCRIPTION
Context: `Query*` DTOs are currently implemented by subclassing (for example) `QueryDb<T>`, which subclasses `QueryBase`. All of the shared query info is on `QueryBase`, however this results in a very awkward to work with protobuf `message` schema. Not a huge problem for .NET-.NET, but awkward for x-plat.

This proposed change changes this by special-casing anything that subclasses `QueryDb`; when detected, it applies a fixed offset (currently 32) to all the regular fields in the type, and instead of absorbing the base type via protobuf-net's spoofed inheritance, it hoists all of the relevant fields directly into the 32-field reserved chunk (only 7 currently in use, so space for a few extra). This gives a far more pleasing shape, and avoids a lot of unnecessary overhead related to how protobuf-net implements inheritance.

HOWEVER!!!

It is fundamentally a shape breaking change, and **MUST** demand matching client and server versions. It **WILL NOT** be compatible between conflicting versions; as such, this should probably be held back to the next major.

---

Additional notes:

- rev of protobuf-net to 2.4.5 is for the new `ApplyFieldOffset` method
- move from `TypeModel.Create` to `RuntimeTypeModel.Create` is for protobuf-net v3 compatibility