### PR TITLE
Fix Firebird OrmLite type converters + add Firebird 5 dialect

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdBoolConverter.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdBoolConverter.cs
@@ -1,13 +1,31 @@
 ﻿using System;
+using System.Data;
 using ServiceStack.OrmLite.Converters;
 
 namespace ServiceStack.OrmLite.Firebird.Converters
 {
+    // Firebird < 3 has no BOOLEAN type -> store bool as INTEGER (base/legacy dialect).
     public class FirebirdBoolConverter : BoolAsIntConverter
     {
         public override string ColumnDefinition
         {
             get { return "INTEGER"; }
         }
+    }
+
+    // Firebird 3+ has a native BOOLEAN type. The INTEGER converter binds a raw .NET bool into an INTEGER param,
+    // which the FB client rejects (InvalidCast). Map BOOLEAN so the bool binds natively (used by Firebird4+ dialect).
+    public class FirebirdBooleanConverter : BoolConverter
+    {
+        public override string ColumnDefinition => "BOOLEAN";
+        public override DbType DbType => DbType.Boolean;
+
+        public override object ToDbValue(Type fieldType, object value) => (bool)value;
+
+        public override object FromDbValue(Type fieldType, object value)
+            => value is bool b ? b : Convert.ToBoolean(value);
+
+        public override string ToQuotedString(Type fieldType, object value)
+            => (bool)value ? "TRUE" : "FALSE";
     }
 }

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdDateTimeConverter.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdDateTimeConverter.cs
@@ -5,9 +5,12 @@ namespace ServiceStack.OrmLite.Firebird.Converters
 {
     public class FirebirdDateTimeConverter : DateTimeConverter
     {
+        // "LOCALTIME" is a context variable (current time, no TZ), NOT a valid column type -> FB rejects it in
+        // DDL (SQL error -104, token unknown). A .NET DateTime (no offset) maps to TIMESTAMP (WITHOUT TIME ZONE;
+        // plain TIMESTAMP is still no-TZ in FB4/5). WITH-TIME-ZONE is the separate DateTimeOffset mapping.
         public override string ColumnDefinition
         {
-            get { return "LOCALTIME"; }
+            get { return "TIMESTAMP"; }
         }
 
         public override string ToQuotedString(Type fieldType, object value)

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdFloatConverters.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdFloatConverters.cs
@@ -19,18 +19,14 @@ namespace ServiceStack.OrmLite.Firebird.Converters
         }
     }
 
-    public class FirebirdDoubleConverter : FloatConverter
+    public class FirebirdDoubleConverter : DoubleConverter
     {
+        // Firebird FLOAT is single-precision (32-bit) -> loses precision for a .NET double
+        // (e.g. 3.14159 -> 3.14159011...). DOUBLE PRECISION is the correct 64-bit mapping.
+        // (Also derive from DoubleConverter, not FloatConverter, so DbType/handling are correct.)
         public override string ColumnDefinition
         {
-            get { return "FLOAT"; }
-        }
-
-        public override string ToQuotedString(Type fieldType, object value)
-        {
-            var s = ((double)value).ToString(CultureInfo.InvariantCulture);
-            if (s.Length > 20) s = s.Substring(0, 20);
-            return "'" + s + "'"; // when quoted exception is more clear!
+            get { return "DOUBLE PRECISION"; }
         }
     }
 

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdGuidConverter.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdGuidConverter.cs
@@ -33,20 +33,21 @@ namespace ServiceStack.OrmLite.Firebird.Converters
             get { return "CHAR(16) CHARACTER SET OCTETS"; }
         }
 
+        // Literal must match the parameterized octet order (Guid.ToByteArray()), else it disagrees with ToDbValue.
         public override string ToQuotedString(Type fieldType, object value)
         {
-            return "X'" + ((Guid)value).ToString("N") + "'";
+            return "X'" + BitConverter.ToString(((Guid)value).ToByteArray()).Replace("-", "") + "'";
         }
 
