### PR TITLE
Don't dispose HTTP message handler if it was injected

### DIFF
--- a/src/ServiceStack.HttpClient/JsonHttpClient.cs
+++ b/src/ServiceStack.HttpClient/JsonHttpClient.cs
@@ -123,10 +123,11 @@ namespace ServiceStack
             if (HttpClient != null)
                 return HttpClient;
 
-            if (HttpMessageHandler == null && GlobalHttpMessageHandlerFactory != null)
-                HttpMessageHandler = GlobalHttpMessageHandlerFactory();
-
             var handler = HttpMessageHandler;
+
+            if (handler == null && GlobalHttpMessageHandlerFactory != null)
+                handler = GlobalHttpMessageHandlerFactory();
+
             if (handler == null)
             {
                 var useHandler = new HttpClientHandler
@@ -144,7 +145,7 @@ namespace ServiceStack
             
             var baseUri = BaseUri != null ? new Uri(BaseUri) : null;
 
-            var client = new HttpClient(handler) { BaseAddress = baseUri };
+            var client = new HttpClient(handler, disposeHandler: HttpMessageHandler == null) { BaseAddress = baseUri };
 
             if (BearerToken != null)
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", BearerToken);

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceClientTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/ServiceClientTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -154,6 +155,23 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             var response = await client.GetAsync(new EchoRequestInfo());
 
             Assert.That(response.Headers["Foo"], Is.EqualTo("Bar"));
+        }
+
+        [Test]
+        public async Task Doesnt_dispose_injected_handler()
+        {
+            var handler = new HttpClientHandler();
+
+            var client1 = (JsonHttpClient)GetClient();
+            client1.HttpMessageHandler = handler;
+            await client1.GetAsync(new GetCustomer { CustomerId = 5 });
+            client1.Dispose();
+
+            var client2 = (JsonHttpClient)GetClient();
+            client2.HttpMessageHandler = handler;
+            var response = await client2.GetAsync(new GetCustomer { CustomerId = 5 });
+
+            Assert.That(response, Is.Not.Null);
         }
     }
 


### PR DESCRIPTION
`JsonHttpClient` was disposing the injected `HttpMessageHandler` preventing re-use.

A `SocketsHttpHandler` instance pools connections so can be long-lived [without fear of socket exhaustion or DNS problems](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#alternatives-to-ihttpclientfactory).

For situations where the same `JsonHttpClient` can't be re-used (different authentication for example), it would be useful to at least re-use the handler and underlying connections (with cookies off).
