### PR TITLE
Use async cache client if registered to avoid possible NRE

### DIFF
--- a/src/ServiceStack/CacheResponseAttribute.cs
+++ b/src/ServiceStack/CacheResponseAttribute.cs
@@ -199,7 +199,11 @@ namespace ServiceStack
                     res.AddHeader(HttpHeaders.CacheControl, cacheControl);
 
                 if (!doHttpCaching)
-                    lastModified = cache.Get<DateTime?>(cacheInfo.LastModifiedKey());
+                {
+                    lastModified = cacheAsync != null ?
+                        await cacheAsync.GetAsync<DateTime?>(cacheInfo.LastModifiedKey(), token).ConfigAwait() :
+                        cache.Get<DateTime?>(cacheInfo.LastModifiedKey());
+                }
 
                 if (lastModified != null)
                     res.AddHeader(HttpHeaders.LastModified, lastModified.Value.ToUniversalTime().ToString("r"));


### PR DESCRIPTION
Use async cache client if registered to avoid possible NRE when using `ICacheClientAsync`.