### PR TITLE
Add failing test for use of `AddColumn<T>` for migrations.

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteSchemaModifyApi.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteSchemaModifyApi.cs
@@ -41,6 +41,8 @@ namespace ServiceStack.OrmLite
         {
             var modelDef = ModelDefinition<T>.Definition;
             var fieldDef = modelDef.GetFieldDefinition(field);
+            if(fieldDef.Name != OrmLiteConfig.IdField)
+                fieldDef.IsPrimaryKey = false;
             dbConn.AddColumn(typeof(T), fieldDef);
         }
 

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Migrations/Migration1004.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Migrations/Migration1004.cs
@@ -1,0 +1,17 @@
+﻿using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests.Migrations;
+
+public class Migration1004 : MigrationBase
+{
+    class Booking
+    {
+        [Default(0)]
+        public bool IsLocked { get; set; }
+    }
+    
+    public override void Up()
+    {
+        Db.AddColumn<Booking>(booking => booking.IsLocked);
+    }
+}


### PR DESCRIPTION
Issue related to logic for `isPrimaryKey` and `isFirst` property when building the `FieldDefinition`. Since migrations use inner classes related to only the difference.,

Updated  `AddColumn<T>` to check if field is `Id`, otherwise set `IsPrimaryKey` to false after creation field defintion.