### PR TITLE
JoinAlias enhancements

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
@@ -224,7 +224,14 @@ namespace ServiceStack.OrmLite
             return this;
         }
 
+        /// <summary>
+        /// Hold the <see cref="TableOptions"/> for each Join and clear them at the end of the Join
+        /// </summary>
         private TableOptions joinAlias;
+        /// <summary>
+        /// If <see cref="UseJoinTypeAsAliases"/> is enabled, record the <see cref="TableOptions"/> set for different types each time Join
+        /// </summary>
+        private Dictionary<ModelDefinition,TableOptions> joinAliases;
 
         protected virtual SqlExpression<T> InternalJoin(string joinType, Expression joinExpr, ModelDefinition sourceDef, ModelDefinition targetDef, TableOptions options = null)
         {
@@ -243,6 +250,13 @@ namespace ServiceStack.OrmLite
                     joinFormat = null;
                     options.ModelDef = targetDef;
                     joinAlias = options;
+
+                    if (UseJoinTypeAsAliases)
+                    {
+                        joinAliases ??= new Dictionary<ModelDefinition,TableOptions>();
+                        //If join multiple times and set different TableOptions, only the last setting will be used
+                        joinAliases[targetDef]=options;
+                    }
                 }
             } 
             

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -42,6 +42,7 @@ namespace ServiceStack.OrmLite
         public int? Offset { get; set; }
         public bool PrefixFieldWithTableName { get; set; }
         public bool UseSelectPropertiesAsAliases { get; set; }
+        public bool UseJoinTypeAsAliases { get; set; }
         public bool WhereStatementWithoutWhereString { get; set; }
         public ISet<string> Tags { get; } = new HashSet<string>();
         public bool AllowEscapeWildcards { get; set; }= true;
@@ -2065,8 +2066,7 @@ namespace ServiceStack.OrmLite
             OnVisitMemberType(modelType);
 
             var tableDef = modelType.GetModelDefinition();
-
-            var tableAlias = GetTableAlias(m);
+            var tableAlias = GetTableAlias(m, tableDef);
             var columnName = tableAlias == null
                 ? GetQuotedColumnName(tableDef, m.Member.Name)
                 : GetQuotedColumnName(tableDef, tableAlias, m.Member.Name);
@@ -2077,7 +2077,7 @@ namespace ServiceStack.OrmLite
             return new PartialSqlString(columnName);
         }
 
-        protected virtual string GetTableAlias(MemberExpression m)
+        protected virtual string GetTableAlias(MemberExpression m, ModelDefinition tableDef)
         {
             if (originalLambda == null)
                 return null;
@@ -2098,6 +2098,11 @@ namespace ServiceStack.OrmLite
 
                 if (pe.Type == joinType && pe.Name == joinParamName)
                     return joinAlias.Alias;
+            }
+
+            if (UseJoinTypeAsAliases && joinAliases != null && joinAliases.TryGetValue(tableDef, out var tableOptions))
+            {
+                return tableOptions.Alias;
             }
 
             return null;

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
@@ -11,7 +11,7 @@ using ServiceStack.Text;
 namespace ServiceStack.OrmLite.Tests;
 
 [TestFixtureOrmLite]
-public class OrmLiteSelectTests : OrmLiteProvidersTestBase
+public partial class OrmLiteSelectTests : OrmLiteProvidersTestBase
 {
     public OrmLiteSelectTests(DialectContext context) : base(context) { }
 
@@ -439,7 +439,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
 
         Assert.That(rows.Count, Is.EqualTo(1));
     }
