### PR TITLE
Remove extra slash that is added to PathBase when calling ResolveStaticBaseUrl

### DIFF
--- a/src/ServiceStack/AppHostExtensions.cs
+++ b/src/ServiceStack/AppHostExtensions.cs
@@ -146,7 +146,7 @@ namespace ServiceStack
         {
             return (appHost.Config.WebHostUrl ??
                 (!string.IsNullOrEmpty(appHost.PathBase)
-                    ? "/" + appHost.PathBase
+                    ? ("/" + appHost.PathBase).ReplaceAll("//", "/")
                     : "")).TrimEnd('/');
         }
     }


### PR DESCRIPTION
The .NET Core version of the AppHostBase throws an exception when PathBase doesn't start with '/'. ResolveStaticBaseUrl adds an additional '/' which in turn breaks the login.html page. The quickest way to fix this is to remove the concatenation of the '/' to appHost.PathBase in ResolceStaticBaseUrl. However, I wasn't sure if in the Framework version of this code allows setting PathBase to a value that doesn't start with '/' so I've replaced the double '//' here using ReplaceAll. If the Framework version works the same as the .NET Core version then this could just be simplified as mentioned above.