### PR TITLE
Set GatewayRequest.Files from IRequest in FromRequest

### DIFF
--- a/ServiceStack/src/ServiceStack/Host/GatewayRequest.cs
+++ b/ServiceStack/src/ServiceStack/Host/GatewayRequest.cs
@@ -88,6 +88,7 @@ public class GatewayRequest : BasicRequest, IHttpRequest, IConvertRequest, IClon
             XForwardedProtocol = httpReq?.XForwardedProtocol,
             XRealIp = httpReq?.XRealIp,
             Accept = httpReq?.Accept,
+            Files = req.Files,
         };
         ret.PathInfo = req.PathInfo ?? ret.PathInfo;
         ret.AbsoluteUri = req.AbsoluteUri ?? ret.AbsoluteUri;


### PR DESCRIPTION
Currently when making a call through the Gateway the Files from the Request object is not set on the GatewayRequest