### PR TITLE
Fix string[] Contains translated to LIKE under C# 14 and interpret one-shot Evaluate expressions

### DIFF
--- a/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/ServiceStack.OrmLite/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -2912,20 +2912,35 @@ namespace ServiceStack.OrmLite
             if (!isMemoryExtensions)
                 return false;
 
-            // Check the second argument type to determine if this is string/char Contains or collection Contains
-            var secondArgType = m.Arguments[1].Type;
-
-            // If the second argument is a string or ReadOnlySpan<char>, this is string Contains (should use LIKE)
-            if (secondArgType == typeof(string) || secondArgType == typeof(char))
+            // The element type of the span (first argument) decides what kind of Contains this is:
+            // - ReadOnlySpan<char>/Span<char> overloads are substring searches (should use LIKE)
+            // - any other element type is a collection lookup (should use IN)
+            // The searched value (second argument) must not be used for this decision, otherwise a
+            // string[] collection searched with a string column would be misclassified as a LIKE.
+            var spanType = m.Arguments[0].Type;
+            if (spanType.IsGenericType &&
+                spanType.GenericTypeArguments.Length == 1 &&
+                spanType.GenericTypeArguments[0] == typeof(char))
                 return false;
 
-            if (secondArgType.Name == "ReadOnlySpan`1" && secondArgType.GenericTypeArguments.Length > 0 &&
-                secondArgType.GenericTypeArguments[0] == typeof(char))
-                return false;
-
-            // Otherwise, this is a collection Contains (should use IN)
-            // The second argument is the value being searched for (e.g., x.Id)
             return true;
+        }
+
+        private static Expression UnwrapSpanConversion(Expression e)
+        {
+            // C# 14 inserts an implicit array -> ReadOnlySpan<T>/Span<T> conversion, either as a
+            // Convert node or as a call to op_Implicit. Evaluate the underlying array instead of the
+            // ref struct, which can't be boxed and defeats the cached expression compiler fast paths.
+            while (true)
+            {
+                if (e is UnaryExpression { NodeType: ExpressionType.Convert } u && u.Type.IsRefStruct())
+                    e = u.Operand;
+                else if (e is MethodCallExpression { Method.Name: "op_Implicit", Object: null } c &&
+                         c.Arguments.Count == 1 && c.Type.IsRefStruct())
+                    e = c.Arguments[0];
+                else
+                    return e;
+            }
         }
 
         protected virtual object VisitEnumerableMethodCall(MethodCallExpression m)
@@ -2951,10 +2966,10 @@ namespace ServiceStack.OrmLite
             switch (m.Method.Name)
             {
                 case "Contains":
-                    List<object> args = this.VisitExpressionList(m.Arguments);
-                    // args[0] is the collection, args[1] is the column/value to check
-                    object quotedColName = args[1];
-                    Expression collectionExpr = m.Arguments[0];
+                    // Only visit the searched value (the column). The span argument is a compiler
+                    // generated conversion of the source array and must not be evaluated as a span.
+                    object quotedColName = Visit(m.Arguments[1]);
+                    Expression collectionExpr = UnwrapSpanConversion(m.Arguments[0]);
                     return ToInPartialString(collectionExpr, quotedColName);
 
                 default:

--- a/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/ServiceStack.OrmLite/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -226,6 +226,90 @@ public class ExpressionVisitorTests(DialectContext context) : OrmLiteProvidersTe
         CollectionAssert.AreEquivalent(new[] { 1, 3 }, target.Select(t => t.Id).ToArray());
     }
 