-        
+
     public class AccountIntId
     {
         [AutoIncrement]
@@ -458,7 +458,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         db.DropAndCreateTable<AccountIntId>();
         db.Insert(new AccountIntId { Username = "johnsmith" });
         db.Insert(new AccountIntId { Username = "2-whatever-more-3" });
-            
+
         Assert.That(db.SingleById<AccountIntId>(1).Username, Is.EqualTo("johnsmith"));
         Assert.That(db.SingleById<AccountIntId>(3), Is.Null);
 
@@ -467,16 +467,16 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         {
             result = db.SingleById<AccountIntId>("");
         }
-        catch {}
+        catch { }
         Assert.That(result, Is.Null);
 
         try
         {
             result = db.SingleById<AccountIntId>("johnsmith2");
         }
-        catch {}
+        catch { }
         Assert.That(result, Is.Null);
-        
+
         Assert.Throws<ArgumentNullException>(() => db.SingleById<AccountIntId>(null));
 
         // Returns Id=2 in Sqlite/MySql
@@ -506,7 +506,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         public int CustomMax { get; set; }
         public int CustomCount { get; set; }
     }
-    
+
     [Test]
     [IgnoreDialect(Dialect.MySql, "Does not support LIKE escape sequences")]
     public void Does_support_LIKE_Escape_Char()
@@ -514,7 +514,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         using var db = OpenDbConnection();
         db.DropAndCreateTable<CustomSql>();
         db.Insert(new CustomSql { Id = 1, Name = "Jo[h]n" });
