### PR TITLE
Remove stack trace from SerializationException message

### DIFF
--- a/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
+++ b/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
@@ -226,7 +226,7 @@ namespace ServiceStack.Host.Handlers
             }
             catch (Exception ex)
             {
-                var msg = $"Could not deserialize '{contentType}' request using {requestType}'\nError: {ex}";
+                var msg = $"Could not deserialize '{contentType}' request using {requestType}'\nError: {ex.Message}";
                 throw new SerializationException(msg, ex);
             }
             return requestType.CreateInstance().InTask(); //Return an empty DTO, even for empty request bodies


### PR DESCRIPTION
String interpolation for `SerializationException` calls `ex.ToString()` under the hood which inadvertently includes the stack trace in the error message.