### PR TITLE
#Script - Option to parse numbers as decimals

### DIFF
--- a/src/ServiceStack.Common/Script/JsToken.cs
+++ b/src/ServiceStack.Common/Script/JsToken.cs
@@ -471,7 +471,7 @@ namespace ServiceStack.Script
 
                 //don't convert into ternary to avoid Type coercion
                 if ((firstDecimalPos > 0 && firstDecimalPos < i) || hasExponent)
-                    token = new JsLiteral(numLiteral.ParseDouble());
+                    token = ScriptContext.DecimalFloatingPointNumbers ? new JsLiteral(numLiteral.ParseDecimal()) : new JsLiteral(numLiteral.ParseDouble());
                 else
                     token = new JsLiteral(numLiteral.ParseSignedInteger());
 

--- a/src/ServiceStack.Common/Script/JsToken.cs
+++ b/src/ServiceStack.Common/Script/JsToken.cs
@@ -471,7 +471,7 @@ namespace ServiceStack.Script
 
                 //don't convert into ternary to avoid Type coercion
                 if ((firstDecimalPos > 0 && firstDecimalPos < i) || hasExponent)
-                    token = ScriptContext.DecimalFloatingPointNumbers ? new JsLiteral(numLiteral.ParseDecimal()) : new JsLiteral(numLiteral.ParseDouble());
+                    token = new JsLiteral(ScriptConfig.ParseRealNumber(numLiteral));
                 else
                     token = new JsLiteral(numLiteral.ParseSignedInteger());
 

--- a/src/ServiceStack.Common/Script/ScriptConfig.cs
+++ b/src/ServiceStack.Common/Script/ScriptConfig.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using ServiceStack.IO;
+using ServiceStack.Text;
 
 namespace ServiceStack.Script
 {
@@ -36,7 +37,8 @@ namespace ServiceStack.Script
         public static string DefaultErrorClassName { get; set; } = "alert alert-danger";
         public static bool AllowUnixPipeSyntax { get; set; } = true;
         public static bool AllowAssignmentExpressions { get; set; } = true;
-        
+        public static ParseRealNumber ParseRealNumber = numLiteral => numLiteral.ParseDouble();
+
         public static CultureInfo CreateCulture()
         {
             var culture = DefaultCulture;
@@ -52,4 +54,6 @@ namespace ServiceStack.Script
             return culture;
         }
     }
+
+    public delegate object ParseRealNumber(ReadOnlySpan<char> numLiteral);
 }

--- a/src/ServiceStack.Common/Script/ScriptContext.cs
+++ b/src/ServiceStack.Common/Script/ScriptContext.cs
@@ -195,11 +195,6 @@ namespace ServiceStack.Script
         /// </summary>
         public int MaxStackDepth { get; set; } = 25;
 
-        /// <summary>
-        /// Parse floating point numbers as decimals instead of doubles
-        /// </summary>
-        public static bool DecimalFloatingPointNumbers { get; set; }
-
         private ILog log;
         public ILog Log => log ??= LogManager.GetLogger(GetType());
         

--- a/src/ServiceStack.Common/Script/ScriptContext.cs
+++ b/src/ServiceStack.Common/Script/ScriptContext.cs
@@ -195,6 +195,11 @@ namespace ServiceStack.Script
         /// </summary>
         public int MaxStackDepth { get; set; } = 25;
 
+        /// <summary>
+        /// Parse floating point numbers as decimals instead of doubles
+        /// </summary>
+        public static bool DecimalFloatingPointNumbers { get; set; }
+
         private ILog log;
         public ILog Log => log ??= LogManager.GetLogger(GetType());
         

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ScriptTests/JsLiteralTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ScriptTests/JsLiteralTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using ServiceStack.Script;
+using ServiceStack.Text;
 
 namespace ServiceStack.WebHost.Endpoints.Tests.ScriptTests
 {
@@ -17,6 +18,17 @@ namespace ServiceStack.WebHost.Endpoints.Tests.ScriptTests
             "`a`".ParseJsExpression(out token);
             Assert.That(token, Is.EqualTo(new JsTemplateLiteral(
                 new[] { new JsTemplateElement("a","a", tail:true) })));
+
+            "1.0".ParseJsExpression(out token);
+            Assert.That(token, Is.EqualTo(new JsLiteral(1.0)));
+
+            var hold = ScriptConfig.ParseRealNumber;
+            ScriptConfig.ParseRealNumber = numLiteral => numLiteral.ParseDecimal();
+
+            "1.0".ParseJsExpression(out token);
+            Assert.That(token, Is.EqualTo(new JsLiteral(1.0m)));
+
+            ScriptConfig.ParseRealNumber = hold;
 
             "`a${b}`".ParseJsExpression(out token);
             Assert.That(token, Is.EqualTo(new JsTemplateLiteral(


### PR DESCRIPTION
I'm considering using #Script/Js.eval as an embedded language in a financial application, for user defined formulas. However currently all "decimal" numbers are parsed as `double`s. I appreciate this is in keeping with the JavaScript roots.

It would be great if there was an opt-in option to parse numbers as `decimal`s instead of `double`s.

I've added a static flag to the `ScriptContext`, but this could be an instance field, it would just need passing all the way done 🐢.

Please let me know if this is something you'd consider allowing, if it is I can look at adding tests and changing to an instance field etc.
