### PR TITLE
AspNetWindowsAuthProvider to avoid Admin default role

### DIFF
--- a/src/ServiceStack/Auth/AspNetWindowsAuthProvider.cs
+++ b/src/ServiceStack/Auth/AspNetWindowsAuthProvider.cs
@@ -38,7 +38,7 @@ namespace ServiceStack.Auth
             //Add all pre-defined Roles used to in App to 'AllRoles'
             appHost.AfterInitCallbacks.Add(host =>
             {
-                var allExistingRoles = host.Metadata.GetAllRoles();
+                var allExistingRoles = host.Metadata.GetAllRoles(false);
                 allExistingRoles.Each(x => AllRoles.AddIfNotExists(x));
             });
         }

--- a/src/ServiceStack/Host/ServiceMetadata.cs
+++ b/src/ServiceStack/Host/ServiceMetadata.cs
@@ -701,11 +701,11 @@ namespace ServiceStack.Host
         }
 #endif
 
-        public List<string> GetAllRoles()
+        public List<string> GetAllRoles(bool includeAdmin = true)
         {
-            var to = new List<string> {
-                RoleNames.Admin
-            };
+            var to = new List<string>();
+            if (includeAdmin)
+                to.Add(RoleNames.Admin);
 
             foreach (var op in OperationsMap.Values)
             {


### PR DESCRIPTION
Revert default behaviour of AspNetWindowsAuthProvider trying to use `Roles.Admin` by default with NTLM which can cause conflicts if roles are being avoided in their environment.

See -> https://forums.servicestack.net/t/the-trust-relationship-between-the-primary-domain-and-the-trusted-domain-failed-after-upgrade-to-v5-11/10044