### PR TITLE
Fix broken grpc tests

### DIFF
--- a/src/ServiceStack.Extensions/GrpcFeature.cs
+++ b/src/ServiceStack.Extensions/GrpcFeature.cs
@@ -310,15 +310,7 @@ namespace ServiceStack
             // All DTO Types with inheritance need to be registered in GrpcMarshaller<T> / GrpcUtils.TypeModel
             foreach (var dto in allDtos)
             {
-                try
-                {
-                    GrpcConfig.Register(dto);
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e);
-                    // throw;
-                }
+                GrpcConfig.Register(dto);
             }
         }
 

--- a/src/ServiceStack.Extensions/ServiceStack.Extensions.csproj
+++ b/src/ServiceStack.Extensions/ServiceStack.Extensions.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Grpc.AspNetCore.Server" Version="2.28.0-pre2" />
         <PackageReference Include="Grpc.Core.Api" Version="2.28.0-pre3" />
-        <PackageReference Include="protobuf-net" Version="3.0.0-alpha.133" />
+        <PackageReference Include="protobuf-net" Version="3.0.0-alpha.143" />
         <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.36" />
         
         <PackageReference Include="System.Threading.Channels" Version="4.7.0" />

--- a/src/ServiceStack.GrpcClient/ServiceStack.GrpcClient.csproj
+++ b/src/ServiceStack.GrpcClient/ServiceStack.GrpcClient.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Grpc.Core" Version="2.26.0" />
         <PackageReference Include="protobuf-net.Grpc" Version="1.0.22" />
         <!-- the transitive import of protobuf-net is lower; we need at least this -->
-        <PackageReference Include="protobuf-net" Version="2.4.5" />
+        <PackageReference Include="protobuf-net" Version="2.4.6" />
         <PackageReference Include="ServiceStack.Text" Version="$(Version)" />
 
         <ProjectReference Include="..\ServiceStack.Interfaces\ServiceStack.Interfaces.csproj" />

--- a/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.Core.csproj
+++ b/src/ServiceStack.ProtoBuf/ServiceStack.ProtoBuf.Core.csproj
@@ -16,6 +16,6 @@
     <ProjectReference Include="..\ServiceStack.Common\ServiceStack.Common.Core.csproj" />
     <ProjectReference Include="..\ServiceStack\ServiceStack.Core.csproj" />
     <PackageReference Include="ServiceStack.Text.Core" Version="$(Version)" />
-    <PackageReference Include="protobuf-net" Version="2.4.5" />
+    <PackageReference Include="protobuf-net" Version="2.4.6" />
   </ItemGroup>
 </Project>

--- a/tests/CheckGrpc/CheckGrpc.csproj
+++ b/tests/CheckGrpc/CheckGrpc.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.7.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>

--- a/tests/CheckWebCore/CheckWebCore.csproj
+++ b/tests/CheckWebCore/CheckWebCore.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.7.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>


### PR DESCRIPTION
1. fix AddField typo
2. use AfterApplyDefaultBehaviour to move timing of type configuration (moves config code to GrpcConfig)
3. above needs newer protobuf-net build

Main change is 1; this seems to have been a change when `AddField` was refactored after my earlier PR; [original code](https://github.com/ServiceStack/ServiceStack/commit/14dd3eb9d29661c7990c7f30c8508d9bfc1a988d#diff-eeb5a8117e8744e028e08c16d2c43d97R746) added `field.ItemType`; code in "master" added `field.ItemType ?? field.MemberType`, which incorrectly tries to configure everything as "repeated". If this was done for a specific reason, let me know - I can look into that.

2. moves type config to use the newer protobuf-net API that allows configuration *during discovery*, avoiding a lot of timing problems; this required moving code from `GrpcServiceClient` to `GrpcConfig`

There's still something going on re `CheckServiceProto_DerivedType` - will look more this later today.