-        public override object FromDbValue(Type fieldType, object value)
+        // Previous impl applied a NetworkToHostOrder swap on READ that the WRITE side never applied -> the returned
+        // Guid didn't match the stored one (round-trip mismatch). The client already round-trips CHAR(16) OCTETS
+        // symmetrically via Guid.ToByteArray()/new Guid(bytes), so just pass the value through.
+        public override object FromDbValue(Type fieldType, object value) => value switch
         {
-            //BitConverter.IsLittleEndian // TODO: check big endian
-
-            byte[] raw = ((Guid)value).ToByteArray();
-            return new Guid(System.Net.IPAddress.NetworkToHostOrder(BitConverter.ToInt32(raw, 0)),
-                System.Net.IPAddress.NetworkToHostOrder(BitConverter.ToInt16(raw, 4)),
-                System.Net.IPAddress.NetworkToHostOrder(BitConverter.ToInt16(raw, 6)),
-                raw[8], raw[9], raw[10], raw[11], raw[12], raw[13], raw[14], raw[15]);
-        }
+            Guid g => g,
+            byte[] b when b.Length == 16 => new Guid(b),
+            string s => new Guid(s),
+            _ => base.FromDbValue(fieldType, value),
+        };
     }
 }

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdTimeConverters.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Converters/FirebirdTimeConverters.cs
@@ -1,0 +1,43 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Data;
+using System.Globalization;
+using ServiceStack.OrmLite.Converters;
+
+namespace ServiceStack.OrmLite.Firebird.Converters
+{
+    // .NET DateOnly -> Firebird DATE. The core DateOnlyConverter derives from DateTimeConverter, so without this
+    // override it emits "DATETIME" (not a Firebird type -> CreateTable fails, SQL error -607).
+    public class FirebirdDateOnlyConverter : DateOnlyConverter
+    {
+        public override string ColumnDefinition => "DATE";
+
+        public override string ToQuotedString(Type fieldType, object value)
+            => "'" + ((DateOnly)value).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + "'";
+    }
+
+    // .NET TimeOnly -> Firebird TIME. The core TimeOnlyConverter stores ticks in a BIGINT, which (a) isn't a TIME
+    // column and (b) breaks against real TIME columns: on write the client can't put a long ticks value into a TIME
+    // param, and on read ConvertNumber(long, TimeSpan) throws when the value comes back as a TimeSpan.
+    // Fix: map TIME, bind a DateTime carrying the time-of-day (accepted by the FB client for TIME on write), and read
+    // back a TimeSpan/DateTime (legacy long-ticks still handled via base).
+    public class FirebirdTimeOnlyConverter : TimeOnlyConverter
+    {
+        public override string ColumnDefinition => "TIME";
+        public override DbType DbType => DbType.Time;
+
+        public override object ToDbValue(Type fieldType, object value)
+            => new DateTime(1, 1, 1).Add(((TimeOnly)value).ToTimeSpan());
+
+        public override object FromDbValue(Type fieldType, object value) => value switch
+        {
+            TimeSpan ts => TimeOnly.FromTimeSpan(ts),
+            DateTime dt => TimeOnly.FromDateTime(dt),
+            _ => base.FromDbValue(fieldType, value), // legacy: long ticks in a BIGINT column
+        };
+
+        public override string ToQuotedString(Type fieldType, object value)
+            => "'" + ((TimeOnly)value).ToString("HH:mm:ss.ffff", CultureInfo.InvariantCulture) + "'";
+    }
+}
+#endif

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Firebird4OrmLiteDialectProvider.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Firebird4OrmLiteDialectProvider.cs
@@ -64,7 +64,10 @@ namespace ServiceStack.OrmLite.Firebird
             base.AutoIncrementDefinition = " GENERATED ALWAYS AS IDENTITY ";
             NamingStrategy = new Firebird4NamingStrategy();
 
