### PR TITLE
Change HttpMethod on SendAll and SendAllAsync based on IVerb interfaces

### DIFF
--- a/src/ServiceStack.Client/AsyncServiceClient.cs
+++ b/src/ServiceStack.Client/AsyncServiceClient.cs
@@ -153,8 +153,7 @@ namespace ServiceStack
             this.PopulateRequestMetadata(request);
 
             var requestUri = absoluteUrl;
-            var hasQueryString = request != null && !HttpUtils.HasRequestBody(httpMethod);
-            if (hasQueryString)
+            if (!this.EmulateHttpViaPost && !HttpUtils.HasRequestBody(httpMethod) && request != null)
             {
                 var queryString = QueryStringSerializer.SerializeToString(request);
                 if (!string.IsNullOrEmpty(queryString))

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Funq;
 using NUnit.Framework;
 
@@ -45,13 +46,19 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
     public class NoVerbRequest : IReturn<string> { }
 	
-    public class GetRequest : IReturn<string>, IGet { }
+    public class GetRequest : IReturn<string>, IGet
+    {
+        public int Id { get; set; }
+    }
 
     public class PostRequest : IReturn<string>, IPost { }
 
     public class PutRequest : IReturn<string>, IPut { }
 
-    public class DeleteRequest : IReturn<string>, IDelete { }
+    public class DeleteRequest : IReturn<string>, IDelete
+    {
+        public int Id { get; set; }
+    }
 
     public class PatchRequest : IReturn<string>, IPatch { }
 
@@ -107,7 +114,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 				
         public object Get(GetRequest request) => HttpMethods.Get;
 		
-        public object Get(GetRequest[] request) => $"{HttpMethods.Get}AutoBatched";
+        public object Get(GetRequest[] request) => $"{HttpMethods.Get}AutoBatched{request[0].Id}";
 		
         public object Post(PostRequest request) => HttpMethods.Post;
 		
@@ -119,7 +126,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 		
         public object Delete(DeleteRequest request) => HttpMethods.Delete;
 		
-        public object Delete(DeleteRequest[] request) => $"{HttpMethods.Delete}AutoBatched";
+        public object Delete(DeleteRequest[] request) => $"{HttpMethods.Delete}AutoBatched{request[0].Id}";
 		
         public object Patch(PatchRequest request) => HttpMethods.Patch;
 
@@ -222,11 +229,11 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void SendAll_request_for_IGet_calls_Get_Method()
         {
-            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
 
-            var response = client.SendAll(new[] { new GetRequest() });
+            var response = client.SendAll(new[] { new GetRequest { Id = 1} });
 
-            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Get}AutoBatched"));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Get}AutoBatched1"));
         }
 
         [Test]
@@ -262,7 +269,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void SendAll_request_for_IPut_calls_Put_Method()
         {
-            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
 
             var response = client.SendAll(new[] { new PutRequest() });
 
@@ -282,11 +289,11 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void SendAll_request_for_IDelete_calls_Delete_Method()
         {
-            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
 
-            var response = client.SendAll(new[] { new DeleteRequest() });
+            var response = client.SendAll(new[] { new DeleteRequest { Id = 1 } });
 
-            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Delete}AutoBatched"));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Delete}AutoBatched1"));
         }
 
         [Test]
@@ -302,7 +309,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void SendAll_request_for_IPatch_calls_Patch_Method()
         {
-            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
 
             var response = client.SendAll(new[] { new PatchRequest() });
 
@@ -322,9 +329,69 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void SendAll_request_for_request_with_no_marker_calls_Any_Method()
         {
-            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
 
             var response = client.SendAll(new[] { new NoVerbRequest() });
+
+            Assert.That(response, Is.All.EqualTo("NoVerbAutoBatched"));
+        }
+        
+        [Test]
+        public async Task SendAllAsync_request_for_IGet_calls_Get_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
+
+            var response = await client.SendAllAsync(new[] { new GetRequest { Id = 1} });
+
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Get}AutoBatched1"));
+        }
+
+        [Test]
+        public async Task SendAllAsync_request_for_IPost_calls_Post_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = await client.SendAllAsync(new[] { new PostRequest() });
+
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Post}AutoBatched"));
+        }
+        
+        [Test]
+        public async Task SendAllAsync_request_for_IPut_calls_Put_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};;
+
+            var response = await client.SendAllAsync(new[] { new PutRequest() });
+
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Put}AutoBatched"));
+        }
+        
+        [Test]
+        public async Task SendAllAsync_request_for_IDelete_calls_Delete_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
+
+            var response = await client.SendAllAsync(new[] { new DeleteRequest { Id = 1 } });
+
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Delete}AutoBatched1"));
+        }
+
+        [Test]
+        public async Task SendAllAsync_request_for_IPatch_calls_Patch_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
+
+            var response = await client.SendAllAsync(new[] { new PatchRequest() });
+
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Patch}AutoBatched"));
+        }
+
+        [Test]
+        public async Task SendAllAsync_request_for_request_with_no_marker_calls_Any_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri) {EmulateHttpViaPost = true};
+
+            var response = await client.SendAllAsync(new[] { new NoVerbRequest() });
 
             Assert.That(response, Is.All.EqualTo("NoVerbAutoBatched"));
         }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
