### PR TITLE
Pass connection parameter to called UpdateInternalAsync

### DIFF
--- a/ServiceStack/src/ServiceStack.Server/AutoQueryFeature.AutoCrud.cs
+++ b/ServiceStack/src/ServiceStack.Server/AutoQueryFeature.AutoCrud.cs
@@ -678,7 +678,7 @@ namespace ServiceStack
 
             var meta = AutoCrudMetadata.Create(dto.GetType());
             if (meta.SoftDelete)
-                return PartialUpdate<Table>(dto, req);
+                return PartialUpdate<Table>(dto, req, db);
 
             var ctx = CrudContext.Create<Table>(req,db,dto,AutoCrudOperation.Delete);
             var feature = HostContext.GetPlugin<AutoQueryFeature>();
@@ -708,7 +708,7 @@ namespace ServiceStack
 
             var meta = AutoCrudMetadata.Create(dto.GetType());
             if (meta.SoftDelete)
-                return await UpdateInternalAsync<Table>(req, dto, AutoCrudOperation.Patch).ConfigAwait();
+                return await UpdateInternalAsync<Table>(req, dto, AutoCrudOperation.Patch, db).ConfigAwait();
 
             var ctx = CrudContext.Create<Table>(req,db,dto,AutoCrudOperation.Delete);
             var feature = HostContext.GetPlugin<AutoQueryFeature>();


### PR DESCRIPTION
Encountered problem when trying to do a bulk soft delete in a loop.  There was an exception thrown in the middle of the update but when I rolled back the transaction, the updates for the soft deletes up to that point were committed.

The delete method delegates to the UpdateInternal method but did not pass its db parameter along causing the existing connection to reset and transaction is unable to rollback the updates.