### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-azure.yml
+++ b/.github/workflows/build-azure.yml
@@ -6,6 +6,9 @@ on:
       - 'ServiceStack.Azure/**'
       - '.github/workflows/build-azure.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-azure:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-blazor.yml
+++ b/.github/workflows/build-blazor.yml
@@ -6,6 +6,9 @@ on:
       - 'ServiceStack.Blazor/**'
       - '.github/workflows/build-blazor.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-blazor:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -6,6 +6,9 @@ on:
       - 'ServiceStack.Core/**'
       - '.github/workflows/build-core.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-servicestack-core:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-logging.yml
+++ b/.github/workflows/build-logging.yml
@@ -6,6 +6,9 @@ on:
       - 'ServiceStack.Logging/**'
       - '.github/workflows/build-logging.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-logging:
     runs-on: ubuntu-20.04

--- a/.github/workflows/myget-pack.yml
+++ b/.github/workflows/myget-pack.yml
@@ -2,6 +2,9 @@
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   myget-push:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
