### PR TITLE
Convert BigInteger in ConvertNumber (Firebird 4+ INT128)

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/IOrmLiteConverter.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/IOrmLiteConverter.cs
@@ -123,6 +123,51 @@ public static class OrmLiteConverterExtensions
             return value;
 
         var typeCode = toIntegerType.GetUnderlyingTypeCode();
+
+        // BigInteger does NOT implement IConvertible, so every Convert.ToX below throws
+        // InvalidCastException ("Unable to cast object of type 'System.Numerics.BigInteger' to type
+        // 'System.IConvertible'") instead of converting it.
+        //
+        // Providers do hand it back. Firebird 4+ has INT128 and widens SUM() of a BIGINT to it, which the
+        // stock FirebirdClient correctly surfaces as BigInteger. Measured on Firebird 5.0.4:
+        //     SUM(INTEGER)            -> Int64        SUM(BIGINT)             -> BigInteger
+        //     SUM(NUMERIC(18,0))      -> Decimal      SUM(OCTET_LENGTH(blob)) -> BigInteger
+        //     COUNT(*)                -> Int64
+        // So counting works and summing a BIGINT throws, at runtime, in whichever query hits it first -
+        // which is what makes it easy to miss. (OCTET_LENGTH of a BLOB is BIGINT, so summing blob sizes
+        // reproduces it without anything in the schema being declared INT128.)
+        //
+        // The casts below are checked, so a value genuinely too large for the target type still throws
+        // OverflowException - which is the correct answer, and not the same as silently truncating it.
+        if (value is System.Numerics.BigInteger bigInteger)
+        {
+            switch (typeCode)
+            {
+                case TypeCode.Byte:
+                    return (byte)bigInteger;
+                case TypeCode.SByte:
+                    return (sbyte)bigInteger;
+                case TypeCode.Int16:
+                    return (short)bigInteger;
+                case TypeCode.UInt16:
+                    return (ushort)bigInteger;
+                case TypeCode.Int32:
+                    return (int)bigInteger;
+                case TypeCode.UInt32:
+                    return (uint)bigInteger;
+                case TypeCode.Int64:
+                    return (long)bigInteger;
+                case TypeCode.UInt64:
+                    return (ulong)bigInteger;
+                case TypeCode.Single:
+                    return (float)bigInteger;
+                case TypeCode.Double:
+                    return (double)bigInteger;
+                case TypeCode.Decimal:
+                    return (decimal)bigInteger;
+            }
+        }
+
         switch (typeCode)
         {
             case TypeCode.Byte:

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.FirebirdTests/FirebirdInt128SumTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.FirebirdTests/FirebirdInt128SumTests.cs
@@ -1,0 +1,115 @@
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.Firebird;
+using ServiceStack.OrmLite.Tests;
+
+namespace ServiceStack.OrmLite.FirebirdTests;
+
+// Regression test for reading an aggregate off Firebird 4+.
+//
+// Firebird 4 introduced INT128 and widens SUM() of a BIGINT to it. The stock FirebirdClient correctly
+// surfaces INT128 as System.Numerics.BigInteger, but BigInteger does not implement IConvertible, so
+// ConvertNumber's Convert.ToInt64(value) threw
+//
+//     InvalidCastException: Unable to cast object of type 'System.Numerics.BigInteger'
+//                           to type 'System.IConvertible'
+//
+// rather than converting it.
+//
+// WHICH EXPRESSIONS WIDEN, measured on Firebird 5.0.4 - the distinction matters, because a test built on
+// the wrong one passes with or without the fix:
+//     SUM(SMALLINT)              -> Int64        (unaffected)
+//     SUM(INTEGER)               -> Int64        (unaffected)
+//     SUM(BIGINT)                -> BigInteger   <-- reproduces
+//     SUM(OCTET_LENGTH(blob))    -> BigInteger   <-- reproduces (OCTET_LENGTH of a BLOB is BIGINT)
+//     SUM(NUMERIC(18,0))         -> Decimal      (unaffected)
+//     COUNT(*)                   -> Int64        (unaffected)
+//
+// That last row is what made this easy to miss in the wild: counting worked, summing a BIGINT did not, and
+// only at runtime in whichever query happened to hit it first.
+[TestFixture]
+public class FirebirdInt128SumTests : OrmLiteTestBase
+{
+    protected override string GetFileConnectionString() => FirebirdDb.V4Connection;
+    protected override IOrmLiteDialectProvider GetDialectProvider() => Firebird4OrmLiteDialectProvider.Instance;
+
+    public class Int128SumModel
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        // BIGINT, so Firebird 4+ widens SUM() over it to INT128. An int column would NOT reproduce this.
+        public long LongValue { get; set; }
+    }
+
+    [Test]
+    public void Can_read_SUM_of_BIGINT_column_as_long()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<Int128SumModel>();
+
+        db.Insert(new Int128SumModel { LongValue = 10 });
+        db.Insert(new Int128SumModel { LongValue = 20 });
+        db.Insert(new Int128SumModel { LongValue = 12 });
+
+        // The call that threw. No CAST in the SQL on purpose: casting to BIGINT server-side is the
+        // workaround this fix exists to make unnecessary.
+        var total = db.Scalar<long>("SELECT SUM(LongValue) FROM Int128SumModel".SqlFmt(db.GetDialectProvider()));
+
+        Assert.That(total, Is.EqualTo(42L));
+    }
+
+    [Test]
+    public void Can_read_SUM_of_BIGINT_column_as_other_numeric_types()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<Int128SumModel>();
+
+        db.Insert(new Int128SumModel { LongValue = 7 });
+        db.Insert(new Int128SumModel { LongValue = 35 });
+
+        var sql = "SELECT SUM(LongValue) FROM Int128SumModel".SqlFmt(db.GetDialectProvider());
+
+        // Every target a caller may ask for goes through the same conversion, so each must handle INT128.
+        Assert.That(db.Scalar<int>(sql), Is.EqualTo(42));
+        Assert.That(db.Scalar<long>(sql), Is.EqualTo(42L));
+        Assert.That(db.Scalar<decimal>(sql), Is.EqualTo(42m));
+        Assert.That(db.Scalar<double>(sql), Is.EqualTo(42d));
+    }
+
+    [Test]
+    public void SUM_over_no_rows_reads_as_default()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<Int128SumModel>();
+
+        // SUM() over no rows is NULL, not zero - it must not be mistaken for a conversion failure.
+        var total = db.Scalar<long>("SELECT SUM(LongValue) FROM Int128SumModel".SqlFmt(db.GetDialectProvider()));
+
+        Assert.That(total, Is.EqualTo(0L));
+    }
+
+    // The shape that actually failed in production: summing OCTET_LENGTH over a BLOB column. OCTET_LENGTH
+    // returns BIGINT, so SUM() of it widens to INT128 even though nothing in the schema is declared INT128.
+    public class Int128BlobModel
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+        public byte[] Data { get; set; }
+    }
+
+    [Test]
+    public void Can_read_SUM_of_OCTET_LENGTH_over_a_BLOB_as_long()
+    {
+        using var db = new OrmLiteConnectionFactory(ConnectionString, Firebird4Dialect.Provider).OpenDbConnection();
+        db.DropAndCreateTable<Int128BlobModel>();
+
+        db.Insert(new Int128BlobModel { Data = new byte[100] });
+        db.Insert(new Int128BlobModel { Data = new byte[150] });
+
+        var total = db.Scalar<long>(
+            "SELECT SUM(OCTET_LENGTH(Data)) FROM Int128BlobModel".SqlFmt(db.GetDialectProvider()));
+
+        Assert.That(total, Is.EqualTo(250L));
+    }
+}

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
@@ -23,6 +23,46 @@ public class ConverterTests(DialectContext context) : OrmLiteProvidersTestBase(c
         Assert.That(convertedValue, Is.Null);
     }
 
