### PR TITLE
Fixing unhandled exception in sentinel worker

### DIFF
--- a/ServiceStack.Redis/src/ServiceStack.Redis/RedisSentinelWorker.cs
+++ b/ServiceStack.Redis/src/ServiceStack.Redis/RedisSentinelWorker.cs
@@ -134,6 +134,21 @@ internal class RedisSentinelWorker : IDisposable
 
     internal List<string> GetReplicaHosts(string masterName)
     {
+        try
+        {
+            return GetReplicaHostsInternal(masterName);
+        }
+        catch (Exception ex)
+        {
+            if (OnSentinelError != null)
+                OnSentinelError(ex);
+
+            return new List<string>();
+        }
+    }
+
+    private List<string> GetReplicaHostsInternal(string masterName)
+    {
         List<Dictionary<string, string>> sentinelReplicas;
 
         lock (oLock)

--- a/ServiceStack.Redis/tests/ServiceStack.Redis.Tests.Sentinel/RedisSentinelFailOverTests.cs
+++ b/ServiceStack.Redis/tests/ServiceStack.Redis.Tests.Sentinel/RedisSentinelFailOverTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NUnit.Framework;
+using ServiceStack.Logging;
+
+namespace ServiceStack.Redis.Tests.Sentinel
+{
+    [TestFixture, Category("Integration")]
+    public class RedisSentinelFailOverTests : RedisSentinelTestBase
+    {
+        [OneTimeSetUp]
+        public void OnBeforeTestFixture()
+        {
+            StartAllRedisServers();
+            StartAllRedisSentinels();
+            LogManager.LogFactory = new ConsoleLogFactory(debugEnabled:true);
+        }
+
+        [OneTimeTearDown]
+        public void OnAfterTestFixture()
+        {
+            ShutdownAllRedisSentinels();
+            ShutdownAllRedisServers();
+        }
+        
+        [Test]
+        public void Can_Handle_First_Sentinel_Down()
+        {
+            var sentinel = new RedisSentinel(SentinelHosts)
+            {
+                RedisManagerFactory = (masters, replicas) => new PooledRedisClientManager(masters, replicas)
+            };
+
+            var redisManager = sentinel.Start();
+
+            var cacheKey = Guid.NewGuid().ToString();
+
+            var client = new RedisClient("127.0.0.1", SentinelPorts[0]);
+            client.ShutdownNoSave();
+            
+            using var readOnlyClient = redisManager.GetReadOnlyClient();
+
+            readOnlyClient.Get<long>(cacheKey);
+        }
+    }
+}


### PR DESCRIPTION
Unhandled exception when getting a ready-only client from PooledRedisClientManager when the first of multiple sentinel hosts is down.