### PR TITLE
Introduce Asp.Net Core 3.1 & Net 5 targets

### DIFF
--- a/src/ServiceStack.Interfaces/Caching/ICacheClientAsync.cs
+++ b/src/ServiceStack.Interfaces/Caching/ICacheClientAsync.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace ServiceStack.Caching
 {
     public interface ICacheClientAsync
-#if NET472 || NETSTANDARD2_0        
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         : IAsyncDisposable
 #endif
         
@@ -114,7 +114,7 @@ namespace ServiceStack.Caching
         
         Task<TimeSpan?> GetTimeToLiveAsync(string key, CancellationToken token=default);
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         IAsyncEnumerable<string> GetKeysByPatternAsync(string pattern, CancellationToken token=default);
 #endif
         

--- a/src/ServiceStack/AppHostBase.cs
+++ b/src/ServiceStack/AppHostBase.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using System;
 using System.Reflection;
 using System.Web;

--- a/src/ServiceStack/AppHostExtensions.cs
+++ b/src/ServiceStack/AppHostExtensions.cs
@@ -127,7 +127,7 @@ namespace ServiceStack
 
         public static IAppHost Start(this IAppHost appHost, IEnumerable<string> urlBases)
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             var listener = (ServiceStack.Host.HttpListener.HttpListenerBase)appHost;
             listener.Start(urlBases);
 #endif

--- a/src/ServiceStack/AppHostHttpListenerBase.cs
+++ b/src/ServiceStack/AppHostHttpListenerBase.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.Net;

--- a/src/ServiceStack/AppHostHttpListenerPoolBase.cs
+++ b/src/ServiceStack/AppHostHttpListenerPoolBase.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/AppSelfHostBase.cs
+++ b/src/ServiceStack/AppSelfHostBase.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/AppUtils.cs
+++ b/src/ServiceStack/AppUtils.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/AspNet/ServiceStackPage.cs
+++ b/src/ServiceStack/AspNet/ServiceStackPage.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 using System;
 using System.Data;
@@ -101,7 +101,7 @@ namespace ServiceStack.AspNet
 
         public virtual IRedisClient Redis => ServiceStackProvider.Redis;
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public virtual ValueTask<IRedisClientAsync> GetRedisAsync() => ServiceStackProvider.GetRedisAsync();
 #endif
 

--- a/src/ServiceStack/Auth/ApiKeyAuthProvider.cs
+++ b/src/ServiceStack/Auth/ApiKeyAuthProvider.cs
@@ -207,7 +207,7 @@ namespace ServiceStack.Auth
         public override async Task<object> AuthenticateAsync(IServiceBase authService, IAuthSession session, Authenticate request, CancellationToken token=default)
         {
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(authService.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/Auth/AspNetWindowsAuthProvider.cs
+++ b/src/ServiceStack/Auth/AspNetWindowsAuthProvider.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/Auth/AuthMetadataProvider.cs
+++ b/src/ServiceStack/Auth/AuthMetadataProvider.cs
@@ -64,7 +64,7 @@ namespace ServiceStack.Auth
                     requestFilter: req =>
                     {
                         req.SetUserAgent("ServiceStack");
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                         req.AllowAutoRedirect = false; //Missing in .NET Core
 #endif
                     },

--- a/src/ServiceStack/Auth/AuthProvider.cs
+++ b/src/ServiceStack/Auth/AuthProvider.cs
@@ -179,7 +179,7 @@ namespace ServiceStack.Auth
             }
 
             var authRepo = GetAuthRepositoryAsync(authService.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/Auth/AuthenticateService.cs
+++ b/src/ServiceStack/Auth/AuthenticateService.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using System.Configuration;
 #endif
 

--- a/src/ServiceStack/Auth/CredentialsAuthProvider.cs
+++ b/src/ServiceStack/Auth/CredentialsAuthProvider.cs
@@ -50,7 +50,7 @@ namespace ServiceStack.Auth
         public virtual async Task<bool> TryAuthenticateAsync(IServiceBase authService, string userName, string password, CancellationToken token=default)
         {
             var authRepo = GetUserAuthRepositoryAsync(authService.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)
@@ -141,7 +141,7 @@ namespace ServiceStack.Auth
             IServiceBase authService, IAuthSession session, string userName, string password, string referrerUrl, CancellationToken token=default)
         {
             var authRepo = GetUserAuthRepositoryAsync(authService.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/Auth/DigestAuthProvider.cs
+++ b/src/ServiceStack/Auth/DigestAuthProvider.cs
@@ -130,7 +130,7 @@ namespace ServiceStack.Auth
             }
 
             var authRepo = GetUserAuthRepositoryAsync(authService.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/Auth/IRedisClientFacade.cs
+++ b/src/ServiceStack/Auth/IRedisClientFacade.cs
@@ -46,7 +46,7 @@ namespace ServiceStack.Auth
         Task ClearAsync(CancellationToken token=default);
     }
     
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
     public partial interface IRedisClientManagerFacade : IClearableAsync
     {
         Task<IRedisClientFacadeAsync> GetClientAsync(CancellationToken token=default);
@@ -82,7 +82,7 @@ namespace ServiceStack.Auth
         public RedisClientManagerFacade(IRedisClientsManager redisManager)
         {
             this.redisManager = redisManager;
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             this.redisManagerAsync = (IRedisClientsManagerAsync) redisManager;
 #endif
         }
@@ -203,7 +203,7 @@ namespace ServiceStack.Auth
             }
         }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         private readonly IRedisClientsManagerAsync redisManagerAsync;
         public async Task ClearAsync(CancellationToken token=default)
         {

--- a/src/ServiceStack/Auth/InMemoryAuthRepository.cs
+++ b/src/ServiceStack/Auth/InMemoryAuthRepository.cs
@@ -88,7 +88,7 @@ namespace ServiceStack.Auth
                 return TypeConstants.EmptyTask;
             }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             public async Task<IRedisClientFacadeAsync> GetClientAsync(CancellationToken token = default)
             {
                 return new InMemoryClientFacadeAsync(root);
@@ -283,7 +283,7 @@ namespace ServiceStack.Auth
             }
         }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         internal class InMemoryClientFacadeAsync : IRedisClientFacadeAsync
         {
             private readonly IMemoryAuthRepository root;

--- a/src/ServiceStack/Auth/JwtAuthProviderReader.cs
+++ b/src/ServiceStack/Auth/JwtAuthProviderReader.cs
@@ -596,7 +596,7 @@ namespace ServiceStack.Auth
                 if (ValidateToken != null && !ValidateToken(verifiedPayload, req)) 
                     return null;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }

--- a/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
+++ b/src/ServiceStack/Auth/NetCoreIdentityAuthProvider.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ServiceStack/Auth/PasswordHasher.cs
+++ b/src/ServiceStack/Auth/PasswordHasher.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Text;
 using ServiceStack.Logging;
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
 #endif
 
@@ -25,7 +25,7 @@ namespace ServiceStack.Auth
         /// The PBKDF2 strategy PasswordHasher implementation that's used for hashing PBKDF2 passwords.
         /// </summary>
         public static Pbkdf2DeriveKeyDelegate DeriveKey { get; set; }
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             = KeyDerivation.Pbkdf2; // .NET Core uses the most optimal implementation available for Windows
 #else
             = new ManagedPbkdf2Provider().DeriveKey; // Slowest managed implementation used by .NET Framework and all non-Windows OS's

--- a/src/ServiceStack/Auth/RedisAuthRepositoryAsync.cs
+++ b/src/ServiceStack/Auth/RedisAuthRepositoryAsync.cs
@@ -1,4 +1,4 @@
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/ServiceStack/Auth/RegisterService.cs
+++ b/src/ServiceStack/Auth/RegisterService.cs
@@ -34,7 +34,7 @@ namespace ServiceStack.Auth
                         .MustAsync(async (x,token) =>
                         {
                             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(base.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                             await using (authRepo as IAsyncDisposable)
 #else
                             using (authRepo as IDisposable)
@@ -50,7 +50,7 @@ namespace ServiceStack.Auth
                         .MustAsync(async (x,token) =>
                         {
                             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(base.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                             await using (authRepo as IAsyncDisposable)
 #else
                             using (authRepo as IDisposable)
@@ -172,7 +172,7 @@ namespace ServiceStack.Auth
 
             if (request.AutoLogin.GetValueOrDefault())
             {
-#if NETSTANDARD2_0 || NET472
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0 || NET472
                 await using var authService = base.ResolveService<AuthenticateService>();
 #else
                 using var authService = base.ResolveService<AuthenticateService>();
@@ -287,7 +287,7 @@ namespace ServiceStack.Auth
             var session = await this.GetSessionAsync().ConfigAwait();
 
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(base.Request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/Auth/SaltedHash.cs
+++ b/src/ServiceStack/Auth/SaltedHash.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.Auth
             Salt = new byte[SalthLength];
 
             var random = RandomNumberGenerator.Create();
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             random.GetNonZeroBytes(Salt);
 #else
             random.GetBytes(Salt);

--- a/src/ServiceStack/AutoQueryDataFeature.cs
+++ b/src/ServiceStack/AutoQueryDataFeature.cs
@@ -10,7 +10,9 @@ using System.Runtime.Serialization;
 using System.Threading;
 using ServiceStack.Caching;
 using ServiceStack.DataAnnotations;
+#if NETFRAMEWORK || NETSTANDARD
 using ServiceStack.Extensions;
+#endif
 using ServiceStack.Host;
 using ServiceStack.MiniProfiler;
 using ServiceStack.Web;

--- a/src/ServiceStack/CacheClientExtensions.cs
+++ b/src/ServiceStack/CacheClientExtensions.cs
@@ -515,7 +515,7 @@ namespace ServiceStack
             return cache.GetKeysByPattern(prefix + "*");
         }
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public static IAsyncEnumerable<string> GetKeysByPatternAsync(this ICacheClientAsync cache, string pattern)
         {
             return cache.GetKeysByPatternAsync(pattern);

--- a/src/ServiceStack/Caching/CacheClientAsyncWrapper.cs
+++ b/src/ServiceStack/Caching/CacheClientAsyncWrapper.cs
@@ -77,7 +77,7 @@ namespace ServiceStack.Caching
             return TypeConstants.EmptyTask;
         }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public async IAsyncEnumerable<string> GetKeysByPatternAsync(string pattern, [EnumeratorCancellation] CancellationToken token = default)
         {
             foreach (var key in Cache.GetKeysByPattern(pattern))

--- a/src/ServiceStack/Caching/CacheClientWithPrefixAsync.cs
+++ b/src/ServiceStack/Caching/CacheClientWithPrefixAsync.cs
@@ -121,8 +121,8 @@ namespace ServiceStack.Caching
             await (cache as IRemoveByPatternAsync).RemoveByRegexAsync(EnsurePrefix(regex), token).ConfigAwait();
         }
 
-#if NET472 || NETSTANDARD2_0
-        public async IAsyncEnumerable<string> GetKeysByPatternAsync(string pattern, CancellationToken token = default)
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
+        public async IAsyncEnumerable<string> GetKeysByPatternAsync(string pattern, [EnumeratorCancellation] CancellationToken token = default)
         {
             await foreach (var key in cache.GetKeysByPatternAsync(EnsurePrefix(pattern), token))
             {

--- a/src/ServiceStack/Caching/MultiCacheClient.cs
+++ b/src/ServiceStack/Caching/MultiCacheClient.cs
@@ -253,7 +253,7 @@ namespace ServiceStack.Caching
             await cacheClientsAsync.ExecAllAsync(client => client.RemoveExpiredEntriesAsync(token)).ConfigAwait();
         }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public async ValueTask DisposeAsync()
         {
             foreach (var cache in cacheClientsAsync)

--- a/src/ServiceStack/Configuration/AppSettings.cs
+++ b/src/ServiceStack/Configuration/AppSettings.cs
@@ -15,7 +15,7 @@ namespace ServiceStack.Configuration
         {
             public string Get(string key)
             {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 return ConfigurationManager.AppSettings[key];
 #else
                 var appSettings = ConfigUtils.GetAppSettingsMap();
@@ -27,7 +27,7 @@ namespace ServiceStack.Configuration
 
             public List<string> GetAllKeys()
             {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 return new List<string>(ConfigurationManager.AppSettings.AllKeys);
 #else
                 var appSettings = ConfigUtils.GetAppSettingsMap();

--- a/src/ServiceStack/Configuration/AppSettingsBase.cs
+++ b/src/ServiceStack/Configuration/AppSettingsBase.cs
@@ -196,7 +196,7 @@ namespace ServiceStack.Configuration
 
         public static string GetConnectionString(this IAppSettings appSettings, string name)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             return appSettings is NetCoreAppSettings config
                 ? config.Configuration?.GetSection("ConnectionStrings")?[name]
                 : appSettings.GetString("ConnectionStrings:" + name);

--- a/src/ServiceStack/Configuration/MultiAppSettingsBuilder.cs
+++ b/src/ServiceStack/Configuration/MultiAppSettingsBuilder.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Configuration
             return this;
         }
         
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public MultiAppSettingsBuilder AddNetCore(Microsoft.Extensions.Configuration.IConfiguration configuration)
         {
             appSettingsQueue.Enqueue(

--- a/src/ServiceStack/ContainerTypeExtensions.cs
+++ b/src/ServiceStack/ContainerTypeExtensions.cs
@@ -7,7 +7,7 @@ using ServiceStack.Web;
 namespace ServiceStack
 {
     
-#if NETSTANDARD2_0        
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
     public interface IHasServiceScope : IServiceProvider
     {
         Microsoft.Extensions.DependencyInjection.IServiceScope ServiceScope { get; set; }

--- a/src/ServiceStack/DisposableTracker.cs
+++ b/src/ServiceStack/DisposableTracker.cs
@@ -9,7 +9,7 @@ namespace ServiceStack
     /// Used by <see cref="RequestContext"></see> to track <see cref="Funq.Container"></see> created IDisposable instances.
     /// These instances are tracked and disposed at the end of a request.
     /// </summary>
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
     [Serializable]
 #endif
     public class DisposableTracker : IDisposable

--- a/src/ServiceStack/DtoUtils.cs
+++ b/src/ServiceStack/DtoUtils.cs
@@ -28,7 +28,7 @@ namespace ServiceStack
 
             if (debugMode)
             {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 if (ex is System.Web.HttpCompileException compileEx && compileEx.Results.Errors.HasErrors)
                 {
                     responseStatus.Errors ??= new List<ResponseError>();

--- a/src/ServiceStack/Formats/SoapFormat.cs
+++ b/src/ServiceStack/Formats/SoapFormat.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/Funq/ResolutionException.cs
+++ b/src/ServiceStack/Funq/ResolutionException.cs
@@ -6,7 +6,7 @@ namespace Funq
     /// <summary>
     /// Exception thrown by the container when a service cannot be resolved.
     /// </summary>
-#if !(SL5 || NETSTANDARD2_0)
+#if !(SL5 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0)
     [Serializable]
 #endif
     public class ResolutionException : Exception

--- a/src/ServiceStack/GenericAppHost.cs
+++ b/src/ServiceStack/GenericAppHost.cs
@@ -12,7 +12,7 @@ namespace ServiceStack
             : base(typeof (GenericAppHost).GetOperationName(),
                 serviceAssemblies.Length > 0 ? serviceAssemblies : new[]
                 {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                     Assembly.GetExecutingAssembly()
 #else
                     typeof(GenericAppHost).Assembly

--- a/src/ServiceStack/Host/AppDelegates.cs
+++ b/src/ServiceStack/Host/AppDelegates.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System.Web;
 #endif
 using System;

--- a/src/ServiceStack/Host/AspNet/AspNetRequest.cs
+++ b/src/ServiceStack/Host/AspNet/AspNetRequest.cs
@@ -1,7 +1,7 @@
 
 
 using System.Threading.Tasks;
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/Host/AspNet/AspNetResponse.cs
+++ b/src/ServiceStack/Host/AspNet/AspNetResponse.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/Host/BasicRequest.cs
+++ b/src/ServiceStack/Host/BasicRequest.cs
@@ -13,7 +13,7 @@ using ServiceStack.Web;
 namespace ServiceStack.Host
 {
     public class BasicRequest : IRequest, IHasResolver, IHasVirtualFiles
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
     , IHasServiceScope
 #endif    
     {
@@ -22,7 +22,7 @@ namespace ServiceStack.Host
         public object OriginalRequest { get; private set; }
         public IResponse Response { get; set; }
         
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public Microsoft.Extensions.DependencyInjection.IServiceScope ServiceScope { get; set; }
 #endif
         
@@ -74,7 +74,7 @@ namespace ServiceStack.Host
 
         public T TryResolve<T>()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             if (ServiceScope != null)
             {
                 var instance = ServiceScope.ServiceProvider.GetService(typeof(T));

--- a/src/ServiceStack/Host/ContentTypes.cs
+++ b/src/ServiceStack/Host/ContentTypes.cs
@@ -167,7 +167,7 @@ namespace ServiceStack.Host
                     break;
                 case ErrorResponse errorDto:  //ignore writing ErrorResponse bodies for unknown content types
                     break;
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 case System.Drawing.Image img:
                     img.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
                     break;

--- a/src/ServiceStack/Host/Cookies.cs
+++ b/src/ServiceStack/Host/Cookies.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 using Microsoft.AspNetCore.Http;
 #else
 using System.Web;
@@ -66,7 +66,7 @@ namespace ServiceStack.Host
     {
         private static readonly DateTime Session = DateTime.MinValue;
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 #if !NET472
         private static SetMemberDelegate sameSiteFn;
@@ -131,7 +131,7 @@ namespace ServiceStack.Host
         }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public static CookieOptions ToCookieOptions(this Cookie cookie)
         {
             var config = HostContext.Config;

--- a/src/ServiceStack/Host/Handlers/HttpAsyncTaskHandler.cs
+++ b/src/ServiceStack/Host/Handlers/HttpAsyncTaskHandler.cs
@@ -28,7 +28,7 @@ namespace ServiceStack.Host.Handlers
 
         protected virtual Task CreateProcessRequestTask(IRequest httpReq, IResponse httpRes, string operationName)
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
             var ctx = HttpContext.Current;
@@ -37,7 +37,7 @@ namespace ServiceStack.Host.Handlers
             //preserve Current Culture:
             return new Task(() =>
             {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 Thread.CurrentThread.CurrentCulture = currentCulture;
                 Thread.CurrentThread.CurrentUICulture = currentUiCulture;
                 //HttpContext is not preserved in ThreadPool threads: http://stackoverflow.com/a/13558065/85785
@@ -78,7 +78,7 @@ namespace ServiceStack.Host.Handlers
             return task;
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         protected static bool DefaultHandledRequest(HttpListenerContext context) => false;
 
         protected static bool DefaultHandledRequest(HttpContextBase context) => false;

--- a/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
+++ b/src/ServiceStack/Host/Handlers/ServiceStackHandlerBase.cs
@@ -189,7 +189,7 @@ namespace ServiceStack.Host.Handlers
             {
                 return stream.Length; //can throw NotSupportedException
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return -1;
             }
@@ -205,7 +205,7 @@ namespace ServiceStack.Host.Handlers
                     var hasContentBody = httpReq.ContentLength > 0
                         || (HttpUtils.HasRequestBody(httpReq.Verb) && 
                                 (httpReq.GetContentEncoding() != null
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                                 || GetStreamLengthSafe(httpReq.InputStream) > 0 // AWS API Gateway reports ContentLength=0,ContentEncoding=null
 #endif
                                 ));

--- a/src/ServiceStack/Host/Handlers/Soap11Handlers.cs
+++ b/src/ServiceStack/Host/Handlers/Soap11Handlers.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 using System.Threading.Tasks;
 using ServiceStack.Metadata;

--- a/src/ServiceStack/Host/Handlers/Soap12Handlers.cs
+++ b/src/ServiceStack/Host/Handlers/Soap12Handlers.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System.Threading.Tasks;
 using ServiceStack.Metadata;

--- a/src/ServiceStack/Host/Handlers/SoapHandler.cs
+++ b/src/ServiceStack/Host/Handlers/SoapHandler.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.IO;

--- a/src/ServiceStack/Host/Handlers/StaticFileHandler.cs
+++ b/src/ServiceStack/Host/Handlers/StaticFileHandler.cs
@@ -266,7 +266,7 @@ namespace ServiceStack.Host.Handlers
                         }
                     }
                 }
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 catch (System.Net.HttpListenerException ex)
                 {
                     if (ex.ErrorCode == 1229)

--- a/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
+++ b/src/ServiceStack/Host/HttpListener/HttpListenerBase.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/Host/HttpListener/ListenerRequest.Mono.cs
+++ b/src/ServiceStack/Host/HttpListener/ListenerRequest.Mono.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 // Most of this class is sourced from the MONO project in the existing file:
 //
 // https://github.com/mono/mono/blob/master/mcs/class/System.Web/System.Web/HttpRequest.cs

--- a/src/ServiceStack/Host/HttpListener/ListenerRequest.cs
+++ b/src/ServiceStack/Host/HttpListener/ListenerRequest.cs
@@ -1,7 +1,7 @@
 
 
 using System.Threading.Tasks;
-#if !NETSTANDARD2_0 
+#if NETFRAMEWORK 
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/Host/HttpListener/ListenerResponse.cs
+++ b/src/ServiceStack/Host/HttpListener/ListenerResponse.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 //Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt

--- a/src/ServiceStack/Host/HttpWebRequestConfig.cs
+++ b/src/ServiceStack/Host/HttpWebRequestConfig.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 
 using System.Net;
 using System.Web;

--- a/src/ServiceStack/Host/InMemoryRollingRequestLogger.cs
+++ b/src/ServiceStack/Host/InMemoryRollingRequestLogger.cs
@@ -143,7 +143,7 @@ namespace ServiceStack.Host
 
                     if (EnableRequestBodyTracking && request.CanReadRequestBody())
                     {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                         // https://forums.servicestack.net/t/unexpected-end-of-stream-when-uploading-to-aspnet-core/6478/6
                         if (!request.ContentType.MatchesContentType(MimeTypes.MultiPartFormData))
                         {

--- a/src/ServiceStack/Host/NetCore/NetCoreRequest.cs
+++ b/src/ServiceStack/Host/NetCore/NetCoreRequest.cs
@@ -1,7 +1,7 @@
 ﻿
 
 using System.Threading.Tasks;
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,7 +13,9 @@ using ServiceStack.Logging;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+#if NETSTANDARD2_0
 using Microsoft.AspNetCore.Http.Internal;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStack.Configuration;
 using ServiceStack.IO;

--- a/src/ServiceStack/Host/NetCore/NetCoreResponse.cs
+++ b/src/ServiceStack/Host/NetCore/NetCoreResponse.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/Host/RequestPreferences.cs
+++ b/src/ServiceStack/Host/RequestPreferences.cs
@@ -6,7 +6,7 @@ namespace ServiceStack.Host
     {
         private string acceptEncoding;
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         private readonly System.Web.HttpContextBase httpContext;
 
         public RequestPreferences(System.Web.HttpContextBase httpContext)

--- a/src/ServiceStack/Host/ServiceController.cs
+++ b/src/ServiceStack/Host/ServiceController.cs
@@ -155,7 +155,7 @@ namespace ServiceStack.Host
                           returnMarker.GetGenericArguments()[0]
                         : mi.ReturnType != typeof(object) && mi.ReturnType != typeof(void) ?
                           mi.ReturnType
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                         : Type.GetType(requestType.FullName + ResponseDtoSuffix + "," + requestType.Assembly.GetName().Name);
 #else                                                  
                         : AssemblyUtils.FindType(requestType.FullName + ResponseDtoSuffix);
@@ -483,7 +483,7 @@ namespace ServiceStack.Host
                         appHost.Release(service);
                         return taskResponse.GetResult();
                     }
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                     await using (service as IAsyncDisposable) {}
 #endif
                     appHost.Release(service);
@@ -572,7 +572,7 @@ namespace ServiceStack.Host
         public object ExecuteMessage(IMessage dto, IRequest req)
         {
             RequestContext.Instance.StartRequestContext();
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             using var scope = req.StartScope();
 #endif
             
@@ -603,7 +603,7 @@ namespace ServiceStack.Host
         public async Task<object> ExecuteMessageAsync(IMessage dto, IRequest req, CancellationToken token=default)
         {
             RequestContext.Instance.StartRequestContext();
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             using var scope = req.StartScope();
 #endif
             

--- a/src/ServiceStack/Host/ServiceMetadata.cs
+++ b/src/ServiceStack/Host/ServiceMetadata.cs
@@ -648,7 +648,7 @@ namespace ServiceStack.Host
             return type;
         }
         
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         public List<Type> GetAllSoapOperationTypes()
         {
             var operationTypes = GetAllOperationTypes();

--- a/src/ServiceStack/Host/ServiceRunner.cs
+++ b/src/ServiceStack/Host/ServiceRunner.cs
@@ -154,7 +154,7 @@ namespace ServiceStack.Host
                     await taskResponse.ConfigAwait();
                     response = taskResponse.GetResult();
                 }
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                 else if (response is ValueTask<object> valueTaskResponse)
                 {
                     response = await valueTaskResponse;

--- a/src/ServiceStack/HostConfig.cs
+++ b/src/ServiceStack/HostConfig.cs
@@ -148,7 +148,7 @@ namespace ServiceStack
                     "jspm_packages/",
                     "bower_components/",
                     "wwwroot_build/",
-#if !NETSTANDARD2_0 
+#if NETFRAMEWORK 
                     "wwwroot/", //Need to allow VirtualFiles access from ContentRoot Folder
 #endif
                 },
@@ -171,7 +171,7 @@ namespace ServiceStack
                 EnableOptimizations = true,
                 TreatNonNullableRefTypesAsRequired = true,
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 UseCamelCase = false,
                 ReturnsInnerException = true,
 #else

--- a/src/ServiceStack/HostContext.cs
+++ b/src/ServiceStack/HostContext.cs
@@ -36,7 +36,7 @@ namespace ServiceStack
                     
             return ServiceStackHost.Instance;
         }
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         public static bool IsAspNetHost => ServiceStackHost.Instance is AppHostBase;
         public static bool IsHttpListenerHost => ServiceStackHost.Instance is Host.HttpListener.HttpListenerBase;
         public static bool IsNetCore => false;
@@ -260,7 +260,7 @@ namespace ServiceStack
             await AssertAppHost().HandleResponseException(httpReq, httpRes, operationName, ex).ConfigAwait();
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         /// <summary>
         /// Resolves and auto-wires a ServiceStack Service from a ASP.NET HttpContext.
         /// </summary>

--- a/src/ServiceStack/HttpExtensions.cs
+++ b/src/ServiceStack/HttpExtensions.cs
@@ -60,7 +60,7 @@ namespace ServiceStack
             return httpRes.EndHttpHandlerRequestAsync(skipHeaders: skipHeaders, afterHeaders:afterHeaders);
         }
         
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         /// <summary>
         /// End a ServiceStack Request
         /// </summary>

--- a/src/ServiceStack/HttpHandlerFactory.cs
+++ b/src/ServiceStack/HttpHandlerFactory.cs
@@ -30,7 +30,7 @@ namespace ServiceStack
             try
             {
                 var isIntegratedPipeline = false;
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 //MONO doesn't implement this property
                 var pi = typeof(HttpRuntime).GetProperty("UsingIntegratedPipeline");
                 if (pi != null)
@@ -118,7 +118,7 @@ namespace ServiceStack
             }
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         // Entry point for ASP.NET
         public IHttpHandler GetHandler(HttpContext ctx, string requestType, string url, string pathTranslated)
         {

--- a/src/ServiceStack/HttpRequestExtensions.cs
+++ b/src/ServiceStack/HttpRequestExtensions.cs
@@ -18,7 +18,7 @@ using ServiceStack.Text;
 using ServiceStack.Validation;
 using ServiceStack.Web;
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using ServiceStack.Host.AspNet;
 using ServiceStack.Host.HttpListener;
 #endif
@@ -119,7 +119,7 @@ namespace ServiceStack
 
         public static string GetUrlHostName(this IRequest httpReq)
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             if (httpReq is ServiceStack.Host.AspNet.AspNetRequest aspNetReq)
             {
                 return aspNetReq.UrlHostName;
@@ -382,7 +382,7 @@ namespace ServiceStack
             return pathInfo;
         }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public static string GetLastPathInfo(this Microsoft.AspNetCore.Http.HttpRequest request)
         {
             var rawUrl = Microsoft.AspNetCore.Http.Extensions.UriHelper.GetDisplayUrl(request);
@@ -403,7 +403,7 @@ namespace ServiceStack
             return new Uri(request.AbsoluteUri).GetLeftAuthority() + endpointsPath;
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         //http://stackoverflow.com/a/757251/85785
         static readonly string[] VirtualPathPrefixes = System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath == null || System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath == "/"
             ? TypeConstants.EmptyStringArray
@@ -747,7 +747,7 @@ namespace ServiceStack
         public static string GetRawUrl(this IRequest httpReq)
         {
             var appPath = HostContext.Config.HandlerFactoryPath;
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             if (httpReq.OriginalRequest is HttpRequestBase aspReq && aspReq.ApplicationPath?.Length > 1)
                 appPath = aspReq.ApplicationPath.CombineWith(appPath);
 #endif
@@ -936,7 +936,7 @@ namespace ServiceStack
             return false;
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         public static HttpContextBase ToHttpContextBase(this HttpRequestBase aspnetHttpReq)
         {
             return aspnetHttpReq.RequestContext.HttpContext;
@@ -1108,7 +1108,7 @@ namespace ServiceStack
 
         public static IEnumerable<Claim> GetClaims(this IRequest req)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             if (req.OriginalRequest is Microsoft.AspNetCore.Http.HttpRequest httpReq)
                 return httpReq.HttpContext.User?.Claims;
 #else

--- a/src/ServiceStack/HttpResponseExtensionsInternal.cs
+++ b/src/ServiceStack/HttpResponseExtensionsInternal.cs
@@ -552,7 +552,7 @@ namespace ServiceStack
             return false;
         }
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         public static void ApplyGlobalResponseHeaders(this HttpListenerResponse httpRes)
         {
             if (HostContext.Config == null) return;

--- a/src/ServiceStack/HttpResult.cs
+++ b/src/ServiceStack/HttpResult.cs
@@ -475,7 +475,7 @@ namespace ServiceStack
 
     public static class HttpResultExtensions
     {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         public static System.Net.Cookie ToCookie(this HttpCookie httpCookie)
         {
             var to = new System.Net.Cookie(httpCookie.Name, httpCookie.Value, httpCookie.Path)

--- a/src/ServiceStack/IRequiresSoapMessage.cs
+++ b/src/ServiceStack/IRequiresSoapMessage.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System.ServiceModel.Channels;
 
 namespace ServiceStack

--- a/src/ServiceStack/InProcessServiceGateway.cs
+++ b/src/ServiceStack/InProcessServiceGateway.cs
@@ -70,7 +70,7 @@ namespace ServiceStack
             var response = HostContext.ServiceController.Execute(request, req);
             if (response is Task responseTask)
                 response = responseTask.GetResult();
-#if NET472 || NETSTANDARD2_0                
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             else if (response is ValueTask<object> valueTaskResponse)
             {
                 response = valueTaskResponse.GetAwaiter().GetResult();

--- a/src/ServiceStack/InfoScripts.cs
+++ b/src/ServiceStack/InfoScripts.cs
@@ -53,7 +53,7 @@ namespace ServiceStack
         public string[] envLogicalDrives() => Environment.GetLogicalDrives();
         public char envPathSeparator() => Path.PathSeparator;
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public string envFrameworkDescription() => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
         public string envOSDescription() => System.Runtime.InteropServices.RuntimeInformation.OSDescription;
         public System.Runtime.InteropServices.Architecture envOSArchitecture() => System.Runtime.InteropServices.RuntimeInformation.OSArchitecture;

--- a/src/ServiceStack/LispReplTcpServer.cs
+++ b/src/ServiceStack/LispReplTcpServer.cs
@@ -198,7 +198,7 @@ namespace ServiceStack
                 //give it a small chance to die gracefully
                 if (!bgThread.Join(500))
                 {
-#if !NETSTANDARD2_0                    
+#if NETFRAMEWORK                    
                     //Ideally we shouldn't get here, but lets try our hardest to clean it up
                     Log.Warn("Interrupting previous Background Thread: " + bgThread.Name);
                     bgThread.Interrupt();

--- a/src/ServiceStack/Metadata/BaseSoapMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/BaseSoapMetadataHandler.cs
@@ -27,7 +27,7 @@ namespace ServiceStack.Metadata
 
             if (httpReq.QueryString["xsd"] != null)
             {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 var operationTypes = HostContext.Metadata.GetAllSoapOperationTypes();
                 var xsdNo = Convert.ToInt32(httpReq.QueryString["xsd"]);
                 var schemaSet = XsdUtils.GetXmlSchemaSet(operationTypes);

--- a/src/ServiceStack/Metadata/BaseWsdlPage.cs
+++ b/src/ServiceStack/Metadata/BaseWsdlPage.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using System.Web.UI.WebControls;
 
 namespace ServiceStack.Metadata

--- a/src/ServiceStack/Metadata/IndexOperationsControl.cs
+++ b/src/ServiceStack/Metadata/IndexOperationsControl.cs
@@ -131,7 +131,7 @@ namespace ServiceStack.Metadata
                 ForEachItem = RenderRow
             }.ToString();
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             var xsdsPart = new ListTemplate
             {
                 Title = "XSDS:",

--- a/src/ServiceStack/Metadata/Soap11MetadataHandler.cs
+++ b/src/ServiceStack/Metadata/Soap11MetadataHandler.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.IO;

--- a/src/ServiceStack/Metadata/Soap11WsdlMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/Soap11WsdlMetadataHandler.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 namespace ServiceStack.Metadata
 {

--- a/src/ServiceStack/Metadata/Soap12MetadataHandler.cs
+++ b/src/ServiceStack/Metadata/Soap12MetadataHandler.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.IO;

--- a/src/ServiceStack/Metadata/Soap12WsdlMetadataHandler.cs
+++ b/src/ServiceStack/Metadata/Soap12WsdlMetadataHandler.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 namespace ServiceStack.Metadata
 {

--- a/src/ServiceStack/Metadata/WsdlMetadataHandlerBase.cs
+++ b/src/ServiceStack/Metadata/WsdlMetadataHandlerBase.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.Threading.Tasks;

--- a/src/ServiceStack/Metadata/XsdGenerator.cs
+++ b/src/ServiceStack/Metadata/XsdGenerator.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/MetadataFeature.cs
+++ b/src/ServiceStack/MetadataFeature.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0        
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
 using ServiceStack.Host;
 #else
 using System.Web;
@@ -108,7 +108,7 @@ namespace ServiceStack
             }
 
             var pathAction = pathParts[1].ToLowerInvariant();
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             if (pathAction == "wsdl")
             {
                 if (pathController == "soap11")
@@ -130,7 +130,7 @@ namespace ServiceStack
 
                 case "jsv":
                     return new JsvMetadataHandler();
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                 case "soap11":
                     return new Soap11MetadataHandler();
 

--- a/src/ServiceStack/ModularStartup.cs
+++ b/src/ServiceStack/ModularStartup.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ServiceStack
 {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
     using System;
     using System.Reflection;
@@ -276,7 +276,7 @@ namespace ServiceStack
         public static List<object> PriorityZeroOrAbove(this List<Tuple<object, int>> instances) =>
             instances.Where(x => x.Item2 >= 0).OrderBy(x => x.Item2).Map(x => x.Item1);
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         
         /// <summary>
         /// .NET Core 3.0 disables IStartup and multiple Configure* entry points on Startup class requiring the use of a
@@ -311,7 +311,7 @@ namespace ServiceStack
 #endif
     }
     
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
     /// <summary>
     /// .NET Core 3.0 disables IStartup and multiple Configure* entry points on Startup class requiring the use of a
     /// clean ModularStartupActivator adapter class for implementing https://docs.servicestack.net/modular-startup

--- a/src/ServiceStack/NetCore/NetCoreContainerAdapter.cs
+++ b/src/ServiceStack/NetCore/NetCoreContainerAdapter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using Microsoft.AspNetCore.Http;

--- a/src/ServiceStack/NetCore/NetCoreHeadersCollection.cs
+++ b/src/ServiceStack/NetCore/NetCoreHeadersCollection.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections;

--- a/src/ServiceStack/NetCore/NetCoreLogFactory.cs
+++ b/src/ServiceStack/NetCore/NetCoreLogFactory.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using ServiceStack.Logging;

--- a/src/ServiceStack/NetCore/NetCoreQueryStringCollection.cs
+++ b/src/ServiceStack/NetCore/NetCoreQueryStringCollection.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections;

--- a/src/ServiceStack/NetCoreAppSettings.cs
+++ b/src/ServiceStack/NetCoreAppSettings.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections;

--- a/src/ServiceStack/Platform.cs
+++ b/src/ServiceStack/Platform.cs
@@ -10,7 +10,7 @@ namespace ServiceStack
     public class Platform
     {
         public static Platform Instance =
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             new PlatformNetCore();
 #else
             new PlatformNet();

--- a/src/ServiceStack/Platforms/PlatformNet.Config.cs
+++ b/src/ServiceStack/Platforms/PlatformNet.Config.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System.Configuration;
 
 namespace ServiceStack.Platforms

--- a/src/ServiceStack/Platforms/PlatformNet.HostConfig.cs
+++ b/src/ServiceStack/Platforms/PlatformNet.HostConfig.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/src/ServiceStack/Platforms/PlatformNet.Wcf.cs
+++ b/src/ServiceStack/Platforms/PlatformNet.Wcf.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/ServiceStack/Platforms/PlatformNet.Web.cs
+++ b/src/ServiceStack/Platforms/PlatformNet.Web.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/ServiceStack/Platforms/PlatformNet.cs
+++ b/src/ServiceStack/Platforms/PlatformNet.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 

--- a/src/ServiceStack/Platforms/PlatformNetCore.Config.cs
+++ b/src/ServiceStack/Platforms/PlatformNetCore.Config.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceStack/Platforms/PlatformNetCore.Web.cs
+++ b/src/ServiceStack/Platforms/PlatformNetCore.Web.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Collections;
@@ -195,7 +195,7 @@ namespace ServiceStack.Host
                 property = ((DefaultMemberAttribute)atts[0]).MemberName;
 
             Type[] argTypes = new Type[] { (is_string) ? typeof(string) : typeof(int) };
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             PropertyInfo prop = t.GetProperty(property, argTypes);
 #else
             PropertyInfo prop = t.GetTypeInfo().GetProperty(property, argTypes);
@@ -225,7 +225,7 @@ namespace ServiceStack.Host
             if (string.IsNullOrEmpty(propName))
                 throw new ArgumentNullException(nameof(propName));
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             PropertyDescriptor prop = TypeDescriptor.GetProperties(container).Find(propName, true);
 #else
             PropertyInfo prop = container.GetType().GetProperty(propName);            

--- a/src/ServiceStack/Platforms/PlatformNetCore.cs
+++ b/src/ServiceStack/Platforms/PlatformNetCore.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
 
 using System;
 using System.Reflection;

--- a/src/ServiceStack/Profiler.cs
+++ b/src/ServiceStack/Profiler.cs
@@ -63,7 +63,7 @@ namespace ServiceStack.MiniProfiler
     }
 
     public class HtmlString : IHtmlString,
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         ServiceStack.Host.IHtmlString
 #else
         System.Web.IHtmlString
@@ -94,7 +94,7 @@ namespace ServiceStack.Html
 {
     public static class HtmlStringExtensions
     {
-#if NETSTANDARD2_0        
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
         public static ServiceStack.Host.IHtmlString AsRaw(this IHtmlString htmlString) => 
             htmlString is ServiceStack.Host.IHtmlString aspRawStr ? aspRawStr :
                 new HtmlString(htmlString?.ToHtmlString() ?? "");

--- a/src/ServiceStack/RequestContext.cs
+++ b/src/ServiceStack/RequestContext.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using System.Runtime.Remoting.Messaging;
 #else
 using System.Threading;
@@ -19,7 +19,7 @@ namespace ServiceStack
     {
         public static readonly RequestContext Instance = new RequestContext();
 
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
         /// <summary>
         /// Tell ServiceStack to use ThreadStatic Items Collection for RequestScoped items.
         /// Warning: ThreadStatic Items aren't pinned to the same request in async services which callback on different threads.
@@ -59,7 +59,7 @@ namespace ServiceStack
 
         private IDictionary GetItems()
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             try
             {
                 if (UseThreadStatic)
@@ -86,7 +86,7 @@ namespace ServiceStack
 
         private IDictionary CreateItems(IDictionary items = null)
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             try
             {
                 if (UseThreadStatic)
@@ -119,7 +119,7 @@ namespace ServiceStack
 
         public void EndRequest()
         {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
             if (UseThreadStatic)
                 Items = null;
             else

--- a/src/ServiceStack/RequestExtensions.cs
+++ b/src/ServiceStack/RequestExtensions.cs
@@ -274,7 +274,7 @@ namespace ServiceStack
         {
             if (disposable == null)
                 return;
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             var netcoreReq = (Microsoft.AspNetCore.Http.HttpRequest) request.OriginalRequest;
             netcoreReq.HttpContext.Response.RegisterForDispose(disposable);
 #else
@@ -310,7 +310,7 @@ namespace ServiceStack
             }
 
             var userRepo = HostContext.AppHost.GetAuthRepositoryAsync(request);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (userRepo as IAsyncDisposable)
 #else
             using (userRepo as IDisposable)
@@ -333,8 +333,6 @@ namespace ServiceStack
                 }
                 return new SessionSourceResult(session, roles, permissions);
             }
-            
-            return null;
         }
     }
 

--- a/src/ServiceStack/RequestInfoFeature.cs
+++ b/src/ServiceStack/RequestInfoFeature.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0        
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
 using ServiceStack.Host;
 #else
 using System.Web;

--- a/src/ServiceStack/RequestLogsFeature.cs
+++ b/src/ServiceStack/RequestLogsFeature.cs
@@ -145,7 +145,7 @@ namespace ServiceStack
             {
                 appHost.PreRequestFilters.Insert(0, (httpReq, httpRes) =>
                 {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
                     // https://forums.servicestack.net/t/unexpected-end-of-stream-when-uploading-to-aspnet-core/6478/6
                     if (httpReq.ContentType.MatchesContentType(MimeTypes.MultiPartFormData))
                         return;                    

--- a/src/ServiceStack/RequiredPermissionAttribute.cs
+++ b/src/ServiceStack/RequiredPermissionAttribute.cs
@@ -87,7 +87,7 @@ namespace ServiceStack
                 return true;
             
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(req);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/RequiredRoleAttribute.cs
+++ b/src/ServiceStack/RequiredRoleAttribute.cs
@@ -86,7 +86,7 @@ namespace ServiceStack
                 return true;
             
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(req);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/RequiresAnyPermission.cs
+++ b/src/ServiceStack/RequiresAnyPermission.cs
@@ -41,7 +41,7 @@ namespace ServiceStack
             var session = await req.GetSessionAsync().ConfigAwait();
 
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(req);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)
@@ -97,7 +97,7 @@ namespace ServiceStack
             if (authRepo == null)
                 return false;
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/RequiresAnyRoleAttribute.cs
+++ b/src/ServiceStack/RequiresAnyRoleAttribute.cs
@@ -42,7 +42,7 @@ namespace ServiceStack
             var session = await req.GetSessionAsync().ConfigAwait();
 
             var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(req);
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             await using (authRepo as IAsyncDisposable)
 #else
             using (authRepo as IDisposable)

--- a/src/ServiceStack/ServerEventsFeature.cs
+++ b/src/ServiceStack/ServerEventsFeature.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0        
+﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
 using ServiceStack.Host;
 #else
 using System.Web;
@@ -311,7 +311,7 @@ namespace ServiceStack
 
                 feature.OnConnect?.Invoke(subscription, subscription.ConnectArgs);                
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 res.StatusCode = 500;
                 throw;

--- a/src/ServiceStack/Service.cs
+++ b/src/ServiceStack/Service.cs
@@ -16,7 +16,7 @@ namespace ServiceStack
     /// Generic + Useful IService base class
     /// </summary>
     public class Service : IService, IServiceBase, IDisposable, IServiceFilters
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         , IAsyncDisposable
 #endif
     {
@@ -69,7 +69,7 @@ namespace ServiceStack
         private IRedisClient redis;
         public virtual IRedisClient Redis => redis ??= HostContext.AppHost.GetRedisClient(Request);
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public virtual ValueTask<IRedisClientAsync> GetRedisAsync() => HostContext.AppHost.GetRedisClientAsync(Request);
 #endif
 
@@ -188,7 +188,7 @@ namespace ServiceStack
         {
             if (hasDisposed) return;
             hasDisposed = true;
-#if !(NET472 || NETSTANDARD2_0)
+#if !(NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0)
             using (authRepositoryAsync as IDisposable) {}
 #endif
             using (authRepository as IDisposable) { }
@@ -204,7 +204,7 @@ namespace ServiceStack
         public virtual object OnAfterExecute(object response) => response;
         public virtual Task<object> OnExceptionAsync(object requestDto, Exception ex) => TypeConstants.EmptyTask;
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public async ValueTask DisposeAsync()
         {
             if (hasDisposed) return;

--- a/src/ServiceStack/ServiceStack.Core.csproj
+++ b/src/ServiceStack/ServiceStack.Core.csproj
@@ -3,7 +3,7 @@
     <PackageId>ServiceStack.Core</PackageId>
     <AssemblyName>ServiceStack</AssemblyName>
     <RootNamespace>ServiceStack</RootNamespace>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>ServiceStack .NET Standard 2.0</Title>
     <PackageDescription>
       ServiceStack is a simple and fast alternative to WCF, MVC and Web API in one cohesive framework for all your services
@@ -37,6 +37,38 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[3.1.0, 4)" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[5, 6)" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />

--- a/src/ServiceStack/ServiceStack.Source.csproj
+++ b/src/ServiceStack/ServiceStack.Source.csproj
@@ -3,7 +3,7 @@
     <PackageId>ServiceStack</PackageId>
     <AssemblyName>ServiceStack</AssemblyName>
     <RootNamespace>ServiceStack</RootNamespace>
-    <TargetFrameworks>net45;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net472;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>ServiceStack webservice framework: Faster, Cleaner, Modern WCF alternative</Title>
     <PackageDescription>
       ServiceStack is a simple and fast alternative to WCF, MVC and Web API in one cohesive framework for all your services
@@ -49,6 +49,39 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[3.1.0, 4)" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[5, 6)" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />

--- a/src/ServiceStack/ServiceStack.csproj
+++ b/src/ServiceStack/ServiceStack.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>ServiceStack</PackageId>
     <AssemblyName>ServiceStack</AssemblyName>
-    <TargetFrameworks>net45;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net472;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>ServiceStack webservice framework: Faster, Cleaner, Modern WCF alternative</Title>
     <PackageDescription>
     ServiceStack is a simple and fast alternative to WCF, MVC and Web API in one cohesive framework for all your services and web apps that's intuitive and Easy to use!
@@ -45,6 +45,39 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.0, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[3.1.0, 4)" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[5, 6)" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />

--- a/src/ServiceStack/ServiceStackHost.Runtime.cs
+++ b/src/ServiceStack/ServiceStackHost.Runtime.cs
@@ -702,7 +702,7 @@ namespace ServiceStack
             return session;
         }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         /// <summary>
         /// Modify Cookie options
         /// </summary>
@@ -817,7 +817,7 @@ namespace ServiceStack
             return Container.TryResolve<IRedisClientsManager>().GetClient();
         }
 
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         /// <summary>
         /// Resolves <see cref="IRedisClient"></see> based on <see cref="IRedisClientsManager"></see>.GetClient();
         /// Called by itself, <see cref="Service"></see> and <see cref="ServiceStack.Razor.ViewPageBase"></see>

--- a/src/ServiceStack/ServiceStackProvider.cs
+++ b/src/ServiceStack/ServiceStackProvider.cs
@@ -31,7 +31,7 @@ namespace ServiceStack
         ICacheClientAsync CacheAsync { get; }
         IDbConnection Db { get; }
         IRedisClient Redis { get; }
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         ValueTask<IRedisClientAsync> GetRedisAsync();
 #endif
         IMessageProducer MessageProducer { get; }
@@ -215,7 +215,7 @@ namespace ServiceStack
         private IRedisClient redis;
         public virtual IRedisClient Redis => redis ??= HostContext.AppHost.GetRedisClient(Request);
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public virtual ValueTask<IRedisClientAsync> GetRedisAsync() => HostContext.AppHost.GetRedisClientAsync(Request);
 #endif
 
@@ -298,12 +298,12 @@ namespace ServiceStack
             redis?.Dispose();
             messageProducer?.Dispose();
             using (authRepository as IDisposable) {}
-#if !(NET472 || NETSTANDARD2_0)
+#if !(NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0)
             using (authRepositoryAsync as IDisposable) {}
 #endif
         }
         
-#if NET472 || NETSTANDARD2_0
+#if NET472 || NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public async ValueTask DisposeAsync()
         {
             await using (authRepositoryAsync as IAsyncDisposable) {}

--- a/src/ServiceStack/SharpPagesFeature.cs
+++ b/src/ServiceStack/SharpPagesFeature.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System.Web;
 #endif
 using System;
@@ -34,10 +34,6 @@ namespace ServiceStack
         [Obsolete("Use ScriptBlocks")]
         public List<ScriptBlock> TemplateBlocks => ScriptBlocks;
 
-        [Obsolete("Use DefaultMethods")]
-        public DefaultScripts DefaultFilters => DefaultMethods;
-        [Obsolete("Use ProtectedMethods")]
-        public ProtectedScripts ProtectedFilters => ProtectedMethods;
         [Obsolete("Use HtmlMethods")]
         public HtmlScripts HtmlFilters => HtmlMethods;
 

--- a/src/ServiceStack/Support/WebHost/GzipOptimizationTest.cs
+++ b/src/ServiceStack/Support/WebHost/GzipOptimizationTest.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 using System;
 using System.Web;
 

--- a/src/ServiceStack/SuppressFormsAuthenticationRedirectModule.cs
+++ b/src/ServiceStack/SuppressFormsAuthenticationRedirectModule.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETFRAMEWORK
 using System;
 using System.Web;
 

--- a/src/ServiceStack/SvgFeature.cs
+++ b/src/ServiceStack/SvgFeature.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0        
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0        
 using ServiceStack.Host;
 #else
 using System.Web;

--- a/src/ServiceStack/Testing/BasicAppHost.cs
+++ b/src/ServiceStack/Testing/BasicAppHost.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.Testing
             : base(typeof (BasicAppHost).GetOperationName(),
                    serviceAssemblies.Length > 0 ? serviceAssemblies : new[]
                    {
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
                        Assembly.GetExecutingAssembly()
 #else
                        typeof(BasicAppHost).Assembly

--- a/src/ServiceStack/Testing/MockHttpRequest.cs
+++ b/src/ServiceStack/Testing/MockHttpRequest.cs
@@ -12,7 +12,7 @@ using ServiceStack.Web;
 namespace ServiceStack.Testing
 {
     public class MockHttpRequest : IHttpRequest, IHasResolver, IHasVirtualFiles
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         , IHasServiceScope
 #endif    
     {
@@ -23,7 +23,7 @@ namespace ServiceStack.Testing
             set => resolver = value;
         }
         
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
         public Microsoft.Extensions.DependencyInjection.IServiceScope ServiceScope { get; set; }
 #endif
 
@@ -58,7 +58,7 @@ namespace ServiceStack.Testing
 
         public T TryResolve<T>()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0
             if (ServiceScope != null)
             {
                 var instance = ServiceScope.ServiceProvider.GetService(typeof(T));

--- a/src/ServiceStack/XsdUtils.cs
+++ b/src/ServiceStack/XsdUtils.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0
+#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This PR adds new targets (`netcoreapp3.1;net5.0`) for `ServiceStack.Core` so we can drop following deprecated packages:
- `Microsoft.AspNetCore.Http@2.x`
- `Microsoft.AspNetCore.Http.Abstractions@2.x`
- `Microsoft.AspNetCore.Http.Extensions@2.x`
- `Microsoft.AspNetCore.Hosting@2.x`
- `Microsoft.AspNetCore.Hosting.Abstractions@2.x`
- `Microsoft.Extensions.Logging.Abstractions@2.x`
- `Microsoft.Extensions.DependencyInjection@2.x`