### PR TITLE
Fix ServerEvents.GetSubscriptionInfo(id) NullReferenceException if subscription is not valid

### DIFF
--- a/ServiceStack/src/ServiceStack/ServerEventsFeature.cs
+++ b/ServiceStack/src/ServiceStack/ServerEventsFeature.cs
@@ -1588,7 +1588,7 @@ namespace ServiceStack
 
         public SubscriptionInfo GetSubscriptionInfo(string id)
         {
-            return GetSubscription(id).GetInfo();
+            return GetSubscription(id)?.GetInfo();
         }
 
         public List<SubscriptionInfo> GetSubscriptionInfosByUserId(string userId)


### PR DESCRIPTION
Fix: ServerEvents.GetSubscriptionInfo(id) throws a NullReferenceException for non existing sessions
