### PR TITLE
Generic registration plugin with some tests.

### DIFF
--- a/src/ServiceStack/Auth/GenericRegistrationService.cs
+++ b/src/ServiceStack/Auth/GenericRegistrationService.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Linq;
+using System.Globalization;
+using System.Threading.Tasks;
+using ServiceStack.FluentValidation;
+using ServiceStack.Text;
+using ServiceStack.Validation;
+using ServiceStack.Web;
+
+namespace ServiceStack.Auth
+{
+    [ErrorView(nameof(Register.ErrorView))]
+    [DefaultRequest(typeof(Register))]
+    public abstract class GenericRegisterService<T> : Service where T : Register
+    {
+        public static ValidateFn ValidateFn { get; set; }
+        
+        public static bool AllowUpdates { get; set; }
+
+        public IValidator<T> RegistrationValidator { get; set; }
+
+        public IAuthEvents AuthEvents { get; set; }
+        
+        /// <summary>
+        /// Create new Registration
+        /// </summary>
+        public async Task<object> PostAsync(T request)
+        {
+            var returnUrl = Request.GetReturnUrl();
+
+            var authFeature = GetPlugin<AuthFeature>();
+            if (authFeature != null)
+            {
+                if (authFeature.SaveUserNamesInLowerCase)
+                {
+                    if (request.UserName != null)
+                        request.UserName = request.UserName.ToLower();
+                    if (request.Email != null)
+                        request.Email = request.Email.ToLower();
+                }
+                if (!string.IsNullOrEmpty(returnUrl))
+                    authFeature.ValidateRedirectLinks(Request, returnUrl);
+            }
+            
+            var validateResponse = ValidateFn?.Invoke(this, HttpMethods.Post, request);
+            if (validateResponse != null)
+                return validateResponse;
+
+            RegisterResponse response = null;
+            var session = await this.GetSessionAsync().ConfigAwait();
+            var newUserAuth = ToUserAuth(AuthRepositoryAsync as ICustomUserAuth, request);
+
+            var existingUser = session.IsAuthenticated 
+                ? await AuthRepositoryAsync.GetUserAuthAsync(session, null).ConfigAwait() 
+                : null;
+            var registerNewUser = existingUser == null;
+
+            if (!registerNewUser && !AllowUpdates)
+                throw new NotSupportedException(ErrorMessages.RegisterUpdatesDisabled.Localize(Request));
+
+            if (!HostContext.AppHost.GlobalRequestFiltersAsync.Contains(ValidationFilters.RequestFilterAsync) //Already gets run
+                && RegistrationValidator != null)
+            {
+                await RegistrationValidator.ValidateAndThrowAsync<T>(request, registerNewUser ? ApplyTo.Post : ApplyTo.Put).ConfigAwait();
+            }
+            
+            var user = registerNewUser
+                ? await AuthRepositoryAsync.CreateUserAuthAsync(newUserAuth, request.Password).ConfigAwait()
+                : await AuthRepositoryAsync.UpdateUserAuthAsync(existingUser, newUserAuth, request.Password).ConfigAwait();
+
+            if (registerNewUser)
+            {
+                session.PopulateSession(user);
+                session.OnRegistered(Request, session, this);
+                if (session is IAuthSessionExtended sessionExt)
+                    await sessionExt.OnRegisteredAsync(Request, session, this).ConfigAwait();
+                AuthEvents?.OnRegistered(this.Request, session, this);
+                if (AuthEvents is IAuthEventsAsync asyncEvents)
+                    await asyncEvents.OnRegisteredAsync(this.Request, session, this).ConfigAwait();
+            }
+
+            if (request.AutoLogin.GetValueOrDefault())
+            {
+#if NETSTANDARD2_0 || NET472
+                await using var authService = base.ResolveService<AuthenticateService>();
+#else
+                using var authService = base.ResolveService<AuthenticateService>();
+#endif                
+                var authResponse = await authService.PostAsync(
+                    new Authenticate {
+                        provider = CredentialsAuthProvider.Name,
+                        UserName = request.UserName ?? request.Email,
+                        Password = request.Password,
+                    });
+
+                if (authResponse is IHttpError)
+                    throw (Exception)authResponse;
+
+                if (authResponse is AuthenticateResponse typedResponse)
+                {
+                    response = new RegisterResponse
+                    {
+                        SessionId = typedResponse.SessionId,
+                        UserName = typedResponse.UserName,
+                        ReferrerUrl = typedResponse.ReferrerUrl,
+                        UserId = user.Id.ToString(CultureInfo.InvariantCulture),
+                        BearerToken = typedResponse.BearerToken,
+                        RefreshToken = typedResponse.RefreshToken,
+                    };
+                }
+            }
+
+            if (response == null)
+            {
+                response = new RegisterResponse
+                {
+                    UserId = user.Id.ToString(CultureInfo.InvariantCulture),
+                    ReferrerUrl = Request.GetReturnUrl(),
+                    UserName = session.UserName,
+                };
+            }
+
+            var isHtml = Request.ResponseContentType.MatchesContentType(MimeTypes.Html);
+            if (isHtml)
+            {
+                if (string.IsNullOrEmpty(returnUrl))
+                    return response;
+
+                return new HttpResult(response)
+                {
+                    Location = returnUrl
+                };
+            }
+
+            return response;
+        }
+
+        private static IUserAuth ToUserAuth(ICustomUserAuth customUserAuth, T request)
+        {
+            var to = customUserAuth != null
+                ? customUserAuth.CreateUserAuth()
+                : new UserAuth();
+
+            to.PopulateWithNonDefaultValues(request);
+            to.PrimaryEmail = request.Email;
+            return to;
+        }
+    }
+    
+    public class GenericRegistrationValidator<T> : AbstractValidator<T>
+    where T : Register
+    {
+        public GenericRegistrationValidator()
+        {
+            RuleSet(
+                ApplyTo.Post,
+                () =>
+                {
+                    RuleFor(x => x.Password).NotEmpty();
+                    RuleFor(x => x.ConfirmPassword)
+                        .Equal(x => x.Password)
+                        .When(x => x.ConfirmPassword != null)
+                        .WithErrorCode(nameof(ErrorMessages.PasswordsShouldMatch))
+                        .WithMessage(ErrorMessages.PasswordsShouldMatch.Localize(base.Request));
+                    RuleFor(x => x.UserName).NotEmpty().When(x => x.Email.IsNullOrEmpty());
+                    RuleFor(x => x.Email).NotEmpty().EmailAddress().When(x => x.UserName.IsNullOrEmpty());
+                    RuleFor(x => x.UserName)
+                        .MustAsync(async (x,token) =>
+                        {
+                            var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(base.Request);
+#if NET472 || NETSTANDARD2_0
+                            await using (authRepo as IAsyncDisposable)
+#else
+                            using (authRepo as IDisposable)
+#endif
+                            {
+                                return await authRepo.GetUserAuthByUserNameAsync(x).ConfigAwait() == null;
+                            }
+                        })
+                        .WithErrorCode("AlreadyExists")
+                        .WithMessage(ErrorMessages.UsernameAlreadyExists.Localize(base.Request))
+                        .When(x => !x.UserName.IsNullOrEmpty());
+                    RuleFor(x => x.Email)
+                        .MustAsync(async (x,token) =>
+                        {
+                            var authRepo = HostContext.AppHost.GetAuthRepositoryAsync(base.Request);
+#if NET472 || NETSTANDARD2_0
+                            await using (authRepo as IAsyncDisposable)
+#else
+                            using (authRepo as IDisposable)
+#endif
+                            {
+                                return x.IsNullOrEmpty() || await authRepo.GetUserAuthByUserNameAsync(x).ConfigAwait() == null;
+                            }
+                        })
+                        .WithErrorCode("AlreadyExists")
+                        .WithMessage(ErrorMessages.EmailAlreadyExists.Localize(base.Request))
+                        .When(x => !x.Email.IsNullOrEmpty());
+                });
+            RuleSet(
+                ApplyTo.Put,
+                () =>
+                {
+                    RuleFor(x => x.UserName).NotEmpty().When(x => x.Email.IsNullOrEmpty());
+                    RuleFor(x => x.Email).NotEmpty().EmailAddress().When(x => x.UserName.IsNullOrEmpty());
+                });
+        }
+    }
+}

