### PR TITLE
Make NetCoreIdentityAuthProvider virtual

### DIFF
--- a/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
+++ b/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
@@ -108,7 +108,7 @@ namespace ServiceStack.Auth
             throw new NotImplementedException("NetCoreIdentityAuthProvider Authenticate() should not be called directly");
         }
 
-        public virtual PreAuthenticate(IRequest req, IResponse res)
+        public virtual void PreAuthenticate(IRequest req, IResponse res)
         {
             var coreReq = (HttpRequest)req.OriginalRequest;
             var claimsPrincipal = coreReq.HttpContext.User;

--- a/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
+++ b/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
@@ -108,7 +108,7 @@ namespace ServiceStack.Auth
             throw new NotImplementedException("NetCoreIdentityAuthProvider Authenticate() should not be called directly");
         }
 
-        public void PreAuthenticate(IRequest req, IResponse res)
+        public virtual PreAuthenticate(IRequest req, IResponse res)
         {
             var coreReq = (HttpRequest)req.OriginalRequest;
             var claimsPrincipal = coreReq.HttpContext.User;


### PR DESCRIPTION
There are some use cases where it would be helpful to run additional logic in the PreAuthenticate method of the NetCoreIdentityAuthProvider