### PR TITLE
fix ProfilingFeature.cs NullReferenceException

### DIFF
--- a/ServiceStack/src/ServiceStack/ProfilingFeature.cs
+++ b/ServiceStack/src/ServiceStack/ProfilingFeature.cs
@@ -532,7 +532,7 @@ public sealed class ProfilerDiagnosticObserver(ProfilingFeature feature) :
 
     private object ReadHttpContent(System.Net.Http.HttpContent? content)
     {
-        content.LoadIntoBufferAsync().Wait(); //TODO find better way to buffer HttpContent so doesn't fail when reread from client
+        content?.LoadIntoBufferAsync().Wait(); //TODO find better way to buffer HttpContent so doesn't fail when reread from client
         
         var requestBody = content?.ReadAsString();
         if (requestBody == null) 


### PR DESCRIPTION
System.NullReferenceException:“Object reference not set to an instance of an object
issue source code
![image](https://github.com/user-attachments/assets/adcca1f0-c468-4c6a-beb4-b6d7c673b6c0)
I found this issue when creating azure blob's  Container
![image](https://github.com/user-attachments/assets/cdca8f4d-55fb-4dec-b41c-75c9f2d4dcca)
