### PR TITLE
prevent bucket re-creation error

### DIFF
--- a/ServiceStack.Aws/tests/ServiceStack.Aws.Tests/FileStorage/FileStorageProviderCommonTests.cs
+++ b/ServiceStack.Aws/tests/ServiceStack.Aws.Tests/FileStorage/FileStorageProviderCommonTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using NUnit.Framework;
 using ServiceStack.Aws.FileStorage;
 using ServiceStack.Aws.Support;
@@ -20,6 +21,7 @@ namespace ServiceStack.Aws.Tests.FileStorage
         {
             var provider = providerFactory();
             provider.DeleteFolder(baseFolderName, recursive: true);
+            Thread.Sleep(5000);
             provider.CreateFolder(baseFolderName);
         }
 

--- a/ServiceStack.Aws/tests/ServiceStack.Aws.Tests/FileStorage/S3FileStorageProviderTests.cs
+++ b/ServiceStack.Aws/tests/ServiceStack.Aws.Tests/FileStorage/S3FileStorageProviderTests.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.Aws.Tests.FileStorage
             var s3ConnectionFactory = new S3ConnectionFactory(
                 AwsConfig.AwsAccessKey,
                 AwsConfig.AwsSecretKey, 
-                RegionEndpoint.USEast1);
+                RegionEndpoint.USEast2);
 
             providerFactory = () => new S3FileStorageProvider(s3ConnectionFactory);
             


### PR DESCRIPTION
As the AWS bucket re-creation may not happen immediately, I add a thread sleep for 5 seconds after the bucket is deleted and before its creation. AWS doc:
https://aws.amazon.com/premiumsupport/knowledge-center/s3-conflicting-conditional-operation/

What's more, the `us-east-1`region will behave differently with others due to some legacy issues, so I think it is better to use other regions (us-east-2) instead of the us-east-1, as documented:
https://github.com/aws/aws-sdk-net/issues/2083