### PR TITLE
Update FirebirdOrmLiteDialectProvider to include ToTableNamesStatement

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -853,6 +853,18 @@ namespace ServiceStack.OrmLite.Firebird
             $"ALTER TABLE {GetQuotedTableName(table, schema)} DROP {GetQuotedColumnName(column)};";
 
         public override string SqlConcat(IEnumerable<object> args) => string.Join(" || ", args);
+
+  	public override string ToTableNamesStatement(string schema)
+        {
+            var sql = "SELECT TRIM(RDB$RELATION_NAME) AS TABLE_NAME FROM RDB$RELATIONS WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NULL";
+
+            if (!string.IsNullOrEmpty(schema))
+            {
+                sql += " AND TRIM(RDB$OWNER_NAME) = '{0}'".SqlFmt(this, schema);
+            }
+
+            return sql;
+        }
     }
 }
 


### PR DESCRIPTION
Allows for scaffolding crud endpoints using Autoquery.

N.B: It trims whitespace from the table names since RDB$RELATION_NAME is CHAR(31) which pads the string with spaces. This will cause scaffolding to fail on tables like '__EFMigrationsHistory'.

This was just a quick fix I had to implement while trying to test ServiceStack today. Might be a better way to accomplish this with a better understanding of the framework.