### PR TITLE
Fix ReDoS

### DIFF
--- a/src/ServiceStack.Api.Swagger/swagger-ui/lib/marked.js
+++ b/src/ServiceStack.Api.Swagger/swagger-ui/lib/marked.js
@@ -49,7 +49,7 @@ block._tag = '(?!(?:'
   + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|[^\\w\\s@]*@)\\b';
 
 block.html = replace(block.html)
-  ('comment', /<!--[\s\S]*?-->/)
+  ('comment', /<!--(?:(?!<!--[\s\S])*?)-->/)
   ('closed', /<(tag)[\s\S]+?<\/\1>/)
   ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
   (/tag/g, block._tag)


### PR DESCRIPTION
Fix ReDoS

Reported in https://www.huntr.dev/bounties/dc853455-ecc7-47c9-9b82-ca7ab7970dc5/  Access this using your GitHub on the top right corner of huntr page. If you are able to access then you can just click on `mark as valid` and also you can `confirm the fix`.