@@ -102,27 +102,28 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         }
 
         public object Any(NoVerbRequest request) => "NoVerb";
+        
+        public object Any(NoVerbRequest[] request) => "NoVerbAutoBatched";
 				
         public object Get(GetRequest request) => HttpMethods.Get;
 		
-        public object Get(GetRequest[] request) => HttpMethods.Get;
+        public object Get(GetRequest[] request) => $"{HttpMethods.Get}AutoBatched";
 		
         public object Post(PostRequest request) => HttpMethods.Post;
 		
-        public object Post(PostRequest[] request) => HttpMethods.Post;
+        public object Post(PostRequest[] request) => $"{HttpMethods.Post}AutoBatched";
 		
         public object Put(PutRequest request) => HttpMethods.Put;
 		
-        public object Put(PutRequest[] request) => HttpMethods.Put;
+        public object Put(PutRequest[] request) => $"{HttpMethods.Put}AutoBatched";
 		
         public object Delete(DeleteRequest request) => HttpMethods.Delete;
 		
-        public object Delete(DeleteRequest[] request) => HttpMethods.Delete;
+        public object Delete(DeleteRequest[] request) => $"{HttpMethods.Delete}AutoBatched";
 		
         public object Patch(PatchRequest request) => HttpMethods.Patch;
-		
-        public object Patch(PatchRequest[] request) => HttpMethods.Patch;
-		
+
+        public object Patch(PatchRequest[] request) => $"{HttpMethods.Patch}AutoBatched";
     }
 
     [TestFixture]
@@ -225,7 +226,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new GetRequest() });
 
-            Assert.That(response, Is.All.EqualTo(HttpMethods.Get));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Get}AutoBatched"));
         }
 
         [Test]
@@ -245,7 +246,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new PostRequest() });
 
-            Assert.That(response, Is.All.EqualTo(HttpMethods.Post));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Post}AutoBatched"));
         }
 
         [Test]
@@ -265,7 +266,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new PutRequest() });
 
-            Assert.That(response, Is.All.EqualTo(HttpMethods.Put));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Put}AutoBatched"));
         }
 
         [Test]
@@ -285,7 +286,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new DeleteRequest() });
 
-            Assert.That(response, Is.All.EqualTo(HttpMethods.Delete));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Delete}AutoBatched"));
         }
 
         [Test]
@@ -305,7 +306,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new PatchRequest() });
 
-            Assert.That(response, Is.All.EqualTo(HttpMethods.Patch));
+            Assert.That(response, Is.All.EqualTo($"{HttpMethods.Patch}AutoBatched"));
         }
 
         [Test]
@@ -325,7 +326,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             var response = client.SendAll(new[] { new NoVerbRequest() });
 
-            Assert.That(response, Is.All.EqualTo("NoVerb"));
+            Assert.That(response, Is.All.EqualTo("NoVerbAutoBatched"));
         }
     }
 }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AutoBatchTests.cs
@@ -43,6 +43,18 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         }
     }
 
+    public class NoVerbRequest : IReturn<string> { }
+	
+    public class GetRequest : IReturn<string>, IGet { }
+
+    public class PostRequest : IReturn<string>, IPost { }
+
+    public class PutRequest : IReturn<string>, IPut { }
+
+    public class DeleteRequest : IReturn<string>, IDelete { }
+
+    public class PatchRequest : IReturn<string>, IPatch { }
+
     public class GetAutoBatchIndex : IReturn<GetAutoBatchIndexResponse>
     {
     }
@@ -88,6 +100,29 @@ namespace ServiceStack.WebHost.Endpoints.Tests
 
             return responses;
         }
+
+        public object Any(NoVerbRequest request) => "NoVerb";
+				
+        public object Get(GetRequest request) => HttpMethods.Get;
+		
+        public object Get(GetRequest[] request) => HttpMethods.Get;
+		
+        public object Post(PostRequest request) => HttpMethods.Post;
+		
+        public object Post(PostRequest[] request) => HttpMethods.Post;
+		
+        public object Put(PutRequest request) => HttpMethods.Put;
+		
+        public object Put(PutRequest[] request) => HttpMethods.Put;
+		
+        public object Delete(DeleteRequest request) => HttpMethods.Delete;
+		
+        public object Delete(DeleteRequest[] request) => HttpMethods.Delete;
+		
+        public object Patch(PatchRequest request) => HttpMethods.Patch;
+		
+        public object Patch(PatchRequest[] request) => HttpMethods.Patch;
+		
     }
 
     [TestFixture]
