### PR TITLE
AutoQueryGrid's CRUD Create Fails due to missing primary key on model…

### DIFF
--- a/ServiceStack/src/ServiceStack.Client/MetadataTypes.cs
+++ b/ServiceStack/src/ServiceStack.Client/MetadataTypes.cs
@@ -1518,7 +1518,7 @@ public static class AppMetadataUtils
 
     public static PropertyInfo[] GetInstancePublicProperties(this Type type)
     {
-        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance )
             .OnlySerializableProperties(type)
             .Where(t =>
                 t.GetIndexParameters().Length == 0 && // ignore indexed properties


### PR DESCRIPTION
If you define a model that has an inherited primary key, the blazor auto query grid will be unable to locate the primary key and will throw an error as the method that traverses the properties has a DeclaredOnly flag.  This PR removes that flag: 

BindingFlags.Public | BindingFlags.Instance

Example:

```
public abstract class BaseUserEntity : IHaveUserId
  {
      [AutoIncrement]
      [PrimaryKey]
      public long Id { get; set; }
      public string ApplicationUserId { get; set; }
  }
  public class ApiKey : BaseUserEntity
 {
     public Guid Key { get; set; }
     public bool Expired { get; set; } = false;
     public StorageLevel StorageLevel { get; set; }
     public string Name { get; set; }
 }
<AutoQueryGrid Model="ApiKey" Apis="Apis.AutoQuery<ApiKeyQuery, ApiKeyCreate>()" >  

```

The ApiKeyCreate which enables a button that opens a window will throw an error.  Placing the Primary key directly on the model class is a workaround.