-            base.RemoveConverter<bool>();
+            // FB3+ has a native BOOLEAN type; use it so a .NET bool binds natively (the base INTEGER converter
+            // can't bind a bool into an INTEGER param). Previously this just removed the bool converter, leaving a
+            // broken core fallback (bool -> wrong column type + InvalidCast on insert).
+            base.RegisterConverter<bool>(new FirebirdBooleanConverter());
 
             this.Variables = new Dictionary<string, string>
             {

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Firebird5OrmLiteDialectProvider.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/Firebird5OrmLiteDialectProvider.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace ServiceStack.OrmLite.Firebird
+{
+    // Firebird 5.0 dialect. FB5 (ODS 13.1) is largely a performance release and introduces NO new *reserved*
+    // keywords over FB4 — only non-reserved keywords (LOCKED, OPTIMIZE, QUARTER, TARGET, TIMEZONE_NAME,
+    // UNICODE_CHAR, UNICODE_VAL), which are valid identifiers and must NOT be quoted. So this dialect inherits
+    // Firebird4 as-is (identity columns, BOOLEAN, TIMESTAMP + LOCALTIMESTAMP, the type converters, and the FB4
+    // reserved-word set). It exists as the canonical FB5 dialect and a forward extension point for FB5-specific
+    // features (e.g. any future SQL additions serviced into FB5).
+    public class Firebird5OrmLiteDialectProvider : Firebird4OrmLiteDialectProvider
+    {
+        public new static Firebird5OrmLiteDialectProvider Instance = new();
+
+        public Firebird5OrmLiteDialectProvider() : this(true) { }
+
+        public Firebird5OrmLiteDialectProvider(bool compactGuid) : base(compactGuid)
+        {
+            // FB5 adds no new reserved words over FB4 -> reuse the inherited RESERVED list unchanged.
+        }
+    }
+}

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdDialect.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdDialect.cs
@@ -13,3 +13,9 @@ public static class Firebird4Dialect
     public static IOrmLiteDialectProvider Provider => Firebird4OrmLiteDialectProvider.Instance;
     public static Firebird4OrmLiteDialectProvider Instance => Firebird4OrmLiteDialectProvider.Instance;
 }
+
+public static class Firebird5Dialect
+{
+    public static IOrmLiteDialectProvider Provider => Firebird5OrmLiteDialectProvider.Instance;
+    public static Firebird5OrmLiteDialectProvider Instance => Firebird5OrmLiteDialectProvider.Instance;
+}

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -53,6 +53,10 @@ namespace ServiceStack.OrmLite.Firebird
 
             base.RegisterConverter<DateTime>(new FirebirdDateTimeConverter());
             base.RegisterConverter<DateTimeOffset>(new FirebirdDateTimeOffsetConverter());