-        
+
         var results = db.Select<CustomSql>("name LIKE @name", new { name = "Jo\\[h\\]n" });
         if (!Dialect.AnyPostgreSql.HasFlag(Dialect))
         {
@@ -568,7 +568,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         var q = db.From<Tasked>().TagWith(tag);
 
         Debug.Assert(q.Tags.Count == 1);
-        Debug.Assert(q.Tags.ToList()[0]== tag);
+        Debug.Assert(q.Tags.ToList()[0] == tag);
 
         var select = q.ToSelectStatement();
         Debug.Assert(select.Contains(tag));
@@ -627,7 +627,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
 
     public class EscapeWildcardsModel
     {
-        [PrimaryKey,AutoIncrement]
+        [PrimaryKey, AutoIncrement]
         public int Id { get; set; }
 
         [Index]
@@ -655,7 +655,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
         var sql1 = q.ToMergedParamsSelectStatement();
         Debug.Assert(sql1.Contains("WHERE \"Index\" like '1^_2%' escape '^'"));
         var c1 = db.Count(q);
-        Debug.Assert(c1==2);
+        Debug.Assert(c1 == 2);
         q = db.From<EscapeWildcardsModel>(x =>
             {
                 x.AllowEscapeWildcards = false;
@@ -663,7 +663,7 @@ public class OrmLiteSelectTests : OrmLiteProvidersTestBase
             .Where(x => x.Index.StartsWith("1_2"));
         var sql2 = q.ToMergedParamsSelectStatement();
         Debug.Assert(sql2.Contains("WHERE \"Index\" like '1_2%'"));
-        var c2= db.Count(q);
-        Debug.Assert(c2==3);
+        var c2 = db.Count(q);
+        Debug.Assert(c2 == 3);
     }
 }

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTestsJoinAliasTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTestsJoinAliasTests.cs
@@ -6,71 +6,59 @@ namespace ServiceStack.OrmLite.Tests;
 
 public partial class OrmLiteSelectTests
 {
-    [Alias("实体_配置")]
     class Channel
     {
-        [Alias("编码"), Index]
         public string Id { get; set; }
-        [Alias("名称")]
         public string Name { get; set; }
-        [Alias("区域编码")]
         public string Area { get; set; }
-        [Alias("类型"), Index]
         public NttType DstType { get; set; }
-        [Alias("删除状态")]
         public int Delete { get; set; }
     }
 
-    [Alias("实体_状态")]
+    [Alias(nameof(BaseResult))]
     class BaseResult
     {
-        [Alias("编码"), PrimaryKey]
+        [ PrimaryKey]
         public string Id { get; set; }
 
-        [Alias("目标编码")]
         public string Code { get; set; }
 
-        [Alias("目标类型")]
         public virtual NttType DstType { get; set; }
 
-        [Alias("状态类型")]
         public string ResultType { get; set; }
 
-        [Alias("检测项类型")]
         public virtual TestType Type { get; set; }
     }
 
+    [Alias(nameof(BaseResult))]
     class VqdStateResult : BaseResult
     {
-        [Alias("丢失")]
-        public int 丢失状态 { get; set; }
-        [Alias("失色")]
-        public int 失色状态 { get; set; }
+        public int Loss { get; set; }
+        public int Color { get; set; }
     }
 
+    [Alias(nameof(BaseResult))]
     class OcrResult : BaseResult
     {
 
     }
 
+    [Alias(nameof(BaseResult))]
     class LinkResult : BaseResult
     {
-        [Alias("文1")]
-        public StateType State { get; set; } = StateType.未知;
+        public StateType State { get; set; } = StateType.Unknow;
     }
 
-    [Alias("框架_区域")]
     class Region
     {
-        [Alias("编码"), StringLength(60), PrimaryKey]
+        [ StringLength(60), PrimaryKey]
         public string Id { get; set; }
-        [Alias("类型")]
         public int Type { get; set; } = 0;
     }
 
     public enum StateType
     {
-        未知 = -1
+        Unknow = -1
     }
 
     enum TestType
@@ -88,9 +76,6 @@ public partial class OrmLiteSelectTests
     [Test]
     public void Can_JoinAlias_In_Expression()
     {
-        // DbFactory.DialectProvider = MySqlDialect.Provider;
-        // DbFactory.ConnectionString = "Server=82.157.15.104;Port=3306;User Id=root;Password=tnT1R*k0+Eku;Database=demo-ormlite;Pooling=true;Allow User Variables=True;SslMode=none;";
-
         using var db = OpenDbConnection();
         db.DropAndCreateTable<Channel>();
         db.DropAndCreateTable<VqdStateResult>();
@@ -128,13 +113,15 @@ public partial class OrmLiteSelectTests
                 y.Type,
                 LinkState = Sql.TableAlias(h.State, "z").ToString(),
                 LinkState1 = h.State.ToString(),
-                z.丢失状态
+                Loss = z.Loss,
+                Color = z.Color,
             });
 
         var p = db.GetDialectProvider();
         var sql = sqlExpression.ToMergedParamsSelectStatement();
-        Assert.AreEqual(true, sql.Contains($"z.{p.GetQuotedColumnName("文1")}"));
-        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("h")}.{p.GetQuotedColumnName("文1")}"));
-        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("z")}.{p.GetQuotedColumnName("丢失")}"));
+        Assert.AreEqual(true, sql.Contains($"z.{p.GetQuotedColumnName("State")}"));
+        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("h")}.{p.GetQuotedColumnName("State")}"));
+        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("z")}.{p.GetQuotedColumnName("Loss")}"));
+        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("z")}.{p.GetQuotedColumnName("Color")}"));
     }
 }

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTestsJoinAliasTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTestsJoinAliasTests.cs
@@ -1,0 +1,140 @@
+﻿using System.Diagnostics;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests;
+
+public partial class OrmLiteSelectTests
+{
+    [Alias("实体_配置")]
+    class Channel
+    {
+        [Alias("编码"), Index]
+        public string Id { get; set; }
+        [Alias("名称")]
+        public string Name { get; set; }
+        [Alias("区域编码")]
+        public string Area { get; set; }
+        [Alias("类型"), Index]
+        public NttType DstType { get; set; }
+        [Alias("删除状态")]
+        public int Delete { get; set; }
+    }
+
+    [Alias("实体_状态")]
+    class BaseResult
+    {
+        [Alias("编码"), PrimaryKey]
+        public string Id { get; set; }
+
+        [Alias("目标编码")]
+        public string Code { get; set; }
+
+        [Alias("目标类型")]
+        public virtual NttType DstType { get; set; }
+
+        [Alias("状态类型")]
+        public string ResultType { get; set; }
+
+        [Alias("检测项类型")]
+        public virtual TestType Type { get; set; }
+    }
+
+    class VqdStateResult : BaseResult
+    {
+        [Alias("丢失")]
+        public int 丢失状态 { get; set; }
+        [Alias("失色")]
+        public int 失色状态 { get; set; }
+    }
+
+    class OcrResult : BaseResult
+    {
+
+    }
+
+    class LinkResult : BaseResult
+    {
+        [Alias("文1")]
+        public StateType State { get; set; } = StateType.未知;
+    }
+
+    [Alias("框架_区域")]
+    class Region
+    {
+        [Alias("编码"), StringLength(60), PrimaryKey]
+        public string Id { get; set; }
+        [Alias("类型")]
+        public int Type { get; set; } = 0;
+    }
+
+    public enum StateType
+    {
+        未知 = -1
+    }
+
+    enum TestType
+    {
+        Vqd,
+        Osd,
+        Link
+    }
+
+    enum NttType
+    {
+        Channel
+    }
+
+    [Test]
+    public void Can_JoinAlias_In_Expression()
+    {
+        // DbFactory.DialectProvider = MySqlDialect.Provider;
+        // DbFactory.ConnectionString = "Server=82.157.15.104;Port=3306;User Id=root;Password=tnT1R*k0+Eku;Database=demo-ormlite;Pooling=true;Allow User Variables=True;SslMode=none;";
+
+        using var db = OpenDbConnection();
+        db.DropAndCreateTable<Channel>();
+        db.DropAndCreateTable<VqdStateResult>();
+        db.DropAndCreateTable<Region>();
+
+        if (!db.ColumnExists<LinkResult>(x => x.State))
+            db.AddColumn<LinkResult>(x => x.State);
+
+        var sqlExpression = db
+            .From<Channel>(x =>
+            {
+                x.UseSelectPropertiesAsAliases = true;
+                x.UseJoinTypeAsAliases = true;
+            })
+            .LeftJoin<Channel, Region>((x, y) => x.Area == y.Id)
+            .LeftJoin<Channel, VqdStateResult>(
+                (x, z) => x.Id == z.Code && (z.Type == TestType.Vqd) && (z.DstType == NttType.Channel),
+                new TableOptions()
+                {
+                    Alias = "z"
+                })
+            .LeftJoin<Channel, OcrResult>(
+                (x, m) => x.Id == m.Code && m.Type == TestType.Osd && m.DstType == NttType.Channel, new TableOptions()
+                {
+                    Alias = "m"
+                })
+            .LeftJoin<Channel, LinkResult>(
+                (x, h) => x.Id == h.Code && h.Type == TestType.Link && h.DstType == NttType.Channel, new TableOptions()
+                {
+                    Alias = "h"
+                })
+            .Where(x => x.DstType == NttType.Channel && x.Delete == 0)
+            .Select<Channel, Region, VqdStateResult, OcrResult, LinkResult>((x, y, z, m, h) => new
+            {
+                y.Type,
+                LinkState = Sql.TableAlias(h.State, "z").ToString(),
+                LinkState1 = h.State.ToString(),
+                z.丢失状态
+            });
+
+        var p = db.GetDialectProvider();
+        var sql = sqlExpression.ToMergedParamsSelectStatement();
+        Assert.AreEqual(true, sql.Contains($"z.{p.GetQuotedColumnName("文1")}"));
+        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("h")}.{p.GetQuotedColumnName("文1")}"));
+        Assert.AreEqual(true, sql.Contains($"{p.GetQuotedColumnName("z")}.{p.GetQuotedColumnName("丢失")}"));
+    }
+}


