### PR TITLE
fix invalid 2d array type declaration in TypeScriptGenerator

### DIFF
--- a/ServiceStack/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
+++ b/ServiceStack/src/ServiceStack/NativeTypes/TypeScript/TypeScriptGenerator.cs
@@ -823,7 +823,12 @@ namespace ServiceStack.NativeTypes.TypeScript
 
             var arrParts = type.SplitOnFirst('[');
             if (arrParts.Length > 1)
-                return "{0}[]".Fmt(TypeAlias(arrParts[0]));
+            {
+                var numberOfDimensions = type.Count(c => c == '[');
+                var arrayDimensions = String.Concat(Enumerable.Range(0, numberOfDimensions).Select(_ => "[]"));
+                
+                return "{0}{1}".Fmt(TypeAlias(arrParts[0]), arrayDimensions);
+            }
 
             TypeAliases.TryGetValue(type, out var typeAlias);
 

--- a/ServiceStack/tests/ServiceStack.Common.Tests/NativeTypesTypescriptGeneratorTests.cs
+++ b/ServiceStack/tests/ServiceStack.Common.Tests/NativeTypesTypescriptGeneratorTests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using ServiceStack.NativeTypes.TypeScript;
+
+namespace ServiceStack.Common.Tests
+{
+    [TestFixture]
+    public class NativeTypesTypescriptGeneratorTests
+    {
+        [Test]
+        public void TypeScript_Generator_Generates_2D_Array()
+        {
+            // arrange
+            var sut = new TypeScriptGenerator(null);
+
+            // act
+            var result = sut.Type("String[][]", null);
+
+            // assert
+            Assert.AreEqual("string[][]", result);
+        }
+
+        [Test]
+        public void TypeScript_Generator_Generates_Single_Dimension_Array()
+        {
+            // arrange
+            var sut = new TypeScriptGenerator(null);
+
+            // act
+            var result = sut.Type("String[]", null);
+
+            // assert
+            Assert.AreEqual("string[]", result);
+        }
+    }
+}


### PR DESCRIPTION
We found out the TypeScriptGenerator doesn't play well with 2d+ arrays: 

```c#
var gen = new TypeScriptGenerator(null);
var result = gen.Type("String[][]", null);
```

result is `string[]` instead of `string[][]`


