### PR TITLE
Update Dart NativeTypes generator and add tests

### DIFF
--- a/ServiceStack/src/ServiceStack/NativeTypes/Dart/DartGenerator.cs
+++ b/ServiceStack/src/ServiceStack/NativeTypes/Dart/DartGenerator.cs
@@ -105,7 +105,42 @@ public class DartGenerator : ILangGenerator
         {"DateOnly", "DateTime(0)"},
         {"DateTimeOffset", "DateTime(0)"},
     };
-        
+
+    // Default values that are compile-time constants in Dart (safe for constructor params)
+    public static readonly HashSet<string> ConstDefaultValues =
+    [
+        "0", "false", declaredEmptyString,
+    ];
+
+    /// Returns a const-safe default value for a required property, or null if none exists.
+    /// Used for field initializers and constructor params where only compile-time constants are valid.
+    /// When forConstructor is true, collection defaults are prefixed with "const".
+    string GetConstDefault(MetadataPropertyType prop, MetadataType type, bool forConstructor = false)
+    {
+        var propType = GetPropertyType(prop);
+        propType = PropertyTypeFilter?.Invoke(this, type, prop) ?? propType;
+        if (prop.IsEnumerable() && feature.ShouldInitializeCollection(type))
+        {
+            var val = prop.IsDictionary() ? "{}" : "[]";
+            return forConstructor ? $"const {val}" : val;
+        }
+        if (DefaultValues.TryGetValue(propType, out var defaultValue) && ConstDefaultValues.Contains(defaultValue))
+            return defaultValue;
+        return null;
+    }
+
+    /// Returns a runtime default value for a required property in fromMap deserialization, or null if none exists.
+    /// Unlike GetConstDefault, this allows non-const values like DateTime(0).
+    string GetRuntimeDefault(MetadataPropertyType prop)
+    {
+        var propType = GetPropertyType(prop);
+        if (DefaultValues.TryGetValue(propType, out var dv))
+            return dv;
+        if (prop.IsEnumerable())
+            return prop.IsDictionary() ? "{}" : "[]";
+        return null;
+    }
+
     static HashSet<string> BasicJsonTypes =
     [
         nameof(String),
@@ -391,9 +426,10 @@ public class DartGenerator : ILangGenerator
         {
             defaultImports.AddIfNotExists("dart:collection");
         }
-        if (allTypes.Any(x => x.Properties?.Any(p => p.Type == "Byte[]") == true)
-            || requestTypes.Any(x => x.RequestType?.ReturnType?.Name == "Byte[]")
-            || responseTypes.Any(x => x.Name == "Byte[]"))
+        var uint8ListTypes = new[] { "Byte[]", "Stream", "HttpWebResponse" };
+        if (allTypes.Any(x => x.Properties?.Any(p => uint8ListTypes.Contains(p.Type)) == true)
+            || requestTypes.Any(x => uint8ListTypes.Contains(x.RequestType?.ReturnType?.Name))
+            || responseTypes.Any(x => uint8ListTypes.Contains(x.Name)))
         {
             defaultImports.AddIfNotExists("dart:typed_data");
         }
@@ -711,24 +747,29 @@ public class DartGenerator : ILangGenerator
                     sb.AppendLine($"void operator []=(int index, {genericArg} value) {{ l[index] = value; }}");
                 }
 
