### PR TITLE
Support evaluate InvocationExpression like MethodCallExpression

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1634,6 +1634,8 @@ namespace ServiceStack.OrmLite
                     return VisitParameter(exp as ParameterExpression);
                 case ExpressionType.Call:
                     return VisitMethodCall(exp as MethodCallExpression);
+                case ExpressionType.Invoke:
+                    return VisitInvocation(exp as InvocationExpression);
                 case ExpressionType.New:
                     return VisitNew(exp as NewExpression);
                 case ExpressionType.NewArrayInit:
@@ -2482,7 +2484,11 @@ namespace ServiceStack.OrmLite
                    && IsJoinedTable(exp.Expression.Type);
         }
 
-
+        protected virtual object VisitInvocation(InvocationExpression m)
+        {
+            return EvaluateExpression(m);
+        }
+        
         protected virtual object VisitMethodCall(MethodCallExpression m)
         {
             if (m.Method.DeclaringType == typeof(Sql))

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -893,6 +893,21 @@ public class ExpressionVisitorTests(DialectContext context) : OrmLiteProvidersTe
         var target = Db.Select(q);
         Assert.That(target.Count, Is.EqualTo(0));
     }
+    
+    [Test]
+    public void Can_evaluate_invoke_expression()
+    {
+        System.Func<string> getValueWithFunc = () => "val";
+        System.Func<int, string> getValue1WithFunc = (id) => "val" + id;
+
+        var q = Db.From<TestType>().Where(t => t.TextCol.Contains(getValueWithFunc()));
+        var sql = q.ToMergedParamsSelectStatement();
+        Assert.True(!sql.Contains("%Invoke"));
+                
+        q = Db.From<TestType>().Where(t => t.TextCol.Contains(getValue1WithFunc(1)));
+        sql = q.ToMergedParamsSelectStatement();
+        Assert.True(!sql.Contains("%Invoke"));
+    }
 
     private int MethodReturningInt(int val)
     {


### PR DESCRIPTION
I accidentally found that ormlite generated incorrect sql for ``Func<T>`` related calls. This modification solved the problem, but I am not sure if there are any omissions or hidden dangers. Please check it out. 

Thank you