### PR DESCRIPTION
## Motivation
Consider the following code snippet(from OrmLiteSelectTestsJoinAliasTests.cs)
```csharp
  var sqlExpression = db
            .From<Channel>(x =>
            {
                x.UseSelectPropertiesAsAliases = true;
                x.UseJoinTypeAsAliases = false;//Feature flag
            })
            .LeftJoin<Channel, Region>((x, y) => x.Area == y.Id)
            .LeftJoin<Channel, VqdStateResult>(
                (x, z) => x.Id == z.Code && (z.Type == TestType.Vqd) && (z.DstType == NttType.Channel),
                new TableOptions()
                {
                    Alias = "z"
                })
            .LeftJoin<Channel, OcrResult>(
                (x, m) => x.Id == m.Code && m.Type == TestType.Osd && m.DstType == NttType.Channel, new TableOptions()
                {
                    Alias = "m"
                })
            .LeftJoin<Channel, LinkResult>(
                (x, h) => x.Id == h.Code && h.Type == TestType.Link && h.DstType == NttType.Channel, new TableOptions()
                {
                    Alias = "h"
                })
            .Where(x => x.DstType == NttType.Channel && x.Delete == 0)
            .Select<Channel, Region, VqdStateResult, OcrResult, LinkResult>((x, y, z, m, h) => new
            {
                y.Type,
                LinkState = Sql.TableAlias(h.State, "z").ToString(),
                LinkState1 = h.State.ToString(),
                Loss = z.Loss,
                Color = z.Color,
            });
```
Before, this would generate SQL(mysql) like
```sql
SELECT
	`Region`.`Type` AS `Type`,
	cast(
	z.`State` AS CHAR ( 1000 )) AS `LinkState`,
	cast(
	`BaseResult`.`State` AS CHAR ( 1000 )) AS `LinkState1`,
	`BaseResult`.`Loss` AS `Loss`,
	`BaseResult`.`Color` AS `Color` 
FROM
	`Channel`
	LEFT JOIN `Region` ON ( `Channel`.`Area` = `Region`.`Id` )
	LEFT JOIN `BaseResult` `z` ON (((
				`Channel`.`Id` = `z`.`Code` 
				) 
			AND ( `z`.`Type` = 'Vqd' )) 
	AND ( `z`.`DstType` = 'Channel' ))
	LEFT JOIN `BaseResult` `m` ON (((
				`Channel`.`Id` = `m`.`Code` 
				) 
			AND ( `m`.`Type` = 'Osd' )) 
	AND ( `m`.`DstType` = 'Channel' ))
	LEFT JOIN `BaseResult` `h` ON (((
				`Channel`.`Id` = `h`.`Code` 
				) 
			AND ( `h`.`Type` = 'Link' )) 
	AND ( `h`.`DstType` = 'Channel' )) 
WHERE
	((
			`Channel`.`DstType` = 'Channel' 
		) 
	AND ( `Channel`.`Delete` = 0 ))
```
Among them, the SQL composed of the following codes uses type aliases, and they do not respect the aliases set for types during Join
```csharp
...
LinkState1 = h.State.ToString(),
Loss = z.Loss,
Color = z.Color,
...
```
This change allows the last Select to respect the alias set for the type in the Join by adding the UseJoinTypeAsAliases option, which will generate correct SQL(mysql) without using the cumbersome Sql.TableAlias function.
```sql
SELECT
	`Region`.`Type` AS `Type`,
	cast(
	z.`State` AS CHAR ( 1000 )) AS `LinkState`,
	cast(
	`h`.`State` AS CHAR ( 1000 )) AS `LinkState1`,
	`z`.`Loss` AS `Loss`,
	`z`.`Color` AS `Color` 
FROM
	`Channel`
	LEFT JOIN `Region` ON ( `Channel`.`Area` = `Region`.`Id` )
	LEFT JOIN `BaseResult` `z` ON (((
				`Channel`.`Id` = `z`.`Code` 
				) 
			AND ( `z`.`Type` = 'Vqd' )) 
	AND ( `z`.`DstType` = 'Channel' ))
	LEFT JOIN `BaseResult` `m` ON (((
				`Channel`.`Id` = `m`.`Code` 
				) 
			AND ( `m`.`Type` = 'Osd' )) 
	AND ( `m`.`DstType` = 'Channel' ))
	LEFT JOIN `BaseResult` `h` ON (((
				`Channel`.`Id` = `h`.`Code` 
				) 
			AND ( `h`.`Type` = 'Link' )) 
	AND ( `h`.`DstType` = 'Channel' )) 
WHERE
	((
			`Channel`.`DstType` = 'Channel' 
		) 
	AND ( `Channel`.`Delete` = 0 ))
```
More details are in the unit tests (OrmLiteSelectTestsJoinAliasTests.cs).


EDIT:
Remove Chinese content
