### PR TITLE
Fix first element in list losing leading whitespace when deserialized

### DIFF
--- a/ServiceStack.Text/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
+++ b/ServiceStack.Text/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
@@ -67,11 +67,10 @@ namespace ServiceStack.Text.Common
 
             const int startQuotePos = 1;
             const int endQuotePos = 2;
-            var ret = value[0] == JsWriter.ListStartChar
+            var val = value[0] == JsWriter.ListStartChar
                     ? value.Slice(startQuotePos, value.Length - endQuotePos)
                     : value;
-            var val = ret.AdvancePastWhitespace();
-            if (val.Length == 0)
+            if (val.Length == 0 || val.AdvancePastWhitespace().Length == 0)
                 return TypeConstants.EmptyStringSpan;
             return val;
         }

--- a/ServiceStack.Text/tests/ServiceStack.Text.Tests/JsvTests/TypeSerializerToStringListTests.cs
+++ b/ServiceStack.Text/tests/ServiceStack.Text.Tests/JsvTests/TypeSerializerToStringListTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Northwind.Common.DataModel;
+using NUnit.Framework;
+using ServiceStack.Common.Tests.Models;
+
+namespace ServiceStack.Text.Tests.JsvTests
+{
+    [TestFixture]
+    public class TypeSerializerToStringListTests
+    {
+       [Test]
+        public void Can_serialize_values_with_whitespace()
+        {
+            var list = new List<string> { " A " };
+            var jsv = TypeSerializer.SerializeToString(list);
+            var deserializedList = TypeSerializer.DeserializeFromString<List<string>>(jsv);
+            Assert.That(list.First(), Is.EqualTo(deserializedList.First()));
+        }
+    }
+
+}


### PR DESCRIPTION
Found an issue where deserializing a list that had leading whitespace would lose the leading whitespace only on the first element.