### PR TITLE
Allow to deserialize unknown sub type

### DIFF
--- a/ServiceStack.Text/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/ServiceStack.Text/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -127,13 +127,13 @@ public static class DeserializeType<TSerializer>
 
             var type = JsConfig.TypeFinder(typeName);
 
-            JsWriter.AssertAllowedRuntimeType(type);
-
             if (type == null)
             {
                 Tracer.Instance.WriteWarning("Could not find type: " + typeName);
                 return null;
             }
+
+            JsWriter.AssertAllowedRuntimeType(type);
 
             return ReflectionOptimizer.Instance.UseType(type);
         }

--- a/ServiceStack/tests/ServiceStack.Common.Tests/DeserializeTypeTests.cs
+++ b/ServiceStack/tests/ServiceStack.Common.Tests/DeserializeTypeTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using ServiceStack.Text;
+using ServiceStack.Text.Common;
+using ServiceStack.Text.Json;
+
+namespace ServiceStack.Common.Tests;
+
+[TestFixture]
+public class DeserializeTypeTests
+{
+    [Test]
+    public void UnknownType_Returns_Null()
+    {
+        const string typeName =
+            @"{""__type"": ""ServiceStack.Common.Tests.DeserializeTypeTests+InnerStub2, ServiceStack.Common.Tests""}";
+        var type = DeserializeType<JsonTypeSerializer>.ExtractType(typeName);
+        Assert.That(type, Is.Null);
+    }
+
+    [Test]
+    public void KnownType_Returns_TheType()
+    {
+        const string typeName =
+            @"{""__type"": ""ServiceStack.Common.Tests.DeserializeTypeTests+InnerStub, ServiceStack.Common.Tests""}";
+        var type = DeserializeType<JsonTypeSerializer>.ExtractType(typeName);
+        Assert.That(type == typeof(InnerStub));
+    }
+    
+    [Test]
+    public void ArrayThatContainsUnknownType_ShouldContainNullItem()
+    {
+        const string json =
+            @"{""Stubs"": [{""__type"": ""ServiceStack.Common.Tests.DeserializeTypeTests+InnerStub2, ServiceStack.Common.Tests""}]}";
+        var stub = JsonSerializer.DeserializeFromString<Stub>(json);
+        Assert.That(stub.Stubs, Is.Not.Null);
+        Assert.That(stub.Stubs.Count, Is.EqualTo(1));
+        Assert.That(stub.Stubs[0], Is.Null);
+    }
+    
+    [Test]
+    public void ArrayThatContainsKnownType_ShouldContainItem()
+    {
+        const string json =
+            @"{""Stubs"": [{""__type"": ""ServiceStack.Common.Tests.DeserializeTypeTests+InnerStub, ServiceStack.Common.Tests""}]}";
+        var stub = JsonSerializer.DeserializeFromString<Stub>(json);
+        Assert.That(stub.Stubs, Is.Not.Null);
+        Assert.That(stub.Stubs.Count, Is.EqualTo(1));
+        Assert.That(stub.Stubs[0], Is.Not.Null);
+    }
+
+    private interface IInnerStub { }
+    
+    [Serializable]
+    private class Stub
+    {
+        public List<IInnerStub> Stubs { get; set; }
+    }
+
+    [Serializable]
+    private class InnerStub : IInnerStub
+    {
+    }
+}


### PR DESCRIPTION
During my update from ServiceStack 5.9.2 to 8.2.2 I figured out that the behavior changed.
The test ArrayThatContainsUnknownType_ShouldContainNullItem that's failing without the fix explains my issue. (       Assert.That(stub.Stubs, Is.Not.Null);)

To be coherent with DeserializeTypeRefJson., You can check the nullability of the type before calling AssertAllowedRuntimeType which fails with an exception