### PR TITLE
Add IOC GetServiceEntryNamed<T> and ExistsNamed<T>

### DIFF
--- a/src/ServiceStack/Funq/Container.Adapter.cs
+++ b/src/ServiceStack/Funq/Container.Adapter.cs
@@ -129,9 +129,17 @@ namespace Funq
         public ServiceEntry<TService, Func<Container, TService>> GetServiceEntry<TService>() => 
             GetEntry<TService, Func<Container, TService>>(null, throwIfMissing: false);
 
+        public ServiceEntry<TService, Func<Container, TService>> GetServiceEntryNamed<TService>(string name) => 
+            GetEntry<TService, Func<Container, TService>>(name, throwIfMissing: false);
+
         public bool Exists<TService>()
         {
             var entry = GetEntry<TService, Func<Container, TService>>(null, throwIfMissing: false);
+            return entry != null;
+        }
+        public bool ExistsNamed<TService>(string name)
+        {
+            var entry = GetEntry<TService, Func<Container, TService>>(name, throwIfMissing: false);
             return entry != null;
         }
 


### PR DESCRIPTION
As an extension to the previous commit, just adding these overloads for GetServiceEntryNamed<T> and ExistsNamed<T> that are needed for named registrations.