### PR TITLE
using >=6.0.0 for net6.0 reference (instead of 8.0.0).

### DIFF
--- a/ServiceStack.Text/src/Directory.Build.props
+++ b/ServiceStack.Text/src/Directory.Build.props
@@ -56,4 +56,17 @@
     <DefineConstants>DEBUG</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <MicrosoftFamilyLibraryVersions>8.0.0</MicrosoftFamilyLibraryVersions>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <MicrosoftFamilyLibraryVersions>8.0.0</MicrosoftFamilyLibraryVersions>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <MicrosoftFamilyLibraryVersions>6.0.0</MicrosoftFamilyLibraryVersions>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <MicrosoftFamilyLibraryVersions>8.0.0</MicrosoftFamilyLibraryVersions>
+  </PropertyGroup>
+
 </Project>

--- a/ServiceStack.Text/src/ServiceStack.Text/ServiceStack.Text.Core.csproj
+++ b/ServiceStack.Text/src/ServiceStack.Text/ServiceStack.Text.Core.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftFamilyLibraryVersions)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' ">
   </ItemGroup>

--- a/ServiceStack.Text/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/ServiceStack.Text/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -27,14 +27,14 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftFamilyLibraryVersions)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftFamilyLibraryVersions)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' ">
   </ItemGroup>


### PR DESCRIPTION
using >=6.0.0 for net6.0 reference (instead of 8.0.0)

the azure functions runtime doesn't handle 8.0.0 references in a 6.0 runtime. Not sure why, but it doesn't.