### PR TITLE
Update HttpRequestExtensions.cs

### DIFF
--- a/src/ServiceStack/HttpRequestExtensions.cs
+++ b/src/ServiceStack/HttpRequestExtensions.cs
@@ -125,6 +125,9 @@ namespace ServiceStack
                 return aspNetReq.UrlHostName;
             }
 #endif
+            if (httpReq.AbsoluteUri == null)
+                return null;
+            
             var uri = httpReq.AbsoluteUri;
 
             var pos = uri.IndexOf("://", StringComparison.Ordinal) + "://".Length;


### PR DESCRIPTION
Hi - we use BasicMessage for a variety of things, and this throws NRE if the AbsoluteUri is null - just an idea, please reject if this will break other bits.