+    // With C# 14 (default for net10.0) `array.Contains(x.Col)` binds to
+    // MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T) instead of Enumerable.Contains.
+    // These tests ensure string arrays are still translated to SQL IN and not to LIKE.
+
+    [Test]
+    public void Can_Select_using_string_array_Contains()
+    {
+        var p = Db.GetDialectProvider().ParamString;
+        var textCols = new[] { "asdf", "qwer" };
+        var q = Db.From<TestType>().Where(x => textCols.Contains(x.TextCol));
+        Assert.That(q.WhereExpression, Does.Contain($"IN ({p}0,{p}1)"));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(textCols));
+        var target = Db.Select(q);
+        CollectionAssert.AreEquivalent(new[] { 1, 3 }, target.Select(t => t.Id).ToArray());
+    }
+
+    [Test]
+    public void Can_Select_using_string_array_constructed_inside_Contains()
+    {
+        var p = Db.GetDialectProvider().ParamString;
+        var q = Db.From<TestType>().Where(x => new[] { "asdf123", "qwer123" }.Contains(x.TextCol));
+        Assert.That(q.WhereExpression, Does.Contain($"IN ({p}0,{p}1)"));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(new[] { "asdf123", "qwer123" }));
+        var target = Db.Select(q);
+        CollectionAssert.AreEquivalent(new[] { 2, 4 }, target.Select(t => t.Id).ToArray());
+    }
+
+    [Test]
+    public void Does_not_reuse_string_array_Contains_values_between_queries()
+    {
+        var first = new[] { "asdf" };
+        var q = Db.From<TestType>().Where(x => first.Contains(x.TextCol));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(first));
+        CollectionAssert.AreEquivalent(new[] { 1 }, Db.Select(q).Select(t => t.Id).ToArray());
+
+        var second = new[] { "qwer", "qwer123" };
+        q = Db.From<TestType>().Where(x => second.Contains(x.TextCol));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(second));
+        CollectionAssert.AreEquivalent(new[] { 3, 4 }, Db.Select(q).Select(t => t.Id).ToArray());
+    }
+
+    private class ArrayContainsFilter(string[] textCols, int[] ids)
+    {
+        public string[] TextCols = textCols;
+        public int[] Ids = ids;
+        public SqlExpression<TestType> ByTextCol(IDbConnection db) => db.From<TestType>().Where(x => TextCols.Contains(x.TextCol));
+        public SqlExpression<TestType> ById(IDbConnection db) => db.From<TestType>().Where(x => Ids.Contains(x.Id));
+    }
+
+    [Test]
+    public void Does_not_reuse_array_Contains_values_captured_from_different_instances()
+    {
+        var p = Db.GetDialectProvider().ParamString;
+        var filter1 = new ArrayContainsFilter(["asdf"], [1]);
+        var filter2 = new ArrayContainsFilter(["qwer"], [3]);
+
+        var q = filter1.ByTextCol(Db);
+        Assert.That(q.WhereExpression, Does.Contain($"IN ({p}0)"));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(new[] { "asdf" }));
+        CollectionAssert.AreEquivalent(new[] { 1 }, Db.Select(q).Select(t => t.Id).ToArray());
+
+        q = filter2.ByTextCol(Db);
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(new[] { "qwer" }));
+        CollectionAssert.AreEquivalent(new[] { 3 }, Db.Select(q).Select(t => t.Id).ToArray());
+
+        q = filter1.ById(Db);
+        Assert.That(q.WhereExpression, Does.Contain($"IN ({p}0)"));
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(new object[] { 1 }));
+        CollectionAssert.AreEquivalent(new[] { 1 }, Db.Select(q).Select(t => t.Id).ToArray());
+
+        q = filter2.ById(Db);
+        Assert.That(q.Params.Select(x => x.Value), Is.EqualTo(new object[] { 3 }));
+        CollectionAssert.AreEquivalent(new[] { 3 }, Db.Select(q).Select(t => t.Id).ToArray());
+    }
+
+    [Test]
+    public void Can_Select_using_string_Contains_as_LIKE()
+    {
+        var q = Db.From<TestType>().Where(x => x.TextCol.Contains("sdf"));
+        Assert.That(q.WhereExpression.ToLower(), Does.Contain("like"));
+        var target = Db.Select(q);
+        CollectionAssert.AreEquivalent(new[] { 1, 2 }, target.Select(t => t.Id).ToArray());
+    }
+
     [Test]
     public void Can_Select_using_int_list_constructed_inside_Contains()
     {

--- a/ServiceStack/src/ServiceStack.Common/CachedExpressionCompiler.cs
+++ b/ServiceStack/src/ServiceStack.Common/CachedExpressionCompiler.cs
@@ -46,7 +46,9 @@ namespace ServiceStack
         {
             Expression<Func<object, object>> lambdaExpr =
                 Expression.Lambda<Func<object, object>>(Expression.Convert(arg, typeof(object)), _unusedParameterExpr);
-            return ExpressionUtil.CachedExpressionCompiler.Process(lambdaExpr);
+            // The delegate is invoked exactly once. When the expression can't be served from a cache,
+            // interpreting it is far cheaper than emitting and JIT compiling a throwaway DynamicMethod.
+            return ExpressionUtil.CachedExpressionCompiler.Process(lambdaExpr, preferInterpretation: true);
         }
     }
 }
