### PR TITLE
Add missing ServiceStack.OrmLite.Oracle.Core.csproj

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.Core.csproj
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.Core.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <AssemblyName>ServiceStack.OrmLite.Oracle</AssemblyName>
+    <PackageId>ServiceStack.OrmLite.Oracle</PackageId>
+    <Title>OrmLite.Oracle - Fast, code-first, config-free POCO ORM</Title>
+    <PackageDescription>
+      Light, simple and fast convention-based code-first POCO ORM for Oracle RDBMS (Unofficial).
+      Support for Creating and Dropping Table Schemas from POCOs, Complex Property types transparently
+      stored in schemaless text blobs in Oracle.
+    </PackageDescription>
+    <PackageTags>Oracle;OrmLite;RDBMS;SQL;POCO;Code-First;ORM;Schema-less;Blobs</PackageTags>
+    <DefineConstants>$(DefineConstants);ASYNC</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.130" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\ServiceStack\src\ServiceStack.Common\ServiceStack.Common.Core.csproj" />
+    <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.Core.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Update="OracleCommand.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="OracleConnection.cs">
+      <SubType>Component</SubType>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteConfig.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteConfig.cs
@@ -98,6 +98,14 @@ namespace ServiceStack.OrmLite
             }
         }
 
+        public static void SetLastCommand(this IDbConnection db, IDbCommand dbCmd)
+        {
+            if (db is OrmLiteConnection ormLiteConn)
+            {
+                ormLiteConn.LastCommand = dbCmd;
+            }
+        }
+
         private const string RequiresOrmLiteConnection = "{0} can only be set on a OrmLiteConnectionFactory connection, not a plain IDbConnection";
 
         /// <summary>

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteConnection.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteConnection.cs
@@ -22,6 +22,7 @@ namespace ServiceStack.OrmLite
 
         public IOrmLiteDialectProvider DialectProvider { get; set; }
         public string LastCommandText { get; set; }
+        public IDbCommand LastCommand { get; set; }
 
         /// <summary>
         /// Gets or sets the wait time before terminating the attempt to execute a command and generating an error(in seconds).

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteExecFilter.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteExecFilter.cs
@@ -40,6 +40,7 @@ namespace ServiceStack.OrmLite
                 ? (ormLiteConn.CommandTimeout ?? OrmLiteConfig.CommandTimeout) 
                 : OrmLiteConfig.CommandTimeout;
 
+            ormLiteConn.SetLastCommand(dbCmd);
             ormLiteConn.SetLastCommandText(null);
 
             return ormLiteConn != null
@@ -53,6 +54,7 @@ namespace ServiceStack.OrmLite
 
             OrmLiteConfig.AfterExecFilter?.Invoke(dbCmd);
 
+            dbConn.SetLastCommand(dbCmd);
             dbConn.SetLastCommandText(dbCmd.CommandText);
 
             dbCmd.Dispose();
@@ -90,6 +92,7 @@ namespace ServiceStack.OrmLite
             var ret = filter(dbCmd);
             if (dbCmd != null)
             {
+                dbConn.SetLastCommand(dbCmd);
                 dbConn.SetLastCommandText(dbCmd.CommandText);
             }
             return ret;

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteWriteApi.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/OrmLiteWriteApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -17,6 +17,85 @@ namespace ServiceStack.OrmLite
         public static string GetLastSql(this IDbConnection dbConn)
         {
             return dbConn is OrmLiteConnection ormLiteConn ? ormLiteConn.LastCommandText : null;
+        }
+
+        /// <summary>
+        /// Get the last SQL statement that was executed (include parameters).
+        /// </summary>
+        public static string GetMergedParamsLastSql(this IDbConnection dbConn)
+        {
+            if (dbConn is OrmLiteConnection ormLiteConn)
+            {
+                var dbCmd= ormLiteConn.LastCommand;
+                var commandText = dbCmd.CommandText;
+                var dialectProvider = ormLiteConn.GetDialectProvider();
+                foreach (IDataParameter parameter in dbCmd.Parameters)
+                {
+                    var type = GetTypeFromDbType(parameter.DbType);
+                    commandText= commandText.Replace(parameter.ParameterName, dialectProvider.GetQuotedValue(parameter.Value,type));
+                }
+
+                return commandText;
+            }
+            else
+            {
+                return null;
+            }
+
+            static Type GetTypeFromDbType(DbType dbType)
+            {
+                switch (dbType)
+                {
+                    case DbType.Binary:
+                        return typeof(byte[]);
+                    case DbType.Byte:
+                        return typeof(byte);
+                    case DbType.Boolean:
+                        return typeof(bool);
+                    case DbType.Currency:
+                        return typeof(decimal);
+                    case DbType.Date:
+                    case DbType.DateTime:
+                    case DbType.DateTime2:
+                    case DbType.DateTimeOffset:
+                        return typeof(DateTime);
+                    case DbType.Decimal:
+                        return typeof(decimal);
+                    case DbType.Double:
+                        return typeof(double);
+                    case DbType.Guid:
+                        return typeof(Guid);
+                    case DbType.Int16:
+                        return typeof(short);
+                    case DbType.Int32:
+                        return typeof(int);
+                    case DbType.Int64:
+                        return typeof(long);
+                    case DbType.SByte:
+                        return typeof(sbyte);
+                    case DbType.Single:
+                        return typeof(float);
+                    case DbType.String:
+                    case DbType.AnsiString:
+                    case DbType.AnsiStringFixedLength:
+                    case DbType.StringFixedLength:
+                    case DbType.Xml:
+                        return typeof(string);
+                    case DbType.Time:
+                        return typeof(TimeSpan);
+                    case DbType.UInt16:
+                        return typeof(ushort);
+                    case DbType.UInt32:
+                        return typeof(uint);
+                    case DbType.UInt64:
+                        return typeof(ulong);
+                    case DbType.VarNumeric:
+                        return typeof(decimal);
+                    case DbType.Object:
+                    default:
+                        return typeof(object);
+                }
+            }
         }
 
         public static string GetLastSqlAndParams(this IDbCommand dbCmd)


### PR DESCRIPTION
1. Other libraries such as ``Mysql``, ``MysqlConnector``, etc. all have ``*.Core`` versions.

2. There is currently a ``GetLastSql`` extension function, but this is not intuitive for sql with parameters, and it can even be said to be meaningless, because even if the sql is obtained from the log, no verification and debugging can be performed at the database level.
Therefore, relevant infrastructure has been added so that complete sql statements can be obtained