### PR TITLE
Dart - avoid_return_types_on_setters style

### DIFF
--- a/src/ServiceStack/NativeTypes/Dart/DartGenerator.cs
+++ b/src/ServiceStack/NativeTypes/Dart/DartGenerator.cs
@@ -564,7 +564,7 @@ namespace ServiceStack.NativeTypes.Dart
                     {
                         var genericArg = baseClass.Substring(9, baseClass.Length - 10);
                         sb.AppendLine($"final List<{genericArg}> l = [];");
-                        sb.AppendLine("void set length(int newLength) { l.length = newLength; }");
+                        sb.AppendLine("set length(int newLength) { l.length = newLength; }");
                         sb.AppendLine("int get length => l.length;");
                         sb.AppendLine($"{genericArg} operator [](int index) => l[index];");
                         sb.AppendLine($"void operator []=(int index, {genericArg} value) {{ l[index] = value; }}");


### PR DESCRIPTION
I was getting a warning on this code generated.
Source: https://dart-lang.github.io/linter/lints/avoid_return_types_on_setters.html