--- a/src/ServiceStack/RegistrationFeature.cs
+++ b/src/ServiceStack/RegistrationFeature.cs
@@ -38,4 +38,39 @@ namespace ServiceStack
             }
         }
     }
+    
+    public class GenericRegistrationFeature<T,TReq> : IPlugin, Model.IHasStringId
+        where TReq : Register
+    {
+        // Use same Plugin ID as they should not be used together
+        public string Id { get; set; } = Plugins.Register;
+        public string AtRestPath { get; set; }
+        
+        public ValidateFn ValidateFn 
+        {
+            get => GenericRegisterService<TReq>.ValidateFn; 
+            set => GenericRegisterService<TReq>.ValidateFn = value;
+        }
+
+        public bool AllowUpdates
+        {
+            get => GenericRegisterService<TReq>.AllowUpdates; 
+            set => GenericRegisterService<TReq>.AllowUpdates = value;
+        }
+
+        public GenericRegistrationFeature()
+        {
+            this.AtRestPath = "/register";
+        }
+
+        public void Register(IAppHost appHost)
+        {
+            appHost.RegisterService<T>(AtRestPath);
+
+            if (!appHost.GetContainer().Exists<IValidator<TReq>>())
+            {
+                appHost.RegisterAs<GenericRegistrationValidator<TReq>, IValidator<TReq>>();
+            }
+        }
+    }
 }

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/IntegrationTests/GenericRegistrationFeatureTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/IntegrationTests/GenericRegistrationFeatureTests.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Funq;
+using NUnit.Framework;
+using ServiceStack.Auth;
+using ServiceStack.Data;
+using ServiceStack.OrmLite;
+using ServiceStack.Validation;
+
+namespace ServiceStack.WebHost.Endpoints.Tests.IntegrationTests
+{
+    public class GenericRegistrationFeatureTests
+    {
+        private ServiceStackHost appHost;
+
+        private static string custonValidationError = "Must contain @";
+        class AppHost : AppSelfHostBase
+        {
+            public AppHost()
+                : base(nameof(GenericRegistrationFeatureTests), typeof(MyRegistrationService).Assembly) { }
+            
+            public override void Configure(Container container)
+            {
+                Plugins.Add(new AuthFeature(() => new CustomRegisterUserSession(),
+                    new IAuthProvider[]
+                    {
+                        new CredentialsAuthProvider()
+                    }));
+
+                Plugins.Add(new GenericRegistrationFeature<MyRegistrationService,CustomRegister>
+                {
+                    ValidateFn = (service, method, dto) =>
+                    {
+                        var req = (CustomRegister)dto;
+                        if (req.Email != null && !req.Email.Contains("@"))
+                            throw new ValidationError(new ValidationErrorField(
+                                HttpStatusCode.BadRequest, "email", custonValidationError));
+                        return null;
+                    }
+                });
+
+                container.Register<IDbConnectionFactory>(new OrmLiteConnectionFactory(":memory:",
+                    SqliteDialect.Provider));
+                container.Register<IAuthRepository>(new OrmLiteAuthRepository<CustomRegisterUserAuth,UserAuthDetails>(
+                    container.Resolve<IDbConnectionFactory>()));
+
+                var authRepo = container.Resolve<IAuthRepository>();
+                authRepo.InitSchema();
+
+            }
+        }
+
+        [OneTimeSetUp]
+        public void OnetimeSetup()
+        {
+            appHost = new AppHost()
+                .Init()
+                .Start(Config.ListeningOn);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() => appHost.Dispose();
+
+        [Test]
+        public void Can_register_user()
+        {
+            var client = GetClient();
+            var req = GetValidRegisterRequest();
+            var response = client.Post(req);
+            
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.UserId, Is.Not.Null);
+
+            using var db = appHost.Resolve<IDbConnectionFactory>().OpenDbConnection();
+            var regUser = db.SingleById<CustomRegisterUserAuth>(int.Parse(response.UserId));
+            
+            Assert.That(regUser.NetworkName, Is.EqualTo("Test1234"));
+        }
+
+        [Test]
+        public void Can_validate_custom_register_request()
+        {
+            var client = GetClient();
+            var req1 = new CustomRegister()
+            {
+                Email = "no-password@email.com"
+            };
+            
+            var exception = Assert.Throws<WebServiceException>(() =>
+            {
+                var response = client.Post(req1);
+            });
+            
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception.StatusCode, Is.EqualTo(500));
+            Assert.That(exception.ResponseBody, Contains.Substring("'Password' must not be empty."));
+
+            // Validation error comes from custom ValidationFn
+            var req2 = new CustomRegister
+            {
+                Email = "bademail-",
+                Password = "test1234"
+            };
+            
+            exception = Assert.Throws<WebServiceException>(() =>
+            {
+                var response = client.Post(req2);
+            });
+            
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception.StatusCode, Is.EqualTo(400));
+            Assert.That(exception.ResponseBody, Contains.Substring(custonValidationError));
+            
+            // Validation error coming from default RegistrationValidator
+            var req3 = new CustomRegister
+            {
+                Email = "4@email.com",
+                Password = "test1234",
+                ConfirmPassword = "1234test"
+            };
+            
+            exception = Assert.Throws<WebServiceException>(() =>
+            {
+                var response = client.Post(req3);
+            });
+            
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception.StatusCode, Is.EqualTo(500));
+            Assert.That(exception.ResponseBody, Contains.Substring("Passwords should match"));
+        }
+
+        [Test]
+        public void Can_throw_on_duplicate_due_to_default_validator()
+        {
+            var client = GetClient();
+            var req = GetValidRegisterRequest();
+            
+            var response = client.Post(req);
+            
+            var exception = Assert.Throws<WebServiceException>(() =>
+            {
+                client.Post(req);
+            });
+            
+            Assert.That(exception, Is.Not.Null);
+        }
+
+        [Test]
+        public void Can_persist_custom_session_data()
+        {
+            var client = GetClient();
+            var req = GetValidRegisterRequest(null,"Test", true);
+            var response = client.Post(req);
+            
+            Assert.That(response.UserId, Is.Not.Null);
+
+            using var db = appHost.Resolve<IDbConnectionFactory>().OpenDbConnection();
+            var regUser = db.SingleById<CustomRegisterUserAuth>(int.Parse(response.UserId));
+            Assert.That(regUser.NetworkName, Is.EqualTo("Test"));
+
+            var sessionResponse = client.Get(new GetRegisteredUserSession());
+            
+            Assert.That(sessionResponse, Is.Not.Null);
+            Assert.That(sessionResponse.Session, Is.Not.Null);
+            Assert.That(sessionResponse.Session.NetworkName, Is.Not.Null);
+            Assert.That(sessionResponse.Session.NetworkName, Is.EqualTo("Test"));
+
+        }
+
+        private JsonServiceClient GetClient() => new (Config.ListeningOn);
+
+        private CustomRegister GetValidRegisterRequest(string email = null, string networkName = null, bool? autoLogin = null)
+        {
+            var req = new CustomRegister
+            {
+                DisplayName = "DisplayName",
+                Email = email ?? Guid.NewGuid()+ "@email.com",
+                FirstName = "FirstName",
+                LastName = "LastName",
+                Password = "Password",
+                NetworkName = networkName ?? "Test1234",
+                AutoLogin = autoLogin
+            };
+            return req;
+        }
+    }
+    
+    public class MyRegistrationService : GenericRegisterService<CustomRegister>
+    {}
+
+    public class CustomRegister : Register, IReturn<RegisterResponse>
+    {
+        public string NetworkName { get; set; }
+    }
+
+    public class CustomRegisterUserAuth : UserAuth
+    {
+        public string NetworkName { get; set; }
+    }
+
+    public class CustomRegisterUserSession : AuthUserSession
+    {
+        public string NetworkName { get; set; }
+    }
+
+    public class SessionService : Service
+    {
+        [Authenticate]
+        public object Get(GetRegisteredUserSession request)
+        {
+            var session = SessionAs<CustomRegisterUserSession>();
+            return new GetRegisteredUserSessionResponse()
+            {
+                Session = session
+            };
+        }
+    }
+
+    public class GetRegisteredUserSession : IReturn<GetRegisteredUserSessionResponse>
+    {
+        
+    }
+
+    public class GetRegisteredUserSessionResponse
+    {
+        public CustomRegisterUserSession Session { get; set; }
+    }
+}


