### PR TITLE
#767 Add support for custom select in AutoQuery filters.

### DIFF
--- a/src/ServiceStack.Server/AutoQueryFeature.cs
+++ b/src/ServiceStack.Server/AutoQueryFeature.cs
@@ -1443,7 +1443,9 @@ namespace ServiceStack
                     ? match.ImplicitQuery 
                     : implicitQuery.Combine(match.ImplicitQuery);
 
-                var quotedColumn = q.DialectProvider.GetQuotedColumnName(match.ModelDef, match.FieldDef);
+                var quotedColumn = match.FieldDef.CustomSelect != null
+                    ? match.FieldDef.CustomSelect
+                    : q.DialectProvider.GetQuotedColumnName(match.ModelDef, match.FieldDef);
 
                 var value = entry.Value(dto);
                 if (value == null)
@@ -1464,8 +1466,10 @@ namespace ServiceStack
                     continue;
 
                 var implicitQuery = match.ImplicitQuery;
-                var quotedColumn = q.DialectProvider.GetQuotedColumnName(match.ModelDef, match.FieldDef);
-
+                var quotedColumn = match.FieldDef.CustomSelect != null
+                    ? match.FieldDef.CustomSelect
+                    : q.DialectProvider.GetQuotedColumnName(match.ModelDef, match.FieldDef);
+                
                 var strValue = !string.IsNullOrEmpty(entry.Value)
                     ? entry.Value
                     : null;

--- a/tests/ServiceStack.WebHost.Endpoints.Tests/AutoQueryTests.cs
+++ b/tests/ServiceStack.WebHost.Endpoints.Tests/AutoQueryTests.cs
@@ -1139,6 +1139,16 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             Assert.That(customRes.Results.Count, Is.EqualTo(TotalAlbums));
             ages = customRes.Results.Select(x => x.Age);
             Assert.That(ages.Contains(27 * 2));
+
+            response = client.Get(new QueryJoinedRockstarAlbumsCustomSelect { Age = 54, Include = "Total" });
+            Assert.That(response.Total, Is.EqualTo(6));
+            Assert.That(response.Results.Count, Is.EqualTo(6));
+            ages = response.Results.Select(x => x.Age);
+            Assert.That(ages.All(x => x == 54));
+            var lastNames = response.Results.Select(x => x.LastName);
+            Assert.That(lastNames, Is.EquivalentTo(new[] {
+                "Hendrix", "Cobain", "Cobain", "Cobain", "Cobain", "Cobain",
+            }));
         }
         
         [Test]


### PR DESCRIPTION
Note that I wasn't able to run all tests (no SQL Server on hand and only .NET core), but those that do run succeed.