### PR TITLE
Do not skip tags for SqlExpressions that have Limit

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -627,7 +627,7 @@ namespace ServiceStack.OrmLite.SqlServer
             if (sql.Length < "SELECT".Length)
                 return sql;
 
-            return selectType + " TOP " + take + sql.Substring(selectType.Length);
+            return sql.Substring(0, sql.IndexOf(selectType)) + selectType + " TOP " + take + sql.Substring(sql.IndexOf(selectType) + selectType.Length);
         }
 
         //SELECT without RowNum and prefer aliases to be able to use in SELECT IN () Reference Queries

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.SqlServer.Tests/Issues/TagTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.SqlServer.Tests/Issues/TagTests.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Issues
+{
+    [TestFixture]
+    public class TagTests : OrmLiteTestBase
+    {
+        [Test]
+        public void Can_Tag_Expression_That_Has_Limit()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<SimpleModel>();
+
+                db.Insert(new SimpleModel { Id = 1, Foo = 1, Bar = 2 });
+                db.Insert(new SimpleModel { Id = 2, Foo = 3, Bar = 4 });
+
+                var query = db.From<SimpleModel>()
+                              .Limit(1)
+                              .TagWith("AnAwesomeQuery");
+
+                var x = query.ToSelectStatement();
+                Assert.That(x, Does.StartWith("-- AnAwesomeQuery"));
+
+                var results = db.Select(query);
+                Assert.That(results.Count, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
+        public void Can_Tag_Distinct_Expression_That_Has_Limit()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<SimpleModel>();
+
+                db.Insert(new SimpleModel { Id = 1, Foo = 1, Bar = 2 });
+                db.Insert(new SimpleModel { Id = 2, Foo = 3, Bar = 4 });
+
+                var query = db.From<SimpleModel>()
+                              .Limit(1)
+                              .TagWith("AnAwesomeQuery")
+                              .SelectDistinct();
+
+                Assert.That(query.ToSelectStatement(), Does.StartWith("-- AnAwesomeQuery"));
+
+                var results = db.Select(query);
+                Assert.That(results.Count, Is.EqualTo(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
OrmLite generates an invalid SQL query when tagging a `SqlExpression` that has a Limit, with `SqlServerOrmLiteDialectProvider`.

For example, the expression `db.From<SimpleModel>().Limit(1).TagWith(AnAwesomeQuery)` generates 

```sql
SELECT TOP 1wesomeQuery

SELECT "Id", "Foo", "Bar" 
FROM "SimpleModel"
```

which throws "_System.Data.SqlClient.SqlException : Invalid column name 'wesomeQuery'._"