### PR DESCRIPTION
This new plugin is to make it easier to have the functionality of `RegisterFeature` but with the ability to specify custom request DTO so data can be populated between custom `UserAuth` and custom `AuthUserSession`. Eg

```
class AppHost : AppSelfHostBase
{
    public AppHost()
        : base(nameof(GenericRegistrationFeatureTests), typeof(MyRegistrationService).Assembly) { }
    
    public override void Configure(Container container)
    {
        Plugins.Add(new AuthFeature(() => new CustomRegisterUserSession(),
            new IAuthProvider[]
            {
                new CredentialsAuthProvider()
            }));

        Plugins.Add(new GenericRegistrationFeature<MyRegistrationService,CustomRegister>());

        container.Register<IDbConnectionFactory>(new OrmLiteConnectionFactory(":memory:",
            SqliteDialect.Provider));
        container.Register<IAuthRepository>(new OrmLiteAuthRepository<CustomRegisterUserAuth,UserAuthDetails>(
            container.Resolve<IDbConnectionFactory>()));

        var authRepo = container.Resolve<IAuthRepository>();
        authRepo.InitSchema();
    }
}

public class MyRegistrationService : GenericRegisterService<CustomRegister>
{}

public class CustomRegister : Register, IReturn<RegisterResponse>
{
    public string NetworkName { get; set; }
}

public class CustomRegisterUserAuth : UserAuth
{
    public string NetworkName { get; set; }
}

public class CustomRegisterUserSession : AuthUserSession
{
    public string NetworkName { get; set; }
}
```

I'm not sure of the best way to reduce duplication between RegisterFeature and this feature so logic is shared without breaking existing `RegistrationFeature` usage. Same with the progression of this to a fully custom registration process, should PostAsync be overridable ? Is there maybe a better way to structure this so just the DTO is declared rather than the empty service, similar with AutoQuery and DTOs use of QueryDb<T>?