### PR TITLE
Check each previously run migration before attempting to rerun

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Migrator.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Migrator.cs
@@ -82,8 +82,10 @@ public class Migrator
 
         Type? nextRun = null;
         var q = db.From<Migration>()
-            .OrderByDescending(x => x.Name).Limit(1);
-        var lastRun = db.Single(q);
+            .OrderByDescending(x => x.Name);
+        // Select all previously run migrations and find the last completed migration
+        var runMigrations = db.Select(q);
+        var lastRun = runMigrations.FirstOrDefault();
         if (lastRun != null)
         {
             var elapsedTime = DateTime.UtcNow - lastRun.CreatedDate;
@@ -113,11 +115,22 @@ public class Migrator
                 }
                 return null;
             }
-
+            
+            
             // Remove completed migrations
             completedMigrations = migrationTypes.Any(x => x.Name == lastRun.Name) 
                 ? migrationTypes.TakeWhile(x => x.Name != lastRun.Name).ToList()
                 : new List<Type>();
+            
+            // Make sure we don't rerun any migrations that have already been run
+            foreach (var migrationType in migrationTypes)
+            {
+                if (runMigrations.Any(x => x.Name == migrationType.Name && x.CompletedDate != null))
+                {
+                    completedMigrations.Add(migrationType);
+                }
+            }
+            
             if (completedMigrations.Count > 0)
                 migrationTypes.RemoveAll(x => completedMigrations.Contains(x));
 


### PR DESCRIPTION
Check each previously run migration to avoid the issue where multiple developers are working on the same shared development environment. Issue relates to the assumption that migration classes would not be deleted. If accidentally done, all previous migrations will attempt to be rerun. This was caused by only ever checking the last run migration via the `.Limit(1)` at the end of the query.

This change selects all rows in `Migration` to check against each known `migrationType` to validate if it needs to be rerun or not. Optionally, we could optimize to the last `N` migrations like `5` as this would be very unlikely to hit the same issue but I guess still possible.

Related to raised issue in [customer forums](https://forums.servicestack.net/t/migration-where-local-migration-class-es-not-present-in-current-project-caused-unexpected-behavior/11776/1)

