### PR TITLE
docs: fix typo udpate -> update in OrmLite provider READMEs

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/README.md
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/README.md
@@ -131,7 +131,7 @@ Below is a complete example of how to use "SqlExpressionVisitor <T>" in OrmLite:
 				Console.WriteLine(ev.WhereExpression);
 				Console.WriteLine("Expected:{0} ; Selected:{1}, OK? {2}", expected, result.Count, expected==result.Count);
 			
-				//  enough selecting, lets udpate;
+				//  enough selecting, lets update;
 				
 				// set Active=false where rate =0
 				expected=2;

--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Oracle/README.md
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite.Oracle/README.md
@@ -131,7 +131,7 @@ Below is a complete example of how to use "SqlExpressionVisitor <T>" in OrmLite:
 				Console.WriteLine(ev.WhereExpression);
 				Console.WriteLine("Expected:{0} ; Selected:{1}, OK? {2}", expected, result.Count, expected==result.Count);
 			
-				//  enough selecting, lets udpate;
+				//  enough selecting, lets update;
 				
 				// set Active=false where rate =0
 				expected=2;


### PR DESCRIPTION
Typo fix in two OrmLite provider READMEs, both in the same example code comment:

- `ServiceStack.OrmLite/src/ServiceStack.OrmLite.Firebird/README.md:134`
- `ServiceStack.OrmLite/src/ServiceStack.OrmLite.Oracle/README.md:134`

"// enough selecting, lets udpate" -> "update". Comments only.