-                var sbBody = StringBuilderCacheAlt.Allocate();
                 if (props.Count > 0)
                 {
+                    var ctorParams = new List<string>();
                     foreach (var prop in props)
                     {
-                        if (sbBody.Length == 0)
-                            sbBody.Append(typeNameWithoutGenericArgs + "({");
-                        else
-                            sbBody.Append(",");
-                        sbBody.Append($"this.{GetSafePropertyName(prop)}");
+                        var paramName = $"this.{GetSafePropertyName(prop)}";
                         if (!string.IsNullOrEmpty(prop.Value))
                         {
-                            sbBody.Append("=" + prop.Value);
+                            ctorParams.Add($"{paramName}={prop.Value}");
+                        }
+                        else
+                        {
+                            var constDefault = !IsPropertyOptional(this, type, prop) ? GetConstDefault(prop, type, forConstructor: true) : null;
+                            ctorParams.Add(constDefault != null ? $"{paramName}={constDefault}" : paramName);
                         }
                     }
-                    if (sbBody.Length > 0)
+                    if (ctorParams.Count > 0)
                     {
-                        sb.AppendLine(StringBuilderCacheAlt.ReturnAndFree(sbBody) + "});");
+                        sb.AppendLine($"{typeNameWithoutGenericArgs}({{{ctorParams.Join(",")}}});");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{typeNameWithoutGenericArgs}();");
                     }
                 }
                 else
@@ -738,19 +779,19 @@ public class DartGenerator : ILangGenerator
 
                 if (props.Count > 0)
                 {
-                    sbBody = StringBuilderCacheAlt.Allocate();
-                    sbBody.Append(typeNameWithoutGenericArgs + ".fromJson(Map<String, dynamic> json)");
-                    sbBody.Append(" { fromMap(json); }");
-                    sb.AppendLine(StringBuilderCacheAlt.ReturnAndFree(sbBody));
+                    var sbFromJson = StringBuilderCacheAlt.Allocate();
+                    sbFromJson.Append(typeNameWithoutGenericArgs + ".fromJson(Map<String, dynamic> json)");
+                    sbFromJson.Append(" { fromMap(json); }");
+                    sb.AppendLine(StringBuilderCacheAlt.ReturnAndFree(sbFromJson));
                     sb.AppendLine();
                 }
                 else
                 {
-                    sb.AppendLine(typeNameWithoutGenericArgs + ".fromJson(Map<String, dynamic> json) : " + 
+                    sb.AppendLine(typeNameWithoutGenericArgs + ".fromJson(Map<String, dynamic> json) : " +
                                   (hasDtoBaseClass ? "super.fromJson(json);" : "super();"));
                 }
 
-                sbBody = StringBuilderCacheAlt.Allocate();
+                var sbBody = StringBuilderCacheAlt.Allocate();
                 sbBody.AppendLine("fromMap(Map<String, dynamic> json) {");
                 if (hasDtoBaseClass)
                     sbBody.AppendLine("        super.fromMap(json);");
@@ -759,6 +800,8 @@ public class DartGenerator : ILangGenerator
                     var propType = GetPropertyType(prop);
                     var jsonName = prop.Name.PropertyStyle();
                     var propName = GetSafePropertyName(prop);
+                    var runtimeDefault = !IsPropertyOptional(this, type, prop) ? GetRuntimeDefault(prop) : null;
+                    var defaultSuffix = runtimeDefault != null ? $" ?? {runtimeDefault}" : "";
                     if (UseTypeConversion(prop))
                     {
                         bool registerType = true;
@@ -781,18 +824,18 @@ public class DartGenerator : ILangGenerator
                         {
                             RegisterPropertyType(prop, propType);
                         }
-                            
-                        sbBody.AppendLine($"        {propName} = JsonConverters.fromJson(json['{jsonName}'],'{propType}',context!);");
+
+                        sbBody.AppendLine($"        {propName} = JsonConverters.fromJson(json['{jsonName}'],'{propType}',context!){defaultSuffix};");
                     }
                     else
                     {
                         if (DartToJsonConverters.TryGetValue(propType, out var conversionFn))
                         {
-                            sbBody.AppendLine($"        {propName} = JsonConverters.{conversionFn}(json['{jsonName}']);");
+                            sbBody.AppendLine($"        {propName} = JsonConverters.{conversionFn}(json['{jsonName}']){defaultSuffix};");
                         }
                         else
                         {
-                            sbBody.AppendLine($"        {propName} = json['{jsonName}'];");
+                            sbBody.AppendLine($"        {propName} = json['{jsonName}']{defaultSuffix};");
                         }
                     }
                 }
