### PR TITLE
Fix nested child declarative validation when parent properties also have validation

### DIFF
--- a/ServiceStack/src/ServiceStack/Validators.cs
+++ b/ServiceStack/src/ServiceStack/Validators.cs
@@ -172,7 +172,7 @@ namespace ServiceStack
                 {
                     typeRules.Add(rule);
                 }
-                if (rule == null && registerChildValidators && pi.PropertyType.IsClass && pi.PropertyType != typeof(string))
+                if (registerChildValidators && pi.PropertyType.IsClass && pi.PropertyType != typeof(string))
                 {
                     var collectionGenericType = pi.PropertyType.GetTypeWithGenericInterfaceOf(typeof(IEnumerable<>));
                     if (collectionGenericType != null)

--- a/ServiceStack/tests/ServiceStack.WebHost.Endpoints.Tests/DeclarativeValidationTests.cs
+++ b/ServiceStack/tests/ServiceStack.WebHost.Endpoints.Tests/DeclarativeValidationTests.cs
@@ -30,7 +30,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         public List<NoValidators> NoValidators { get; set; }
     }
 
-    public class DeclarativeCollectionValidationTest2 : IReturn<EmptyResponse>
+    public class DeclarativeCollectionValidationParentAttribute : IReturn<EmptyResponse>
     {
         [ValidateNotEmpty]
         [ValidateMaximumLength(20)]
@@ -112,7 +112,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
             return new EmptyResponse();
         }
 
-        public object Any(DeclarativeCollectionValidationTest2 request) => new EmptyResponse();
+        public object Any(DeclarativeCollectionValidationParentAttribute request) => new EmptyResponse();
 
     }
     
@@ -143,14 +143,15 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         public void OneTimeTearDown() => appHost.Dispose();
         IServiceClient CreateClient() => new JsonServiceClient(Config.ListeningOn);
 
+        
         [Test]
-        public void Does_execute_declarative_collection_validation_with_not_empty()
+        public void Does_execute_declarative_collection_validation_when_collection_has_own_not_empty()
         {
             var client = CreateClient();
 
             try
             {
-                var invalidRequest = new DeclarativeCollectionValidationTest2 {
+                var invalidRequest = new DeclarativeCollectionValidationParentAttribute {
                     Site = "Location 1",
                     DeclarativeValidationsWithNotEmpty = new List<DeclarativeChildValidation>
                     {


### PR DESCRIPTION
Fix for [issue reported on customer forums](https://forums.servicestack.net/t/validation-trouble-for-nested/11180) when parent IEnumerable<T> property has own declarative validation attributes, child attributes are skipped. This removes the check so that nested validation is also applied in this case by removing the existing rule check for a parent property validation.