@@ -488,7 +490,16 @@ namespace ServiceStack.ExpressionUtil
         // how to handle it, we'll just compile the expression as normal.
         public static Func<TModel, TValue> Process<TModel, TValue>(Expression<Func<TModel, TValue>> lambdaExpression)
         {
-            return Compiler<TModel, TValue>.Compile(lambdaExpression);
+            return Compiler<TModel, TValue>.Compile(lambdaExpression, preferInterpretation: false);
+        }
+
+        // preferInterpretation only affects expressions that can't be served from a cache. Use it when
+        // the returned delegate is invoked once (see CachedExpressionCompiler.Evaluate), never for
+        // delegates that are kept and invoked repeatedly, where JIT compiled code is much faster.
+        public static Func<TModel, TValue> Process<TModel, TValue>(Expression<Func<TModel, TValue>> lambdaExpression,
+            bool preferInterpretation)
+        {
+            return Compiler<TModel, TValue>.Compile(lambdaExpression, preferInterpretation);
         }
 
         private static class Compiler<TIn, TOut>
@@ -500,7 +511,7 @@ namespace ServiceStack.ExpressionUtil
             private static readonly ConcurrentDictionary<ExpressionFingerprintChain, Hoisted<TIn, TOut>>
                 _fingerprintedCache = new();
 
-            public static Func<TIn, TOut> Compile(Expression<Func<TIn, TOut>> expr)
+            public static Func<TIn, TOut> Compile(Expression<Func<TIn, TOut>> expr, bool preferInterpretation)
             {
                 // The fingerprint cache hoists constants and is safe to reuse. If an
                 // expression cannot be fingerprinted, compile that exact tree: a fallback
@@ -509,7 +520,7 @@ namespace ServiceStack.ExpressionUtil
                        ?? CompileFromConstLookup(expr)
                        ?? CompileFromMemberAccess(expr)
                        ?? CompileFromFingerprint(expr)
-                       ?? CompileSlow(expr);
+                       ?? CompileSlow(expr, preferInterpretation);
             }
 
             private static Func<TIn, TOut> CompileFromConstLookup(Expression<Func<TIn, TOut>> expr)
@@ -603,7 +614,7 @@ namespace ServiceStack.ExpressionUtil
                 return null;
             }
 
-            private static Func<TIn, TOut> CompileSlow(Expression<Func<TIn, TOut>> expr)
+            private static Func<TIn, TOut> CompileSlow(Expression<Func<TIn, TOut>> expr, bool preferInterpretation)
             {
 #if DEBUG
                 Console.WriteLine("SlowCompile");
@@ -626,7 +637,7 @@ namespace ServiceStack.ExpressionUtil
                                 var inner = m.Arguments[0];
                                 var newBody = Expression.Convert(inner, typeof(object));
                                 var newLambda = Expression.Lambda<Func<TIn, TOut>>(newBody, expr.Parameters);
-                                return newLambda.Compile();
+                                return CompileLambda(newLambda, preferInterpretation);
                             }
                             catch
                             {
@@ -635,12 +646,23 @@ namespace ServiceStack.ExpressionUtil
                         }
                     }
 
