### PR TITLE
Update path utils to safeguard whitespaces.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -303,7 +303,7 @@
  - [nhalm](https://github.com/et1975)
  - [scottmcarthur](https://github.com/scottmcarthur) (Scott McArthur)
  - [siliconrob](https://github.com/Siliconrob) (Robin Michael)
-
+ - [tungtle001](https://github.com/tungtle001) (Tung Le)
 
 
 

--- a/ServiceStack.Text/src/ServiceStack.Text/PathUtils.cs
+++ b/ServiceStack.Text/src/ServiceStack.Text/PathUtils.cs
@@ -83,7 +83,7 @@ public static class PathUtils
     {
         foreach (var path in paths)
         {
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrWhiteSpace(path))
                 continue;
 
             if (sb.Length > 0 && sb[sb.Length - 1] != '/')
@@ -124,7 +124,7 @@ public static class PathUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)] //only trim/allocate if need to
     private static string TrimEndIf(this string path, char[] chars)
     {
-        if (string.IsNullOrEmpty(path) || chars == null || chars.Length == 0)
+        if (string.IsNullOrWhiteSpace(path) || chars == null || chars.Length == 0)
             return path;
                 
         var lastChar = path[path.Length - 1];
@@ -140,7 +140,7 @@ public static class PathUtils
     {
         if (path == null)
             path = "";
-        if (string.IsNullOrEmpty(withPath))
+        if (string.IsNullOrWhiteSpace(withPath))
             return path;
         var startPath = path.TrimEndIf(Slashes);
         return startPath + (withPath[0] == '/' ? withPath : "/" + withPath);

--- a/ServiceStack.Text/tests/ServiceStack.Text.Tests/CombinePathTests.cs
+++ b/ServiceStack.Text/tests/ServiceStack.Text.Tests/CombinePathTests.cs
@@ -32,6 +32,13 @@ namespace ServiceStack.Text.Tests
         }
 
         [Test]
+        public void Doesnt_combine_path_with_whitespace_or_forward_slash()
+        {
+            Assert.That("a".CombineWith(" "), Is.EqualTo("a"));
+            Assert.That("a".CombineWith("b/", " ", "/c"), Is.EqualTo("a/b/c"));
+        }
+
+        [Test]
         public void Can_resolve_paths()
         {
             Assert.That("/a/b/../".ResolvePaths(), Is.EqualTo("/a/"));


### PR DESCRIPTION
Updated path combining to safeguard from whitespaces in addition to the existing null and empty checks. This is so it doesn't combine unnecessary whitespaces and forward slashes to the path.