+    // A provider may legitimately hand back a BigInteger: Firebird 4+ returns SUM() over an INTEGER as
+    // INT128, and the stock FirebirdClient surfaces INT128 as System.Numerics.BigInteger. BigInteger does
+    // NOT implement IConvertible, so Convert.ToInt64 and friends throw InvalidCastException on it instead of
+    // converting - which surfaced as "Unable to cast object of type System.Numerics.BigInteger to type
+    // System.IConvertible" from any query that summed a column.
+    [Test]
+    public void ConvertNumber_converts_BigInteger_to_CLR_numeric_types()
+    {
+        var dialectProvider = DialectProvider;
+        var value = new System.Numerics.BigInteger(42);
+
+        Assert.That(dialectProvider.ConvertNumber(typeof(byte), value), Is.EqualTo((byte)42));
+        Assert.That(dialectProvider.ConvertNumber(typeof(short), value), Is.EqualTo((short)42));
+        Assert.That(dialectProvider.ConvertNumber(typeof(int), value), Is.EqualTo(42));
+        Assert.That(dialectProvider.ConvertNumber(typeof(long), value), Is.EqualTo(42L));
+        Assert.That(dialectProvider.ConvertNumber(typeof(ulong), value), Is.EqualTo(42UL));
+        Assert.That(dialectProvider.ConvertNumber(typeof(float), value), Is.EqualTo(42f));
+        Assert.That(dialectProvider.ConvertNumber(typeof(double), value), Is.EqualTo(42d));
+        Assert.That(dialectProvider.ConvertNumber(typeof(decimal), value), Is.EqualTo(42m));
+    }
+
+    [Test]
+    public void ConvertNumber_converts_negative_and_zero_BigInteger()
+    {
+        var dialectProvider = DialectProvider;
+
+        Assert.That(dialectProvider.ConvertNumber(typeof(long), System.Numerics.BigInteger.Zero), Is.EqualTo(0L));
+        Assert.That(dialectProvider.ConvertNumber(typeof(long), new System.Numerics.BigInteger(-5)), Is.EqualTo(-5L));
+    }
+
+    // Out of range must overflow rather than silently truncate - a wrong number is worse than an exception.
+    [Test]
+    public void ConvertNumber_overflows_when_BigInteger_exceeds_target_type()
+    {
+        var dialectProvider = DialectProvider;
+        var tooBig = System.Numerics.BigInteger.Pow(2, 100);
+
+        Assert.Throws<OverflowException>(() => dialectProvider.ConvertNumber(typeof(long), tooBig));
+    }
+
     [Test]
     public void ToDbValue_does_not_throw_Exception()
     {


### PR DESCRIPTION
ConvertNumber reaches Convert.ToInt64/ToInt32/... for every numeric target, and those throw on a BigInteger rather than converting it:

    InvalidCastException: Unable to cast object of type 'System.Numerics.BigInteger'
                          to type 'System.IConvertible'

BigInteger does not implement IConvertible, by design.

Providers do return it. Firebird 4 introduced INT128 and widens SUM() of a BIGINT to it, and the stock FirebirdClient correctly surfaces INT128 as BigInteger. Measured on Firebird 5.0.4:

    SUM(SMALLINT)/SUM(INTEGER)  -> Int64        SUM(BIGINT)             -> BigInteger
    SUM(NUMERIC(18,0))          -> Decimal      SUM(OCTET_LENGTH(blob)) -> BigInteger
    COUNT(*)                    -> Int64

So COUNT works and summing a BIGINT throws, at runtime, in whichever query hits it first. OCTET_LENGTH of a BLOB is BIGINT, so summing blob sizes reproduces it without anything in the schema being declared INT128 - which is how it was found, on a query totalling image sizes.

BigInteger is now converted explicitly, ahead of the existing switch. The casts are checked, so a value genuinely too large for the target still throws OverflowException rather than silently truncating.

Tests:
- ConverterTests (no database, runs everywhere): conversion to each numeric target, negative and zero, and an overflow assertion for a value that does not fit.
- FirebirdInt128SumTests (Firebird 4+): SUM of a BIGINT column read as long/int/decimal/double, SUM of OCTET_LENGTH over a BLOB, and SUM over no rows. A BIGINT column is required - an INTEGER one does not widen to INT128 and would pass with or without this change.

Verified against a real Firebird 5.0.4 server on the stock NuGet FirebirdClient: 4/4 pass with the fix; reverting just the converter change fails 3 of the 4 with the exception above (the fourth sums no rows, so it returns NULL before any conversion).