@@ -171,6 +206,126 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.AreEqual("1", responses[1].Meta["GlobalResponseFilterAutoBatchIndex"]);
 
             Assert.AreEqual("1", responseHeaders["GlobalRequestFilterAutoBatchIndex"]);
+        }
+
+        [Test]
+        public void Send_request_for_IGet_calls_Get_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new GetRequest());
+
+            Assert.That(response, Is.EqualTo(HttpMethods.Get));
+        }
+
+        [Test]
+        public void SendAll_request_for_IGet_calls_Get_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new GetRequest() });
+
+            Assert.That(response, Is.All.EqualTo(HttpMethods.Get));
+        }
+
+        [Test]
+        public void Send_request_for_IPost_calls_Post_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new PostRequest());
+
+            Assert.That(response, Is.EqualTo(HttpMethods.Post));
+        }
+
+        [Test]
+        public void SendAll_request_for_IPost_calls_Post_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new PostRequest() });
+
+            Assert.That(response, Is.All.EqualTo(HttpMethods.Post));
+        }
+
+        [Test]
+        public void Send_request_for_IPut_calls_Put_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new PutRequest());
+
+            Assert.That(response, Is.EqualTo(HttpMethods.Put));
+        }
+
+        [Test]
+        public void SendAll_request_for_IPut_calls_Put_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new PutRequest() });
+
+            Assert.That(response, Is.All.EqualTo(HttpMethods.Put));
+        }
+
+        [Test]
+        public void Send_request_for_IDelete_calls_Delete_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new DeleteRequest());
+
+            Assert.That(response, Is.EqualTo(HttpMethods.Delete));
+        }
+
+        [Test]
+        public void SendAll_request_for_IDelete_calls_Delete_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new DeleteRequest() });
+
+            Assert.That(response, Is.All.EqualTo(HttpMethods.Delete));
+        }
+
+        [Test]
+        public void Send_request_for_IPatch_calls_Patch_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new PatchRequest());
+
+            Assert.That(response, Is.EqualTo(HttpMethods.Patch));
+        }
+
+        [Test]
+        public void SendAll_request_for_IPatch_calls_Patch_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new PatchRequest() });
+
+            Assert.That(response, Is.All.EqualTo(HttpMethods.Patch));
+        }
+
+        [Test]
+        public void Send_request_for_request_with_no_marker_calls_Any_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.Send(new NoVerbRequest());
+
+            Assert.That(response, Is.EqualTo("NoVerb"));
+        }
+
+        [Test]
+        public void SendAll_request_for_request_with_no_marker_calls_Any_Method()
+        {
+            var client = new JsonServiceClient(Config.AbsoluteBaseUri);
+
+            var response = client.SendAll(new[] { new NoVerbRequest() });
+
+            Assert.That(response, Is.All.EqualTo("NoVerb"));
         }
     }
 }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/UseCases/EncryptedMessagesTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/UseCases/EncryptedMessagesTests.cs
@@ -284,7 +284,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests.UseCases
             catch (WebServiceException ex)
             {
                 Assert.That(ex.ResponseStatus.ErrorCode, Is.EqualTo(nameof(ArgumentNullException)));
-                Assert.That(ex.ResponseStatus.Message, Is.EqualTo($"Value cannot be null. (Parameter 'Name')"));
+                Assert.That(ex.ResponseStatus.Message, Is.EqualTo($"Value cannot be null.{Environment.NewLine}Parameter name: Name"));
             }
 
             try

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/UseCases/EncryptedMessagesTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/UseCases/EncryptedMessagesTests.cs
@@ -284,7 +284,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests.UseCases
             catch (WebServiceException ex)
             {
                 Assert.That(ex.ResponseStatus.ErrorCode, Is.EqualTo(nameof(ArgumentNullException)));
-                Assert.That(ex.ResponseStatus.Message, Is.EqualTo($"Value cannot be null.{Environment.NewLine}Parameter name: Name"));
+                Assert.That(ex.ResponseStatus.Message, Is.EqualTo($"Value cannot be null. (Parameter 'Name')"));
             }
 
             try


### PR DESCRIPTION
With this pull request AutoBatched Requests is extended to take the HttpMethod marker of a request (IPost, IGet, IPatch, IDelete, IPut) in consideration when making the underlying request. 

Why: we use HttpVerbs for our messages to perform different actions. We'd like to use AutoBatched requests instead of having to call Put, Delete or Patch methods in a loop 