### PR TITLE
fix for PATCH requests with multipart/form-data not populating the request DTO

### DIFF
--- a/src/ServiceStack/HttpRequestExtensions.cs
+++ b/src/ServiceStack/HttpRequestExtensions.cs
@@ -552,7 +552,7 @@ namespace ServiceStack
                 map[name] = request.QueryString[name];
             }
 
-            if ((request.Verb == HttpMethods.Post || request.Verb == HttpMethods.Put)
+            if ((request.Verb == HttpMethods.Post || request.Verb == HttpMethods.Put || request.Verb == HttpMethods.Patch)
                 && request.FormData != null)
             {
                 foreach (var name in request.FormData.AllKeys)


### PR DESCRIPTION
a patch request with multipart/form-data such as the following results in the request dto objects not getting populated by servicestack.
```
curl --location --request PATCH 'http://localhost:8888/image' \
--form 'Width=1500' \
--form 'Height=1000' \
--form 'ID=5f3c03457118797a3a7a6f8c' \
--form 'File=@/D:/IMG_20190901_144155.jpg'
```

the issue seems to be a simple oversight/omission in  `HttpRequestExtensions.cs`

for more info please refer to my original SO question here: https://stackoverflow.com/questions/63473937