### PR TITLE
Skip PNG resize if Microsoft auth provider fails to use System.Drawing

### DIFF
--- a/src/ServiceStack/Auth/IAuthHttpGateway.cs
+++ b/src/ServiceStack/Auth/IAuthHttpGateway.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using ServiceStack.Internal;
 using ServiceStack.Logging;
 using ServiceStack.Text;
 


### PR DESCRIPTION
Fallback CreateMicrosoftPhotoUrlAsync to skip resizing png if fails due to OS dependencies to read image from stream using System.Drawing.