@@ -1032,24 +1075,12 @@ public class DartGenerator : ILangGenerator
                 PrePropertyFilter?.Invoke(sb, prop, type);
 
                 var isRequired = !IsPropertyOptional(this, type, prop);
-                string initializer = "";
-                if (isRequired)
-                {
-                    if (prop.IsEnumerable() && feature.ShouldInitializeCollection(type))
-                    {
-                        initializer = prop.IsDictionary()
-                            ? " = {}"
-                            : " = []";
-                    }
-                    else if (DefaultValues.TryGetValue(propType, out var defaultValue))
-                    {
-                        initializer = " = " + defaultValue;
-                    }
-                }
-                propType = isRequired 
-                    ? propType 
-                    : propType + "?";
-                
+                var constDefault = isRequired ? GetConstDefault(prop, type) : null;
+                var initializer = constDefault != null ? $" = {constDefault}" : "";
+                if (isRequired && constDefault == null)
+                    isRequired = false; // No const-safe default available, fall back to nullable
+                propType = isRequired ? propType : propType + "?";
+
                 sb.AppendLine($"{propType} {GetSafePropertyName(prop)}{initializer};");
                 PostPropertyFilter?.Invoke(sb, prop, type);
             }

--- a/ServiceStack/tests/ServiceStack.Common.Tests/NativeTypesTests.cs
+++ b/ServiceStack/tests/ServiceStack.Common.Tests/NativeTypesTests.cs
@@ -443,12 +443,65 @@ public class NativeTypesTests
         Assert.That(src, Does.Contain("String string = \"\";"));
         Assert.That(src, Does.Contain("String? nString;"));
         Assert.That(src, Does.Contain("String nRequiredString = \"\";"));
-        Assert.That(src, Does.Contain("OptionalClass optionalClass;"));
+        Assert.That(src, Does.Contain("OptionalClass? optionalClass;"));
         Assert.That(src, Does.Contain("OptionalClass? nOptionalClass;"));
-        Assert.That(src, Does.Contain("OptionalClass nRequiredOptionalClass;"));
-        Assert.That(src, Does.Contain("OptionalEnum optionalEnum;"));
+        Assert.That(src, Does.Contain("OptionalClass? nRequiredOptionalClass;"));
+        Assert.That(src, Does.Contain("OptionalEnum? optionalEnum;"));
         Assert.That(src, Does.Contain("OptionalEnum? nOptionalEnum;"));
