### PR TITLE
Custom byte serializer

### DIFF
--- a/ServiceStack/src/ServiceStack.Client/MessageExtensions.cs
+++ b/ServiceStack/src/ServiceStack.Client/MessageExtensions.cs
@@ -1,74 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
 using ServiceStack.Messaging;
-using ServiceStack.Text;
 
 namespace ServiceStack
 {
     public static class MessageExtensions
     {
-        public static string ToString(byte[] bytes)
-        {
-            return System.Text.Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-        }
-
-        private static Dictionary<Type, ToMessageDelegate> ToMessageFnCache = new Dictionary<Type, ToMessageDelegate>();
-        internal static ToMessageDelegate GetToMessageFn(Type type)
-        {
-            ToMessageFnCache.TryGetValue(type, out var toMessageFn);
-
-            if (toMessageFn != null) return toMessageFn;
-
-            var genericType = typeof(MessageExtensions<>).MakeGenericType(type);
-            var mi = genericType.GetStaticMethod("ConvertToMessage");
-            toMessageFn = (ToMessageDelegate)mi.MakeDelegate(typeof(ToMessageDelegate));
-
-            Dictionary<Type, ToMessageDelegate> snapshot, newCache;
-            do
-            {
-                snapshot = ToMessageFnCache;
-                newCache = new Dictionary<Type, ToMessageDelegate>(ToMessageFnCache) {
-                    [type] = toMessageFn
-                };
-
-            } while (!ReferenceEquals(
-                Interlocked.CompareExchange(ref ToMessageFnCache, newCache, snapshot), snapshot));
-
-            return toMessageFn;
-        }
-
-        public static IMessage ToMessage(this byte[] bytes, Type ofType)
-        {
-            if (bytes == null)
-                return null;
-
-            var msgFn = GetToMessageFn(ofType);
-            var msg = msgFn(bytes);
-            return msg;
-        }
-
-        public static Message<T> ToMessage<T>(this byte[] bytes)
-        {
-            if (bytes == null)
-                return null;
-
-            var messageText = ToString(bytes);
-            return JsonSerializer.DeserializeFromString<Message<T>>(messageText);
-        }
-
-        public static byte[] ToBytes(this IMessage message)
-        {
-            var serializedMessage = JsonSerializer.SerializeToString((object)message);
-            return System.Text.Encoding.UTF8.GetBytes(serializedMessage);
-        }
-
-        public static byte[] ToBytes<T>(this IMessage<T> message)
-        {
-            var serializedMessage = JsonSerializer.SerializeToString(message);
-            return System.Text.Encoding.UTF8.GetBytes(serializedMessage);
-        }
-
         public static string ToInQueueName(this IMessage message)
         {
             var queueName = message.Priority > 0
@@ -98,17 +33,6 @@ namespace ServiceStack
         public static IMessageProducer CreateMessageProducer(this IMessageService mqServer)
         {
             return mqServer.MessageFactory.CreateMessageProducer();
-        }
-    }
-
-    internal delegate IMessage ToMessageDelegate(object param);
-
-    internal static class MessageExtensions<T>
-    {
-        public static IMessage ConvertToMessage(object oBytes)
-        {
-            var bytes = (byte[]) oBytes;
-            return bytes.ToMessage<T>();
         }
     }
 }

--- a/ServiceStack/src/ServiceStack.Client/Messaging/MessageQueueClientFactory.cs
+++ b/ServiceStack/src/ServiceStack.Client/Messaging/MessageQueueClientFactory.cs
@@ -9,9 +9,21 @@ namespace ServiceStack.Messaging
     public class MessageQueueClientFactory
         : IMessageQueueClientFactory
     {
+        private readonly IMessageByteSerializer messageByteSerializer;
+
+        public MessageQueueClientFactory()
+            : this(new ServiceStackTextMessageByteSerializer())
+        {
+        }
+        
+        public MessageQueueClientFactory(IMessageByteSerializer messageByteSerializer)
+        {
+            this.messageByteSerializer = messageByteSerializer;
+        }
+        
         public IMessageQueueClient CreateMessageQueueClient()
         {
-            return new InMemoryMessageQueueClient(this);
+            return new InMemoryMessageQueueClient(this, messageByteSerializer);
         }
 
         readonly object syncLock = new object();
@@ -29,7 +41,7 @@ namespace ServiceStack.Messaging
 
         public void PublishMessage<T>(string queueName, IMessage<T> message)
         {
-            PublishMessage(queueName, message.ToBytes());
+            PublishMessage(queueName, messageByteSerializer.ToBytes(message));
         }
 
         public void PublishMessage(string queueName, byte[] messageBytes)

--- a/ServiceStack/src/ServiceStack.Client/Messaging/RedisMessageFactory.cs
+++ b/ServiceStack/src/ServiceStack.Client/Messaging/RedisMessageFactory.cs
@@ -8,20 +8,27 @@ namespace ServiceStack.Messaging
     public class RedisMessageFactory : IMessageFactory
     {
         private readonly IRedisClientsManager clientsManager;
+        private readonly IMessageByteSerializer messageByteSerializer;
 
         public RedisMessageFactory(IRedisClientsManager clientsManager)
+            : this(clientsManager, new ServiceStackTextMessageByteSerializer())
+        {
+        }
+
+        public RedisMessageFactory(IRedisClientsManager clientsManager, IMessageByteSerializer messageByteSerializer)
         {
             this.clientsManager = clientsManager;
+            this.messageByteSerializer = messageByteSerializer;
         }
 
         public IMessageQueueClient CreateMessageQueueClient()
         {
-            return new RedisMessageQueueClient(clientsManager);
+            return new RedisMessageQueueClient(clientsManager, messageByteSerializer);
         }
 
         public IMessageProducer CreateMessageProducer()
         {
-            return new RedisMessageProducer(clientsManager);
+            return new RedisMessageProducer(clientsManager, messageByteSerializer);
         }
 
         public void Dispose()

--- a/ServiceStack/src/ServiceStack.Client/Messaging/RedisMessageQueueClientFactory.cs
+++ b/ServiceStack/src/ServiceStack.Client/Messaging/RedisMessageQueueClientFactory.cs
@@ -10,19 +10,26 @@ namespace ServiceStack.Messaging
         : IMessageQueueClientFactory
     {
         private readonly Action onPublishedCallback;
+        private readonly IMessageByteSerializer messageByteSerializer;
         private readonly IRedisClientsManager clientsManager;
 
+        public RedisMessageQueueClientFactory(IRedisClientsManager clientsManager, Action onPublishedCallback)
+            : this(clientsManager, new ServiceStackTextMessageByteSerializer(), onPublishedCallback)
+        {
+        }
+        
         public RedisMessageQueueClientFactory(
-            IRedisClientsManager clientsManager, Action onPublishedCallback)
+            IRedisClientsManager clientsManager, IMessageByteSerializer messageByteSerializer, Action onPublishedCallback)
         {
             this.onPublishedCallback = onPublishedCallback;
+            this.messageByteSerializer = messageByteSerializer;
             this.clientsManager = clientsManager;
         }
 
         public IMessageQueueClient CreateMessageQueueClient()
         {
             return new RedisMessageQueueClient(
-                this.clientsManager, this.onPublishedCallback);
+                this.clientsManager, this.messageByteSerializer, this.onPublishedCallback);
         }
 
         public void Dispose()

--- a/ServiceStack/src/ServiceStack.Client/Messaging/ServiceStackTextMessageByteSerializer.cs
+++ b/ServiceStack/src/ServiceStack.Client/Messaging/ServiceStackTextMessageByteSerializer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ServiceStack.Messaging;
+
+public class ServiceStackTextMessageByteSerializer : IMessageByteSerializer
+{
+    public byte[] ToBytes(IMessage message) => message.ToBytes();
+
+    public byte[] ToBytes<T>(IMessage<T> message) => message.ToBytes();
+
+    public IMessage ToMessage(byte[] bytes, Type ofType) => bytes.ToMessage(ofType);
+
+    public Message<T> ToMessage<T>(byte[] bytes) => bytes.ToMessage<T>();
+}

--- a/ServiceStack/src/ServiceStack.Client/Messaging/ServiceStackTextMessageByteSerializer.cs
+++ b/ServiceStack/src/ServiceStack.Client/Messaging/ServiceStackTextMessageByteSerializer.cs
@@ -1,14 +1,77 @@
-﻿using System;
+﻿using ServiceStack.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
 
 namespace ServiceStack.Messaging;
 
 public class ServiceStackTextMessageByteSerializer : IMessageByteSerializer
 {
-    public byte[] ToBytes(IMessage message) => message.ToBytes();
+    internal delegate IMessage ToMessageDelegate(IMessageByteSerializer serializer, object param);
 
-    public byte[] ToBytes<T>(IMessage<T> message) => message.ToBytes();
+    private static IDictionary<Type, ToMessageDelegate> ToMessageFnCache = new Dictionary<Type, ToMessageDelegate>();
 
-    public IMessage ToMessage(byte[] bytes, Type ofType) => bytes.ToMessage(ofType);
+    internal ToMessageDelegate GetToMessageFn(Type type)
+    {
+        ToMessageFnCache.TryGetValue(type, out var toMessageFn);
 
-    public Message<T> ToMessage<T>(byte[] bytes) => bytes.ToMessage<T>();
+        if (toMessageFn != null) return toMessageFn;
+
+        var method = GetType().GetMethods()
+            .Single(x => x.Name == nameof(ToMessage) && x.IsGenericMethod)
+            .MakeGenericMethod(type);
+
+        toMessageFn = (ToMessageDelegate) method.MakeDelegate(typeof(ToMessageDelegate));
+
+        IDictionary<Type, ToMessageDelegate> snapshot, newCache;
+        do
+        {
+            snapshot = ToMessageFnCache;
+            newCache = new Dictionary<Type, ToMessageDelegate>(ToMessageFnCache)
+            {
+                [type] = toMessageFn
+            };
+        } while (!ReferenceEquals(
+                     Interlocked.CompareExchange(ref ToMessageFnCache, newCache, snapshot), snapshot));
+
+        return toMessageFn;
+    }
+
+    public string ToString(byte[] bytes)
+    {
+        return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+    }
+
+    public IMessage ToMessage(byte[] bytes, Type ofType)
+    {
+        if (bytes == null)
+            return null;
+
+        var msgFn = GetToMessageFn(ofType);
+        var msg = msgFn(this, bytes);
+        return msg;
+    }
+
+    public Message<T> ToMessage<T>(byte[] bytes)
+    {
+        if (bytes == null)
+            return null;
+
+        var messageText = ToString(bytes);
+        return JsonSerializer.DeserializeFromString<Message<T>>(messageText);
+    }
+
+    public byte[] ToBytes(IMessage message)
+    {
+        var serializedMessage = JsonSerializer.SerializeToString((object) message);
+        return Encoding.UTF8.GetBytes(serializedMessage);
+    }
+
+    public byte[] ToBytes<T>(IMessage<T> message)
+    {
+        var serializedMessage = JsonSerializer.SerializeToString(message);
+        return Encoding.UTF8.GetBytes(serializedMessage);
+    }
 }

--- a/ServiceStack/src/ServiceStack.Interfaces/Messaging/IMessageByteSerializer.cs
+++ b/ServiceStack/src/ServiceStack.Interfaces/Messaging/IMessageByteSerializer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ServiceStack.Messaging;
+
+public interface IMessageByteSerializer
+{
+    byte[] ToBytes(IMessage message);
+
+    byte[] ToBytes<T>(IMessage<T> message);
+
+    IMessage ToMessage(byte[] bytes, Type ofType);
+
+    Message<T> ToMessage<T>(byte[] bytes);
+}

--- a/ServiceStack/src/ServiceStack/Messaging/InMemoryTransientMessageService.cs
+++ b/ServiceStack/src/ServiceStack/Messaging/InMemoryTransientMessageService.cs
@@ -9,13 +9,23 @@ namespace ServiceStack.Messaging
         internal InMemoryTransientMessageFactory Factory { get; set; }
 
         public InMemoryTransientMessageService()
-            : this(null)
+            : this(factory: null)
         {
         }
 
         public InMemoryTransientMessageService(InMemoryTransientMessageFactory factory)
+            : this(factory, new ServiceStackTextMessageByteSerializer())
         {
-            this.Factory = factory ?? new InMemoryTransientMessageFactory(this);
+        }
+
+        public InMemoryTransientMessageService(IMessageByteSerializer messageByteSerializer)
+            : this(null, messageByteSerializer)
+        {
+        }
+
+        public InMemoryTransientMessageService(InMemoryTransientMessageFactory factory, IMessageByteSerializer messageByteSerializer)
+        {
+            this.Factory = factory ?? new InMemoryTransientMessageFactory(this, messageByteSerializer);
             this.Factory.MqFactory.MessageReceived += factory_MessageReceived;
         }
 

--- a/ServiceStack/tests/ServiceStack.Common.Tests/MessagingTests.cs
+++ b/ServiceStack/tests/ServiceStack.Common.Tests/MessagingTests.cs
@@ -50,6 +50,19 @@ namespace ServiceStack.Common.Tests
 
             Assert.That(typedMessage.GetBody().Value, Is.EqualTo(dto.Value));
         }
+        
+        [Test]
+        public void Can_serialize_IMessage_ToBytes_into_typed_Message_using_MessageByteSerializer()
+        {
+            var serializer = new ServiceStackTextMessageByteSerializer();
+            
+            var dto = new Incr { Value = 1 };
+            var iMsg = MessageFactory.Create(dto);
+            var bytes = serializer.ToBytes(iMsg);
+            var typedMessage = serializer.ToMessage<Incr>(bytes);
+
+            Assert.That(typedMessage.GetBody().Value, Is.EqualTo(dto.Value));
+        }
 
         [Test]
         public void Can_deserialize_concrete_type_into_IOAuthSession()

--- a/ServiceStack/tests/ServiceStack.Server.Tests/Messaging/InMemoryTransientMessagingHostTests.cs
+++ b/ServiceStack/tests/ServiceStack.Server.Tests/Messaging/InMemoryTransientMessagingHostTests.cs
@@ -10,7 +10,7 @@ namespace ServiceStack.Server.Tests.Messaging
 		protected override IMessageFactory CreateMessageFactory()
 		{
 			messageService = new InMemoryTransientMessageService();
-			return new InMemoryTransientMessageFactory(messageService);
+			return new InMemoryTransientMessageFactory(messageService, new ServiceStackTextMessageByteSerializer());
 		}
 
 		protected override TransientMessageServiceBase CreateMessagingService()

--- a/ServiceStack/tests/ServiceStack.WebHost.Endpoints.Tests/LicenseUsageTests.cs
+++ b/ServiceStack/tests/ServiceStack.WebHost.Endpoints.Tests/LicenseUsageTests.cs
@@ -113,7 +113,7 @@ namespace ServiceStack.WebHost.Endpoints.Tests
         [Test]
         public void Allows_MegaDto_through_RedisMqClients()
         {
-            var mqFactory = new RedisMessageFactory(new BasicRedisClientManager());
+            var mqFactory = new RedisMessageFactory(new BasicRedisClientManager(), new ServiceStackTextMessageByteSerializer());
 
             var request = MegaDto.Create();
 


### PR DESCRIPTION
Hi, I hit some issues with ServiceStack.Text serializer and I would like to control the process. Now the `ToBytes` and `ToMessage` are extension methods making them difficult to customize. I extrapolate them to the new `ServiceStackTextMessageByteSerializer`. I believe it's without BC breaks because all constructor signatures were left untouched, I only added new ones.

Although it makes sense to add ServiceStackTextMessageByteSerializer to DI to prevent creating multiple instances, constructors without serializer can be made obsolete with a future main release.