-                    return expr.Compile();
+                    return CompileLambda(expr, preferInterpretation);
                 }
                 catch (Exception)
                 {
                     throw;
                 }
+            }
+
+            private static Func<TIn, TOut> CompileLambda(Expression<Func<TIn, TOut>> expr, bool preferInterpretation)
+            {
+#if NET6_0_OR_GREATER
+                // Interpretation skips IL emit + JIT of a DynamicMethod, which dominates the cost of
+                // compiling a small expression that is only going to be invoked once.
+                return expr.Compile(preferInterpretation);
+#else
+                return expr.Compile();
+#endif
             }
         }
     }

--- a/ServiceStack/tests/ServiceStack.Common.Tests/Expressions/CachedExpressionCompilerTests.cs
+++ b/ServiceStack/tests/ServiceStack.Common.Tests/Expressions/CachedExpressionCompilerTests.cs
@@ -200,6 +200,74 @@ public class CachedExpressionCompilerTests
         Assert.That(second.Count, Is.EqualTo(99));
     }
 
+    // Evaluate() interprets expressions that can't be served from a cache instead of JIT compiling
+    // them. These cover the non-fingerprintable shapes OrmLite evaluates on every query.
+
+    [Test]
+    public void Evaluate_new_expression_with_captured_arguments()
+    {
+        Assert.That(EvaluateNewDateTime(2020, 1, 7), Is.EqualTo(new DateTime(2020, 1, 7)));
+        Assert.That(EvaluateNewDateTime(2026, 9, 11), Is.EqualTo(new DateTime(2026, 9, 11)));
+    }
+
+    [Test]
+    public void Evaluate_list_init_with_captured_values()
+    {
+        Assert.That(EvaluateListInit(1, 2), Is.EqualTo(new List<int> { 1, 2 }));
+        Assert.That(EvaluateListInit(3, 4), Is.EqualTo(new List<int> { 3, 4 }));
+    }
+
+    [Test]
+    public void Evaluate_object_array_with_mixed_captured_and_literal_values()
+    {
+        Assert.That(EvaluateObjectArray(7), Is.EqualTo(new object[] { 7, 0, "x" }));
+        Assert.That(EvaluateObjectArray(99), Is.EqualTo(new object[] { 99, 0, "x" }));
+    }
+
+    [Test]
+    public void Evaluate_strips_implicit_span_conversion_and_returns_source_array()
+    {
+        // C# 14 binds array.Contains(x) to MemoryExtensions.Contains(ReadOnlySpan<T>, T); callers
+        // that evaluate the span argument end up boxing a ref struct, which the compiler can't do.
+        var opImplicit = typeof(ReadOnlySpan<int>).GetMethod("op_Implicit", [typeof(int[])])
+            ?? throw new InvalidOperationException("ReadOnlySpan<int>.op_Implicit(int[]) not found");
+        var source = new[] { 1, 2, 3 };
+        var spanExpr = Expression.Call(opImplicit, Expression.Constant(source));
+
+        var result = CachedExpressionCompiler.Evaluate(spanExpr);
+
+        Assert.That(result, Is.SameAs(source));
+    }
+
+    [Test]
+    public void Compile_slow_path_returns_reusable_delegate()
+    {
+        Expression<Func<object, Entity>> expr = model => new Entity { Count = (int)model, Id = 1 };
+        var fn = CachedExpressionCompiler.Compile(expr);
+
+        Assert.That(fn(7).Count, Is.EqualTo(7));
+        Assert.That(fn(99).Count, Is.EqualTo(99));
+        Assert.That(fn(99).Id, Is.EqualTo(1));
+    }
+
+    private static DateTime EvaluateNewDateTime(int year, int month, int day)
+    {
+        Expression<Func<DateTime>> expr = () => new DateTime(year, month, day);
+        return (DateTime)CachedExpressionCompiler.Evaluate(expr.Body);
+    }
+
+    private static List<int> EvaluateListInit(int a, int b)
+    {
+        Expression<Func<List<int>>> expr = () => new List<int> { a, b };
+        return (List<int>)CachedExpressionCompiler.Evaluate(expr.Body);
+    }
+
+    private static object[] EvaluateObjectArray(int value)
+    {
+        Expression<Func<object[]>> expr = () => new object[] { value, 0, "x" };
+        return (object[])CachedExpressionCompiler.Evaluate(expr.Body);
+    }
+
     private static Entity EvaluateMemberInit(int count)
     {
         Expression<Func<Entity>> expr = () => new Entity { Count = count };


### PR DESCRIPTION
Follow-up to ServiceStack/Issues#828. While bisecting that regression to 10a2ecf41 we found a second regression from the same commit in OrmLite, plus a cheap way to recover most of the performance lost when the slow-compile cache was removed in 9519cbb20.

## 1. `string[]` `Contains` is translated to `LIKE` under C# 14 (regression from 10a2ecf41)

With C# 14 (the default for `net10.0`) `array.Contains(x.Col)` inside an expression tree binds to `MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T)` instead of `Enumerable.Contains`. `IsSpanContainsOnArray` tried to tell substring searches apart from collection lookups by looking at the type of the *searched value*. For a `string[]` collection that value is the string column, so the call was rejected, fell through to the string-method path and silently produced:

```sql
WHERE @1 like @2      -- params: '', '', '%System.String[]%'
```

That query matches nothing and throws no error. It affects captured `string[]` variables, `new[] { "a", "b" }.Contains(x.Col)` literals and `string[]` fields read through `this`. `int[]`, `Guid[]`, `List<string>` and `IEnumerable<string>` were unaffected, which is why the existing int-array tests didn't catch it. The same code on 40e6bf521 (the commit before 10a2ecf41) generated a correct `IN (@0,@1)`.

Fix in `SqlExpression`:
- classify on the span's element type instead: only `ReadOnlySpan<char>`/`Span<char>` overloads are substring searches, everything else is a collection lookup;
- unwrap the compiler-inserted array → span conversion (`Convert` node or `op_Implicit` call) before evaluating the collection, so the array itself goes through the cached expression compiler fast paths instead of a boxed ref struct;
- stop visiting the span argument, whose result was discarded.

Tests were committed first (they fail on `main` with the output above), then the fix.

## 2. Interpret one-shot `Evaluate` expressions instead of JIT compiling them

Since 9519cbb20 removed the slow-compile cache, every expression the fingerprint path can't handle (`NewArrayInit` for inline `Sql.In` params, `New`, `MemberInit`, `ListInit`) is compiled on each `Evaluate` call. `Evaluate` invokes the delegate exactly once, so emitting and JIT compiling a `DynamicMethod` for it is wasted work.

This compiles with `preferInterpretation: true` for the `Evaluate` path only. The cached paths are untouched and the reusable `Compile<TModel, TValue>` API still returns JIT compiled delegates. `net472` has no interpreter overload and keeps the previous behaviour.

Measured on .NET 10 (each op includes building the expression tree):

| Shape reaching the slow path | JIT (9519cbb20) | interpreted |
|---|---|---|
| `new object[] { orgId, 0 }` (inline `Sql.In` params) | 61 µs | 3.8 µs |
| `new Entity { Count = orgId }` | 53 µs | 4.0 µs |
| `new DateTime(y, m, d)` | 109 µs | 5.9 µs |

Allocations roughly halve and no `DynamicMethod` is emitted per call.

## Verification

- `ServiceStack.Common.Tests` `CachedExpressionCompilerTests`: 17 tests pass on net8.0 and net10.0; `ServiceStack.Common` builds for all targets including net472.
- `ServiceStack.OrmLite.Tests` (Sqlite): 1096 passed / 27 failed on this branch vs 1091 / 27 on `main`. The 27 failures are identical on both sides (`Can_filter_*_to_insert_date`, `Can_create_table_with_DefaultValues`, `Can_use_ToUpdateStatement_to_generate_inline_SQL`, all `SQLite Error 1: near ",": syntax error`) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
