### PR TITLE
Fix default LogFactory in NetCore

### DIFF
--- a/src/ServiceStack/AppHostBase.NetCore.cs
+++ b/src/ServiceStack/AppHostBase.NetCore.cs
@@ -85,7 +85,7 @@ namespace ServiceStack
             if (logFactory != null)
             {
                 NetCoreLogFactory.FallbackLoggerFactory = logFactory;
-                if (LogManager.LogFactory == null)
+                if (LogManager.LogFactory.IsNullOrNullLogFactory())
                     LogManager.LogFactory = new NetCoreLogFactory(logFactory);
             }
 

--- a/src/ServiceStack/LogExtensions.cs
+++ b/src/ServiceStack/LogExtensions.cs
@@ -11,5 +11,10 @@ namespace ServiceStack
                 throw ex;
             log.Error(message, ex);
         }
+
+        public static bool IsNullOrNullLogFactory(this ILogFactory factory)
+        {
+            return factory == null || factory.GetType() == typeof(NullLogFactory);
+        }
     }
 }


### PR DESCRIPTION
on NetCore with the UseServiceStack it delegates in Microsoft.Extensions.Logging ILogger if  LogManager.LogFactory == null, but LogManager.LogFactory could not be null because it coerce witha a new NullLogFactory(false)

https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Interfaces/Logging/LogManager.cs#L17-L21
```csharp
        public static ILogFactory LogFactory
        {
            get => logFactory ?? new NullLogFactory();
            set => logFactory = value;
        }
```