### PR TITLE
Pass inner exception to exceptions thrown in JsonApiClient

### DIFF
--- a/ServiceStack/src/ServiceStack.Client/JsonApiClient.cs
+++ b/ServiceStack/src/ServiceStack.Client/JsonApiClient.cs
@@ -803,7 +803,7 @@ public class JsonApiClient : IJsonServiceClient, IHasCookieContainer, IServiceCl
         }
         catch (Exception e)
         {
-            throw CreateException(httpRes, e);
+            throw CreateException(e);
         }
 
         if (!httpRes.IsSuccessStatusCode)
@@ -821,7 +821,7 @@ public class JsonApiClient : IJsonServiceClient, IHasCookieContainer, IServiceCl
         }
         catch (Exception e)
         {
-            throw CreateException(httpRes, e);
+            throw CreateException(e);
         }
 
         if (!httpRes.IsSuccessStatusCode)
@@ -846,7 +846,7 @@ public class JsonApiClient : IJsonServiceClient, IHasCookieContainer, IServiceCl
         return response;
     }
 
-    private static WebServiceException CreateException(HttpResponseMessage httpRes, Exception ex) => new();
+    private static WebServiceException CreateException(Exception ex) => new(ex.Message, ex);
 
     readonly ConcurrentDictionary<Type, Action<HttpResponseMessage, object?, string, object?>> responseHandlers = new();
 


### PR DESCRIPTION
When during `JsonApiClient.SendAsync` an exception was thrown, it was catched and instead an `WebServiceException` thrown. The original exception was ignored, same for the `HttpResponseMessage` which was passed to the internal `CreateException` method.

We had cases where the request itself was successful with a HTTP 200, but an `WebServiceException` was thrown. What we saw in (OpenTelemetry) logs:

exception.message:
```
Exception of type 'ServiceStack.WebServiceException' was thrown.
```

exception.stacktrace:
```
500 Code: Exception of type 'ServiceStack.WebServiceException' was thrown., Message: Exception of type 'ServiceStack.WebServiceException' was thrown.
```

This PR passes the actual exception as inner exception to the created `WebServiceException` and also sets the message to the message of the inner exception, so that there is an exception in case `ResponseStatus.Message` is not available.