### PR TITLE
Add support for QueueOwnerAWSAccountId parameter of GetQueueUrlRequest

### DIFF
--- a/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/ISqsQueueManager.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/ISqsQueueManager.cs
@@ -11,6 +11,7 @@ namespace ServiceStack.Aws.Sqs
         int DefaultReceiveWaitTime { get; set; }
         int DefaultVisibilityTimeout { get; set; }
         bool DisableBuffering { get; set; }
+        string AwsQueueOwnerAccountId { get; set; }
         ConcurrentDictionary<string, SqsQueueDefinition> QueueNameMap { get; }
         IAmazonSQS SqsClient { get; }
 

--- a/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsMqServer.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsMqServer.cs
@@ -97,6 +97,15 @@ namespace ServiceStack.Aws.Sqs
             get => sqsMqMessageFactory.QueueManager.DisableBuffering;
             set => sqsMqMessageFactory.QueueManager.DisableBuffering = value;
         }
+        
+        /// <summary>
+        /// Set the AWS Account Identifier of the AWS Account that owns the SQS queue.
+        /// </summary>
+        public string AwsQueueOwnerAccountId
+        {
+            get => sqsMqMessageFactory.QueueManager.AwsQueueOwnerAccountId;
+            set => sqsMqMessageFactory.QueueManager.AwsQueueOwnerAccountId = value;
+        }
 
         /// <summary>
         /// Execute global transformation or custom logic before a request is processed.
@@ -178,7 +187,7 @@ namespace ServiceStack.Aws.Sqs
                                        Action<IMessageHandler, IMessage<T>, Exception> processExceptionEx,
                                        int noOfThreads, int? retryCount = null,
                                        int? visibilityTimeoutSeconds = null, int? receiveWaitTimeSeconds = null,
-                                       bool? disableBuffering = null)
+                                       bool? disableBuffering = null, string? awsQueueOwnerAccountId = null)
         {
             var type = typeof(T);
 
@@ -201,7 +210,8 @@ namespace ServiceStack.Aws.Sqs
                 ThreadCount = noOfThreads,
                 VisibilityTimeout = visibilityTimeoutSeconds ?? this.VisibilityTimeout,
                 ReceiveWaitTime = receiveWaitTimeSeconds ?? this.ReceiveWaitTime,
-                DisableBuffering = disableBuffering ?? this.DisableBuffering
+                DisableBuffering = disableBuffering ?? this.DisableBuffering,
+                AwsQueueOwnerAccountId = awsQueueOwnerAccountId ?? this.AwsQueueOwnerAccountId
             };
 
             LicenseUtils.AssertValidUsage(LicenseFeature.ServiceStack, QuotaType.Operations, handlerMap.Count);

--- a/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsMqWorkerInfo.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsMqWorkerInfo.cs
@@ -26,6 +26,7 @@ namespace ServiceStack.Aws.Sqs
         }
 
         public bool DisableBuffering { get; set; }
+        public string AwsQueueOwnerAccountId { get; set; }
         public QueueNames QueueNames { get; private set; }
         
         public int VisibilityTimeout

--- a/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsQueueManager.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsQueueManager.cs
@@ -33,6 +33,7 @@ namespace ServiceStack.Aws.Sqs
         public int DefaultVisibilityTimeout { get; set; }
         public int DefaultReceiveWaitTime { get; set; }
         public bool DisableBuffering { get; set; }
+        public string AwsQueueOwnerAccountId { get; set; }
 
         public SqsConnectionFactory ConnectionFactory => sqsConnectionFactory;
 
@@ -90,10 +91,23 @@ namespace ServiceStack.Aws.Sqs
                     return qd.QueueUrl;
             }
 
-            var response = SqsClient.GetQueueUrl(new GetQueueUrlRequest { 
-                QueueName = queueName.AwsQueueName
-            });
-            return response.QueueUrl;
+            if (AwsQueueOwnerAccountId.IsNullOrEmpty())
+            {
+                log.InfoFormat("Calling GetQueueUrl() for a Queue named [{0}]", queueName);
+                var response = SqsClient.GetQueueUrl(new GetQueueUrlRequest { 
+                    QueueName = queueName.AwsQueueName,
+                });
+                return response.QueueUrl;
+            }
+            else
+            {
+                log.InfoFormat("Calling GetQueueUrl() for a Queue named [{0}] on account [{1}]", queueName, AwsQueueOwnerAccountId);
+                var response = SqsClient.GetQueueUrl(new GetQueueUrlRequest { 
+                    QueueName = queueName.AwsQueueName,
+                    QueueOwnerAWSAccountId = AwsQueueOwnerAccountId
+                });
+                return response.QueueUrl;
+            }
         }
 
         public SqsQueueDefinition GetQueueDefinition(string queueName, bool forceRecheck = false)

--- a/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsQueueName.cs
+++ b/ServiceStack.Aws/src/ServiceStack.Aws/Sqs/SqsQueueName.cs
@@ -22,14 +22,16 @@ namespace ServiceStack.Aws.Sqs
 
     public class SqsQueueName : IEquatable<SqsQueueName>
     {
-        public SqsQueueName(string originalQueueName)
+        public SqsQueueName(string originalQueueName, string awsQueueAccountId = null)
         {
             QueueName = originalQueueName;
             AwsQueueName = originalQueueName.ToValidQueueName();
+            AwsQueueAccountId = awsQueueAccountId;
         }
 
         public string QueueName { get; }
         public string AwsQueueName { get; private set; }
+        public string AwsQueueAccountId { get; set; }
 
         public bool Equals(SqsQueueName other)
         {


### PR DESCRIPTION
Enhanced the SQS Message Queuing to support the AWS SDK parameter for specifying the AWS Account Id of the SQS Message queue, which is used for cross-account SQS message queue access.

- Parameter can be optionally be specified at Message Queue configuration, which if configured, will pass it into the Get Queue Name API call request object (the GetQueueUrlRequest) which returns the AWS SQS Queue name. Past this point the queue logic and methods remain unchanged as the API response always included an account Id regardless of us specifying one to get a queue in a different AWS Account.