### PR TITLE
If path is rooted ignore Content Root Path

### DIFF
--- a/ServiceStack/src/ServiceStack.Jobs/BackgroundsJobFeature.cs
+++ b/ServiceStack/src/ServiceStack.Jobs/BackgroundsJobFeature.cs
@@ -110,7 +110,10 @@ public class BackgroundsJobFeature : IPlugin, Model.IHasStringId, IConfigureServ
         var monthDb = DbMonthFile(createdDate);
         if (!OrmLiteConnectionFactory.NamedConnections.ContainsKey(monthDb))
         {
-            var dataSource = AppHost.HostingEnvironment.ContentRootPath.CombineWith(DbDir, monthDb);
+            var dataSource =  Path.IsPathRooted(DbDir) 
+                ? Path.Combine(DbDir, monthDb)
+                : AppHost.HostingEnvironment.ContentRootPath.CombineWith(DbDir, monthDb);
+                
             dbFactory.RegisterConnection(monthDb, $"DataSource={dataSource};Cache=Shared", SqliteDialect.Provider);
             var db = dbFactory.OpenDbConnection(monthDb);
             InitMonthDbSchema(db);

--- a/ServiceStack/src/ServiceStack.Jobs/SqliteRequestLogger.cs
+++ b/ServiceStack/src/ServiceStack.Jobs/SqliteRequestLogger.cs
@@ -284,7 +284,9 @@ public class SqliteRequestLogger : InMemoryRollingRequestLogger, IRequiresSchema
         var monthDb = DbMonthFile(createdDate);
         if (!OrmLiteConnectionFactory.NamedConnections.ContainsKey(monthDb))
         {
-            var dataSource = AppHost.HostingEnvironment.ContentRootPath.CombineWith(DbDir, monthDb);
+            var dataSource =  Path.IsPathRooted(DbDir) 
+                            ? Path.Combine(DbDir, monthDb)
+                            : AppHost.HostingEnvironment.ContentRootPath.CombineWith(DbDir, monthDb);
             dbFactory.RegisterConnection(monthDb, $"DataSource={dataSource};Cache=Shared", SqliteDialect.Provider);
             var db = dbFactory.OpenDbConnection(monthDb);
             InitMonthDbSchema(db, createdDate);


### PR DESCRIPTION
Fixes an issue where if the DbDir is a root path that the monthly database doesn't get incorrectly prefixed with the content root path of the app