### PR TITLE
Fix redis connection string parsing bug

### DIFF
--- a/ServiceStack.Redis/src/ServiceStack.Redis/RedisExtensions.cs
+++ b/ServiceStack.Redis/src/ServiceStack.Redis/RedisExtensions.cs
@@ -62,7 +62,7 @@ namespace ServiceStack.Redis
                 var qsParams = qsParts[1].Split('&');
                 foreach (var param in qsParams)
                 {
-                    var entry = param.Split('=');
+                    var entry = param.SplitOnFirst('=');
                     var value = entry.Length > 1 ? entry[1].UrlDecode() : null;
                     if (value == null) continue;
 

--- a/ServiceStack.Redis/tests/ServiceStack.Redis.Tests/RedisExtensionTests.cs
+++ b/ServiceStack.Redis/tests/ServiceStack.Redis.Tests/RedisExtensionTests.cs
@@ -36,5 +36,22 @@ namespace ServiceStack.Redis.Tests
             Assert.AreEqual("localhost", ep.Host);
             Assert.AreEqual(6123, ep.Port);
         }
+        
+        [Test]
+        public void Host_Querystring_May_Contain_Equals()
+        {
+            var yuckyPassword = "U2VydmljZVN0YWNrIQ==";
+            var hosts = new[] { $"host.com:6123?password={yuckyPassword}&db=5" };
+
+            var endPoints = hosts.ToRedisEndPoints();
+
+            Assert.AreEqual(1, endPoints.Count);
+            var ep = endPoints[0];
+
+            Assert.AreEqual("host.com", ep.Host);
+            Assert.AreEqual(6123, ep.Port);
+            Assert.AreEqual(yuckyPassword, ep.Password);
+            Assert.AreEqual(5, ep.Db);
+        }
     }
 }


### PR DESCRIPTION
Azure Redis Cache automatically generates passwords based on Base64 conversion, which add an "=" to the end of the password string.  This is not properly handled by `RedisExtensions.ToRedisEndpoint()`.