### PR TITLE
Fix Alias check requirement on properties for AutoGen

### DIFF
--- a/src/ServiceStack.Server/GenerateCrudServices.cs
+++ b/src/ServiceStack.Server/GenerateCrudServices.cs
@@ -1148,7 +1148,7 @@ namespace ServiceStack
                             prop.AddAttribute(new PrimaryKeyAttribute());
                         if (column.IsAutoIncrement)
                             prop.AddAttribute(new AutoIncrementAttribute());
-                        if (!string.Equals(dialect.NamingStrategy.GetColumnName(prop.Name), column.ColumnName, StringComparison.OrdinalIgnoreCase))
+                        if (!string.Equals(dialect.NamingStrategy.GetColumnName(prop.Name), column.ColumnName))
                             prop.AddAttribute(new AliasAttribute(column.ColumnName));
                         if (!dataType.IsValueType && !column.AllowDBNull && !isKey)
                             prop.AddAttribute(new RequiredAttribute());


### PR DESCRIPTION
Remove `OrdinalIgnore` case as OrmLite providers using the default OrmLite base naming strategy for column name (which is to do nothing) will incorrectly not apply the alias attribute.