-        Assert.That(src, Does.Contain("OptionalEnum nRequiredOptionalEnum;"));
+        Assert.That(src, Does.Contain("OptionalEnum? nRequiredOptionalEnum;"));
+    }
+
+    [Test]
+    public void Does_generate_dart_constructor_with_correct_nullability()
+    {
+        var src = (string) appHost.ExecuteService(new TypesDart { IncludeTypes = ["DartConstructorTest"] });
+
+        // Non-nullable value type fields should have default initializers
+        Assert.That(src, Does.Contain("double latitude = 0;"));
+        Assert.That(src, Does.Contain("double longitude = 0;"));
+        Assert.That(src, Does.Contain("int count = 0;"));
+
+        // Non-nullable string field should have default initializer
+        Assert.That(src, Does.Contain("String name = \"\";"));
+
+        // Nullable fields should have ? suffix and no initializer
+        Assert.That(src, Does.Contain("String? notes;"));
+        Assert.That(src, Does.Contain("double? score;"));
+        Assert.That(src, Does.Contain("bool? cancelled;"));
+
+        // Nullable class should have ? suffix
+        Assert.That(src, Does.Contain("OptionalClass? nOptionalClass;"));
+
+        // Non-nullable class/enum/DateTime with no const default falls back to nullable
+        Assert.That(src, Does.Contain("OptionalClass? optionalClass;"));
+        Assert.That(src, Does.Contain("DateTime? timestamp;"));
+        Assert.That(src, Does.Contain("DateTime? nTimestamp;"));
+
+        // Constructor: non-nullable value types should have const defaults in constructor params
+        Assert.That(src, Does.Contain("this.latitude=0"));
+        Assert.That(src, Does.Contain("this.longitude=0"));
+        Assert.That(src, Does.Contain("this.count=0"));
+        Assert.That(src, Does.Contain("this.name=\"\""));
+
+        // Constructor: nullable types should NOT have defaults (implicit null is fine)
+        Assert.That(src, Does.Contain("this.notes,") | Does.Contain("this.notes}"));
+        Assert.That(src, Does.Contain("this.score,") | Does.Contain("this.score}"));
+        Assert.That(src, Does.Contain("this.cancelled,") | Does.Contain("this.cancelled}"));
+
+        // Constructor: collections should use const default
+        Assert.That(src, Does.Contain("this.tags=const []"));
+
+        // Constructor: types without const default are nullable, included as optional params
+        Assert.That(src, Does.Not.Contain("required this."));
+        Assert.That(src, Does.Contain("this.optionalClass,") | Does.Contain("this.optionalClass}"));
+        Assert.That(src, Does.Contain("this.timestamp,") | Does.Contain("this.timestamp}"));
+
+        // fromMap: non-nullable fields with converters should use ?? default
+        Assert.That(src, Does.Contain("JsonConverters.toDouble(json['latitude']) ?? 0;"));
+        Assert.That(src, Does.Contain("JsonConverters.toDouble(json['longitude']) ?? 0;"));
+        // fromMap: nullable fields should NOT have ?? default
+        Assert.That(src, Does.Not.Contain("json['notes']) ?? "));
+        Assert.That(src, Does.Not.Contain("json['score']) ?? "));
     }
 
     [Test]
@@ -520,6 +573,47 @@ public class OptionalTest : IReturn<OptionalTest>
 public class OptionalService : Service
 {
     public object Any(OptionalTest request) => request;
+    public object Any(DartConstructorTest request) => request;
+}
+
+[DataContract]
+public class DartConstructorTest : IReturn<DartConstructorTest>
+{
+    [DataMember(Name = "latitude")]
+    public double Latitude { get; set; }
+
+    [DataMember(Name = "longitude")]
+    public double Longitude { get; set; }
+
+    [DataMember(Name = "name")]
+    public string Name { get; set; }
+
+    [DataMember(Name = "count")]
+    public int Count { get; set; }
+
+    [DataMember(Name = "notes")]
+    public string? Notes { get; set; }
+
+    [DataMember(Name = "score")]
+    public double? Score { get; set; }
+
+    [DataMember(Name = "cancelled")]
+    public bool? Cancelled { get; set; }
+
+    [DataMember(Name = "tags")]
+    public List<string> Tags { get; set; }
+
+    [DataMember(Name = "timestamp")]
+    public DateTime Timestamp { get; set; }
+
+    [DataMember(Name = "nTimestamp")]
+    public DateTime? NTimestamp { get; set; }
+
+    [DataMember(Name = "optionalClass")]
+    public OptionalClass OptionalClass { get; set; }
+
+    [DataMember(Name = "nOptionalClass")]
+    public OptionalClass? NOptionalClass { get; set; }
 }
 
 public class Dto : IReturn<DtoResponse>


### PR DESCRIPTION
Updated Dart generation to handle differences in how properties are initialized if not nullable as currently it is invalid. 

Added additional detection for `dart:typed_data` as needed if using Stream. Tested against project with a lot of type variation.

I saw the [release notes regarding Add ServiceStack reference](https://docs.servicestack.net/releases/v10_00#add-servicestack-reference) and though you could just use nullable all the properties like v8, this still retains some of the benefits and falls back to nullable.

Let me know if I've missed a use case for different dart versions.  Tested in flutter project using Flutter 3.29.2, Dart 3.7.2 and DevTools 2.42.3.