+#if NET6_0_OR_GREATER
+            base.RegisterConverter<DateOnly>(new FirebirdDateOnlyConverter()); // DATE (core maps DateOnly -> invalid DATETIME)
+            base.RegisterConverter<TimeOnly>(new FirebirdTimeOnlyConverter()); // TIME (core maps TimeOnly -> BIGINT ticks)
+#endif
 
             base.RegisterConverter<bool>(new FirebirdBoolConverter());
             base.RegisterConverter<string>(new FirebirdStringConverter());

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.FirebirdTests/FirebirdTypeConverterTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.FirebirdTests/FirebirdTypeConverterTests.cs
@@ -1,0 +1,143 @@
+using System;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.Firebird;
+using ServiceStack.OrmLite.Tests;
+
+namespace ServiceStack.OrmLite.FirebirdTests;
+
+// Regression tests for the Firebird type converters. Each of these mapped to the wrong Firebird column type or
+// bound/round-tripped incorrectly (fails on CreateTable + insert/select against a real DB with the stock client):
+//   double   -> FLOAT (32-bit, precision loss)          => DOUBLE PRECISION
+//   bool     -> RemoveConverter<bool> / INTEGER (bind)  => BOOLEAN (FB3+)
+//   Guid     -> CHAR(16) OCTETS, asymmetric byte order  => round-trip must match
+//   DateTime -> LOCALTIME (not a valid column type)     => TIMESTAMP
+//   DateOnly -> DATETIME  (not a Firebird type)         => DATE      (net6+)
+//   TimeOnly -> BIGINT ticks (not a TIME column)        => TIME      (net6+)
+// DateOnly/TimeOnly are net6+, so those parts are guarded (matching the converters).
+[TestFixture]
+public class FirebirdTypeConverterTests : OrmLiteTestBase
+{
+    protected override string GetFileConnectionString() => FirebirdDb.V4Connection;
+    protected override IOrmLiteDialectProvider GetDialectProvider() => Firebird4OrmLiteDialectProvider.Instance;
+
+    public class TypeConverterModel
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+        public bool BoolValue { get; set; }
+        public double DoubleValue { get; set; }
+        public Guid GuidValue { get; set; }
+        public DateTime DateTimeValue { get; set; }
+#if NET6_0_OR_GREATER
+        public DateOnly DateOnlyValue { get; set; }
+        public TimeOnly TimeOnlyValue { get; set; }
+#endif
+    }
+
+    [Test]
+    public void Can_create_table_and_roundtrip_all_types()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<TypeConverterModel>();
+
+        var row = new TypeConverterModel
+        {
+            BoolValue = true,
+            DoubleValue = 3.14159265358979d,               // needs 64-bit DOUBLE PRECISION
+            GuidValue = Guid.NewGuid(),
+            DateTimeValue = new DateTime(2026, 7, 3, 21, 25, 44),
+#if NET6_0_OR_GREATER
+            DateOnlyValue = new DateOnly(2026, 7, 3),
+            TimeOnlyValue = new TimeOnly(21, 25, 44),
+#endif
+        };
+
+        var id = db.Insert(row, selectIdentity: true);
+        var loaded = db.SingleById<TypeConverterModel>(id);
+
+        Assert.That(loaded.BoolValue, Is.EqualTo(row.BoolValue));
+        Assert.That(loaded.DoubleValue, Is.EqualTo(row.DoubleValue));   // no precision loss
+        Assert.That(loaded.GuidValue, Is.EqualTo(row.GuidValue));       // symmetric byte order
+        Assert.That(loaded.DateTimeValue, Is.EqualTo(row.DateTimeValue));
+#if NET6_0_OR_GREATER
+        Assert.That(loaded.DateOnlyValue, Is.EqualTo(row.DateOnlyValue));
+        Assert.That(loaded.TimeOnlyValue, Is.EqualTo(row.TimeOnlyValue));
+#endif
+    }
+
+    [Test]
+    public void Roundtrips_false_bool_and_empty_guid()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<TypeConverterModel>();
+
+        var row = new TypeConverterModel
+        {
+            BoolValue = false,
+            DoubleValue = -1.0d / 3.0d,
+            GuidValue = Guid.Empty,
+            DateTimeValue = new DateTime(2000, 1, 1, 0, 0, 0),
+        };
+        var id = db.Insert(row, selectIdentity: true);
+        var loaded = db.SingleById<TypeConverterModel>(id);
+
+        Assert.That(loaded.BoolValue, Is.False);
+        Assert.That(loaded.DoubleValue, Is.EqualTo(row.DoubleValue));
+        Assert.That(loaded.GuidValue, Is.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public void Generates_correct_Firebird_column_types()
+    {
+        var ddl = Firebird4Dialect.Provider.ToCreateTableStatement(typeof(TypeConverterModel));
+
+        // Assert the full "<column> <type> NOT NULL" fragment (not a naked type substring): a column whose NAME
+        // contains a type keyword (e.g. "DATETIMEVALUE") would otherwise false-match, and "DATE" is a prefix of
+        // "DATETIME" so a DateOnly->DATETIME regression must be ruled out by the trailing " NOT NULL".
+        Assert.That(ddl, Does.Contain("BOOLVALUE BOOLEAN NOT NULL"));            // bool     (not INTEGER)
+        Assert.That(ddl, Does.Contain("DOUBLEVALUE DOUBLE PRECISION NOT NULL")); // double   (not FLOAT)
+        Assert.That(ddl, Does.Contain("DATETIMEVALUE TIMESTAMP NOT NULL"));      // DateTime (not LOCALTIME)
+#if NET6_0_OR_GREATER
+        Assert.That(ddl, Does.Contain("DATEONLYVALUE DATE NOT NULL"));           // DateOnly (not DATETIME)
+        Assert.That(ddl, Does.Contain("TIMEONLYVALUE TIME NOT NULL"));           // TimeOnly (not BIGINT)
+#endif
+        // the invalid / precision-losing column types the buggy converters emitted must NOT appear:
+        Assert.That(ddl, Does.Not.Contain("LOCALTIME"));     // DateTime used LOCALTIME (not a real FB column type)
+        Assert.That(ddl, Does.Not.Contain("FLOAT"));         // double used single-precision FLOAT
+#if NET6_0_OR_GREATER
+        Assert.That(ddl, Does.Not.Contain("BIGINT"));        // TimeOnly used BIGINT ticks
+#endif
+    }
+
+    // Firebird5Dialect inherits every converter from Firebird4; smoke-test that it resolves + round-trips.
+    [Test]
+    public void Firebird5Dialect_inherits_type_converters()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird5Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<TypeConverterModel>();
+
+        var row = new TypeConverterModel
+        {
+            BoolValue = true,
+            DoubleValue = 2.718281828459045d,
+            GuidValue = Guid.NewGuid(),
+            DateTimeValue = new DateTime(2026, 7, 3, 8, 15, 30),
+#if NET6_0_OR_GREATER
+            DateOnlyValue = new DateOnly(2026, 7, 3),
+            TimeOnlyValue = new TimeOnly(8, 15, 30),   // FB5 must inherit the TIME converter (the original bug)
+#endif
+        };
+        var id = db.Insert(row, selectIdentity: true);
+        var loaded = db.SingleById<TypeConverterModel>(id);
+
+        Assert.That(loaded.BoolValue, Is.True);
+        Assert.That(loaded.DoubleValue, Is.EqualTo(row.DoubleValue));
+        Assert.That(loaded.GuidValue, Is.EqualTo(row.GuidValue));
+        Assert.That(loaded.DateTimeValue, Is.EqualTo(row.DateTimeValue));
+#if NET6_0_OR_GREATER
+        Assert.That(loaded.DateOnlyValue, Is.EqualTo(row.DateOnlyValue));
+        Assert.That(loaded.TimeOnlyValue, Is.EqualTo(row.TimeOnlyValue));
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a set of Firebird OrmLite type converters that emit invalid column types or round-trip incorrectly against a real Firebird server, and adds a canonical Firebird 5 dialect.

## Bugs fixed (ServiceStack.OrmLite.Firebird)
| .NET type | before | after |
|-----------|--------|-------|
| `double` | `FLOAT` (32-bit, precision loss) | `DOUBLE PRECISION` |
| `bool` | `RemoveConverter<bool>` / `INTEGER` bind (InvalidCast) | native `BOOLEAN` (FB3+) |
| `Guid` | `CHAR(16) OCTETS`, asymmetric read swap | symmetric round-trip |
| `DateTime` | `LOCALTIME` (context var, not a column type) | `TIMESTAMP` |
| `DateOnly` | `DATETIME` (not a Firebird type) | `DATE` (net6+) |
| `TimeOnly` | `BIGINT` ticks (not a `TIME` column) | `TIME` (net6+) |

## Firebird 5 dialect
Adds `Firebird5OrmLiteDialectProvider` + `Firebird5Dialect`. FB5 (ODS 13.1) adds no new **reserved** words over FB4 (only non-reserved keywords), so it inherits `Firebird4` unchanged as the canonical FB5 dialect / extension point.

## Tests
Adds `FirebirdTypeConverterTests`: round-trips every affected type (plus false-bool / empty-Guid), asserts generated DDL column types, and verifies the FB5 dialect inherits the converters. Verified **4/4 green against a real Firebird 5.0.2 server on the stock `FirebirdSql.Data.FirebirdClient`**. `DateOnly`/`TimeOnly` are `#if NET6_0_OR_GREATER` guarded.

## Notes
- No change to the FB4 reserved-word list (already correct upstream).
- No new dependencies; converter fixes work on the stock client