### PR TITLE
Support the subfolder creation of S3

### DIFF
--- a/ServiceStack.Aws/src/ServiceStack.Aws/FileStorage/S3FileStorageProvider.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/FileStorage/S3FileStorageProvider.cs
@@ -519,13 +519,27 @@ namespace ServiceStack.Aws.FileStorage
 
             var bki = new S3BucketKeyInfo(path);
 
-            var request = new PutBucketRequest
+            if (bki.Key.IsNullOrEmpty())
             {
-                BucketName = bki.BucketName,
-                UseClientRegion = true
-            };
+                var request = new PutBucketRequest
+                {
+                    BucketName = bki.BucketName,
+                    UseClientRegion = true
+                };
 
-            S3Client.PutBucket(request);
+                S3Client.PutBucket(request);
+            }
+            else
+            {
+                var request = new PutObjectRequest
+                {
+                    BucketName = bki.BucketName,
+                    Key = bki.Key + "/",
+                    StorageClass = S3StorageClass.Standard
+                };
+
+                S3Client.PutObject(request);
+            } 
         }
     }
 }


### PR DESCRIPTION
We found that when using the AWS S3 service, we are not able to create the subfolder. Whenever we give the subfolder string to the `CreateFolder` method, the subfolder cannot be created successfully (we check the S3 portal). 

We write this PR to support the subfolder creation in AWS S3. Thanks!