### PR TITLE
Coalesce with nullable bool

### DIFF
--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/ConditionalExpressionTest.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/ConditionalExpressionTest.cs
@@ -197,8 +197,6 @@ public class ConditionalExpressionTest(DialectContext context) : ExpressionsTest
 	[Test]
 	public void Can_use_coalesce_with_nullable_bool()
 	{
-		var dateTime = DateTime.Now.Date;
-
 		using var db = OpenDbConnection();
 		db.Insert(new TestType { NullableBoolColumn = true });
 		db.Insert(new TestType { NullableBoolColumn = false });
@@ -221,7 +219,7 @@ public class ConditionalExpressionTest(DialectContext context) : ExpressionsTest
 		Assert.That(rows3.Count, Is.EqualTo(1));
 		Assert.That(rows4.Count, Is.EqualTo(1));
 
-		if ((Dialect.AnySqlServer).HasFlag(Dialect))
+		if (Dialect.AnySqlServer.HasFlag(Dialect))
 		{
 			StringAssert.Contains("=", q1.WhereExpression, "An expression of non-boolean type specified in a context where a condition is expected, near ')'.");
 			StringAssert.Contains("=", q2.WhereExpression, "An expression of non-boolean type specified in a context where a condition is expected, near ')'.");

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/ConditionalExpressionTest.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/ConditionalExpressionTest.cs
@@ -193,4 +193,39 @@ public class ConditionalExpressionTest(DialectContext context) : ExpressionsTest
         Assert.That(rows.Count, Is.EqualTo(1));
         Assert.That(q.Params.Count, Is.EqualTo(2),  "The second \"dateTime\" constant is not transformed into Sql param.");
     }
+
+	[Test]
+	public void Can_use_coalesce_with_nullable_bool()
+	{
+		var dateTime = DateTime.Now.Date;
+
+		using var db = OpenDbConnection();
+		db.Insert(new TestType { NullableBoolColumn = true });
+		db.Insert(new TestType { NullableBoolColumn = false });
+		db.Insert(new TestType { NullableBoolColumn = null });
+
+		var q1 = db.From<TestType>().Where(q => q.NullableBoolColumn ?? false);
+		var rows1 = db.Select(q1);
+
+		var q2 = db.From<TestType>().Where(q => (q.NullableBoolColumn ?? false) == false);
+		var rows2 = db.Select(q2);
+
+		var q3 = db.From<TestType>().Where(q => (q.NullableBoolColumn ?? false) == true);
+		var rows3 = db.Select(q3);
+
+		var q4 = db.From<TestType>().Where(q => q.NullableBoolColumn == null);
+		var rows4 = db.Select(q4);
+
+		Assert.That(rows1.Count, Is.EqualTo(1));
+		Assert.That(rows2.Count, Is.EqualTo(2));
+		Assert.That(rows3.Count, Is.EqualTo(1));
+		Assert.That(rows4.Count, Is.EqualTo(1));
+
+		if ((Dialect.AnySqlServer).HasFlag(Dialect))
+		{
+			StringAssert.Contains("=", q1.WhereExpression, "An expression of non-boolean type specified in a context where a condition is expected, near ')'.");
+			StringAssert.Contains("=", q2.WhereExpression, "An expression of non-boolean type specified in a context where a condition is expected, near ')'.");
+			StringAssert.Contains("=", q3.WhereExpression, "An expression of non-boolean type specified in a context where a condition is expected, near ')'.");
+		}
+	}
 }

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/TestType.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/Expression/TestType.cs
@@ -11,8 +11,9 @@ public class TestType
     public object NullableCol { get; set; }
     public TimeSpan TimeSpanColumn { get; set; }
     public DateTime? Date { get; set; }
+	public bool? NullableBoolColumn { get; set; }
 
-    [AutoIncrement]
+	[AutoIncrement]
     public int Id { get; set; }
 
     public bool Equals(TestType other)


### PR DESCRIPTION
MS Sql doesn't support the statements like this:

```sql
SELECT * FROM _mytable
WHERE not COALESCE(_is_bool, 0)
```

It has to be:
```sql
SELECT * FROM _mytable
WHERE COALESCE(_is_bool, 0) = 0
```

There is unit test in this PR: 
`Can_use_coalesce_with_nullable_bool`